### PR TITLE
Add User Permissions & Roles Display Feature - Issue #43

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,4 +37,17 @@ class User < ApplicationRecord
     # Any registered user is a volunteer
     persisted?
   end
+
+  # Methods for displaying permissions
+  def global_roles
+    roles.pluck(:name)
+  end
+
+  def conference_lead_conferences
+    conference_roles.where(role_name: ConferenceRole::CONFERENCE_LEAD).includes(:conference).map(&:conference)
+  end
+
+  def conference_admin_conferences
+    conference_roles.where(role_name: ConferenceRole::CONFERENCE_ADMIN).includes(:conference).map(&:conference)
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -57,6 +57,54 @@
 
           <hr class="my-4">
 
+          <h5 class="mb-3">My Permissions & Roles</h5>
+          <div class="card border-info mb-4">
+            <div class="card-body">
+              <h6 class="card-title">Your Current Roles</h6>
+              <ul class="list-unstyled mb-0">
+                <% if resource.village_admin? %>
+                  <li class="mb-2">
+                    <span class="badge bg-primary me-2">Village Admin</span>
+                    <small class="text-muted">You can manage all conferences and create programs</small>
+                  </li>
+                <% end %>
+                <% if resource.conference_lead_conferences.any? %>
+                  <li class="mb-2">
+                    <span class="badge bg-success me-2">Conference Lead</span>
+                    <small class="text-muted">
+                      You are a lead for:
+                      <% resource.conference_lead_conferences.each do |conference| %>
+                        <%= link_to conference.name, conference_path(conference), class: "text-decoration-none" %><%= "," unless conference == resource.conference_lead_conferences.last %>
+                      <% end %>
+                    </small>
+                  </li>
+                <% end %>
+                <% if resource.conference_admin_conferences.any? %>
+                  <li class="mb-2">
+                    <span class="badge bg-warning text-dark me-2">Conference Admin</span>
+                    <small class="text-muted">
+                      You are an admin for:
+                      <% resource.conference_admin_conferences.each do |conference| %>
+                        <%= link_to conference.name, conference_path(conference), class: "text-decoration-none" %><%= "," unless conference == resource.conference_admin_conferences.last %>
+                      <% end %>
+                    </small>
+                  </li>
+                <% end %>
+                <li class="mb-2">
+                  <span class="badge bg-secondary me-2">Volunteer</span>
+                  <small class="text-muted">You can view conferences and sign up for shifts</small>
+                </li>
+              </ul>
+              <% unless resource.village_admin? || resource.conference_lead_conferences.any? || resource.conference_admin_conferences.any? %>
+                <p class="text-muted small mb-0 mt-2">
+                  You currently have volunteer-level permissions. Contact a village administrator if you need additional access.
+                </p>
+              <% end %>
+            </div>
+          </div>
+
+          <hr class="my-4">
+
           <h5 class="mb-3 text-danger">Danger Zone</h5>
           <div class="card border-danger">
             <div class="card-body">

--- a/test/models/user_permissions_test.rb
+++ b/test/models/user_permissions_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class UserPermissionsTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @user = User.create!(
+      email: "user@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    @conference1 = Conference.create!(
+      village: @village,
+      name: "Conference 1",
+      start_date: Date.today,
+      end_date: Date.tomorrow
+    )
+    @conference2 = Conference.create!(
+      village: @village,
+      name: "Conference 2",
+      start_date: Date.today + 7,
+      end_date: Date.tomorrow + 7
+    )
+  end
+
+  test "global_roles returns user's role names" do
+    assert_equal [], @user.global_roles
+
+    village_admin_role = Role.create!(name: Role::VILLAGE_ADMIN)
+    UserRole.create!(user: @user, role: village_admin_role)
+
+    assert_equal [ Role::VILLAGE_ADMIN ], @user.global_roles
+  end
+
+  test "conference_lead_conferences returns conferences where user is lead" do
+    assert_equal [], @user.conference_lead_conferences
+
+    ConferenceRole.create!(
+      user: @user,
+      conference: @conference1,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+
+    assert_equal [ @conference1 ], @user.conference_lead_conferences
+  end
+
+  test "conference_admin_conferences returns conferences where user is admin" do
+    assert_equal [], @user.conference_admin_conferences
+
+    ConferenceRole.create!(
+      user: @user,
+      conference: @conference1,
+      role_name: ConferenceRole::CONFERENCE_ADMIN
+    )
+
+    assert_equal [ @conference1 ], @user.conference_admin_conferences
+  end
+
+  test "conference_lead_conferences returns multiple conferences" do
+    ConferenceRole.create!(
+      user: @user,
+      conference: @conference1,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+    ConferenceRole.create!(
+      user: @user,
+      conference: @conference2,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+
+    assert_equal 2, @user.conference_lead_conferences.count
+    assert_includes @user.conference_lead_conferences, @conference1
+    assert_includes @user.conference_lead_conferences, @conference2
+  end
+end

--- a/test/models/user_role_methods_test.rb
+++ b/test/models/user_role_methods_test.rb
@@ -89,5 +89,3 @@ class UserRoleMethodsTest < ActiveSupport::TestCase
     assert_not @user.can_manage_conference?(@conference)
   end
 end
-
-

--- a/test/policies/village_policy_test.rb
+++ b/test/policies/village_policy_test.rb
@@ -30,5 +30,3 @@ class VillagePolicyTest < ActiveSupport::TestCase
     assert VillagePolicy.new(@village_admin, @village).update?
   end
 end
-
-


### PR DESCRIPTION
Adds a feature to display the logged-in user's current permissions and roles on their profile page.

## Features
- ✅ Display current user's roles (village admin, conference lead, conference admin, volunteer)
- ✅ Show which conferences the user has special permissions for
- ✅ Clear, easy-to-understand format with badges
- ✅ Accessible from user profile page

## Implementation
- Added permissions/roles section to profile edit page
- Added helper methods to User model:
  - `global_roles` - returns user's village-level roles
  - `conference_lead_conferences` - returns conferences where user is lead
  - `conference_admin_conferences` - returns conferences where user is admin
- Uses Bootstrap badges and cards for styling
- Links to conferences for easy navigation

## Testing
- Added comprehensive model tests for permission methods
- All tests passing
- Rubocop clean

## Benefits
- Helps clarify RBAC confusion
- Users can see what they can and cannot do
- Shows which conferences they have management permissions for

Closes #43