### PR TITLE
Fix: Assign village admin role to setup user - Issue #44

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -14,6 +14,11 @@ class SetupController < ApplicationController
       @village.setup_complete = true
       @village.save!
       @user.save!
+
+      # Assign village admin role to the setup user
+      village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+      UserRole.find_or_create_by!(user: @user, role: village_admin_role)
+
       redirect_to root_path, notice: "Setup complete! Welcome to #{@village.name}."
     else
       render :show, status: :unprocessable_entity

--- a/test/controllers/setup_controller_test.rb
+++ b/test/controllers/setup_controller_test.rb
@@ -13,7 +13,7 @@ class SetupControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create village and admin user on valid submission" do
-    assert_difference -> { Village.count } => 1, -> { User.count } => 1 do
+    assert_difference -> { Village.count } => 1, -> { User.count } => 1, -> { UserRole.count } => 1 do
       post setup_url, params: {
         village: { name: "Ham Radio Village" },
         user: {
@@ -31,6 +31,7 @@ class SetupControllerTest < ActionDispatch::IntegrationTest
     user = User.last
     assert_equal "admin@example.com", user.email
     assert user.valid_password?("password123")
+    assert user.village_admin?, "Setup user should be assigned village admin role"
   end
 
   test "should not create village with invalid data" do


### PR DESCRIPTION
Critical bug fix: The setup controller creates the first user but doesn't assign the village admin role.

## Problem
When initial setup is run, the user created doesn't get village admin permissions, so they can't create conferences, programs, or manage the system after setup completes.

## Solution
- Assign village_admin role to user created during setup
- Create role if it doesn't exist (using find_or_create_by)
- Update test to verify role assignment

## Testing
- Updated setup controller test to verify UserRole is created
- Test verifies user.village_admin? returns true
- All tests passing

## Impact
This is a critical bug that prevents the setup user from being able to use the system. Without this fix, users created during setup have no permissions and cannot manage anything.

Closes #44