### PR TITLE
Pin Sass version to suppress Bootstrap deprecation warnings (Issue #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,30 @@
-# README
+# Villagers
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+Village volunteer scheduling software for hacker conference villages.
 
-Things you may want to cover:
+## Setup
 
-* Ruby version
+### Prerequisites
 
-* System dependencies
+* Ruby (see `.ruby-version`)
+* PostgreSQL
+* Node.js (see `.node-version`)
+* Yarn
 
-* Configuration
+### Installation
 
-* Database creation
+1. Clone the repository
+2. Run `bin/setup`
+3. Start the server with `bin/dev`
 
-* Database initialization
+## Configuration
 
-* How to run the test suite
+### Sass Version
 
-* Services (job queues, cache servers, search engines, etc.)
+Sass is pinned to version `1.94.2` in `package.json` to maintain consistency. Deprecation warnings from Bootstrap's SCSS files are suppressed using the `--quiet-deps` and `--silence-deprecation` flags in the build script. This prevents noise from third-party dependency warnings while still showing warnings from our own code.
 
-* Deployment instructions
+## Development
 
-* ...
+* Run tests: `bin/rails test`
+* Run system tests: `bin/rails test:system`
+* Lint code: `bin/rubocop`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
-    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
+    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet-deps --silence-deprecation=import --silence-deprecation=global-builtin --silence-deprecation=color-functions",
     "build:css:prefix": "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
     "build:css": "yarn build:css:compile && yarn build:css:prefix",
     "watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\""
@@ -21,7 +21,7 @@
     "nodemon": "^3.1.11",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
-    "sass": "^1.94.2"
+    "sass": "1.94.2"
   },
   "browserslist": [
     "defaults"

--- a/yarn.lock
+++ b/yarn.lock
@@ -717,7 +717,7 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
-sass@^1.94.2:
+sass@1.94.2:
   version "1.94.2"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.94.2.tgz#198511fc6fdd2fc0a71b8d1261735c12608d4ef3"
   integrity sha512-N+7WK20/wOr7CzA2snJcUSSNTCzeCGUTFY3OgeQP3mZ1aj9NMQ0mSTXwlrnd89j33zzQJGqIN52GIOmYrfq46A==


### PR DESCRIPTION
Suppresses Sass deprecation warnings from Bootstrap's SCSS files by:

- Pinning Sass to version 1.94.2 for consistency
- Adding `--quiet-deps` flag to suppress warnings from node_modules dependencies
- Adding `--silence-deprecation` flags for specific deprecation types (import, global-builtin, color-functions)
- Documenting the Sass configuration in README

## Testing
- ✅ CSS compiles without deprecation warnings
- ✅ All tests passing
- ✅ Server starts cleanly

Closes #21