### PR TITLE
Implement Timeslot Generation System (Issue #10)

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -4,11 +4,14 @@ class Conference < ApplicationRecord
   has_many :users, through: :conference_roles
   has_many :conference_programs, dependent: :destroy
   has_many :programs, through: :conference_programs
+  has_many :timeslots, through: :conference_programs
 
   validates :name, presence: true
   validates :start_date, presence: true
   validates :end_date, presence: true
   validate :end_date_after_start_date
+
+  after_update :regenerate_timeslots_if_schedule_changed
 
   private
 
@@ -16,5 +19,16 @@ class Conference < ApplicationRecord
     return unless start_date && end_date
 
     errors.add(:end_date, "must be after start date") if end_date < start_date
+  end
+
+  def regenerate_timeslots_if_schedule_changed
+    return unless saved_change_to_start_date? || saved_change_to_end_date? ||
+                  saved_change_to_conference_hours_start? || saved_change_to_conference_hours_end?
+
+    # Regenerate timeslots for all conference programs
+    conference_programs.find_each do |cp|
+      cp.timeslots.destroy_all
+      TimeslotGenerator.new(cp).generate
+    end
   end
 end

--- a/app/models/conference_program.rb
+++ b/app/models/conference_program.rb
@@ -1,11 +1,31 @@
 class ConferenceProgram < ApplicationRecord
   belongs_to :conference
   belongs_to :program
+  has_many :timeslots, dependent: :destroy
 
   validates :conference, presence: true
   validates :program, presence: true, uniqueness: { scope: :conference_id }
 
+  after_create :generate_timeslots
+  after_update :regenerate_timeslots_if_needed
+
   def day_schedules
     super || {}
+  end
+
+  private
+
+  def generate_timeslots
+    TimeslotGenerator.new(self).generate
+  end
+
+  def regenerate_timeslots_if_needed
+    return unless saved_change_to_day_schedules? || saved_change_to_public_description?
+
+    # Only regenerate if day_schedules changed
+    return unless saved_change_to_day_schedules?
+
+    timeslots.destroy_all
+    generate_timeslots
   end
 end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -2,6 +2,7 @@ class Program < ApplicationRecord
   belongs_to :village
   has_many :conference_programs, dependent: :destroy
   has_many :conferences, through: :conference_programs
+  has_many :timeslots, through: :conference_programs
 
   validates :name, presence: true
   validates :name, uniqueness: { scope: :village_id, message: "must be unique within the village" }

--- a/app/models/timeslot.rb
+++ b/app/models/timeslot.rb
@@ -1,0 +1,18 @@
+class Timeslot < ApplicationRecord
+  belongs_to :conference_program
+  has_one :conference, through: :conference_program
+  has_one :program, through: :conference_program
+
+  validates :conference_program, presence: true
+  validates :start_time, presence: true
+  validates :end_time, presence: true
+  validates :max_volunteers, presence: true, numericality: { greater_than: 0 }
+  validates :current_volunteers_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :start_time, uniqueness: { scope: :conference_program_id }
+
+  before_validation :set_end_time, if: :start_time?
+
+  def set_end_time
+    self.end_time = start_time + 15.minutes if start_time
+  end
+end

--- a/app/services/timeslot_generator.rb
+++ b/app/services/timeslot_generator.rb
@@ -1,0 +1,52 @@
+class TimeslotGenerator
+  def initialize(conference_program)
+    @conference_program = conference_program
+    @conference = conference_program.conference
+    @day_schedules = conference_program.day_schedules
+  end
+
+  def generate
+    return if @day_schedules.empty?
+
+    (@conference.start_date..@conference.end_date).each_with_index do |date, day_index|
+      day_schedule = @day_schedules[day_index.to_s]
+      next unless day_schedule && day_schedule["enabled"] == true
+
+      generate_timeslots_for_day(date, day_schedule)
+    end
+  end
+
+  private
+
+  def generate_timeslots_for_day(date, day_schedule)
+    start_time_str = day_schedule["start"]
+    end_time_str = day_schedule["end"]
+
+    # Use day-specific times if provided, otherwise use conference defaults
+    if start_time_str.nil? && @conference.conference_hours_start
+      # conference_hours_start is stored as a time, format it as HH:MM
+      time_obj = @conference.conference_hours_start
+      # For time columns, use strftime with UTC to avoid timezone issues
+      start_time_str = time_obj.utc.strftime("%H:%M")
+    end
+    if end_time_str.nil? && @conference.conference_hours_end
+      time_obj = @conference.conference_hours_end
+      end_time_str = time_obj.utc.strftime("%H:%M")
+    end
+
+    return unless start_time_str && end_time_str
+
+    start_time = Time.zone.parse("#{date} #{start_time_str}")
+    end_time = Time.zone.parse("#{date} #{end_time_str}")
+
+    current_time = start_time
+    while current_time < end_time
+      Timeslot.create!(
+        conference_program: @conference_program,
+        start_time: current_time,
+        max_volunteers: 1
+      )
+      current_time += 15.minutes
+    end
+  end
+end

--- a/db/migrate/20251124033225_create_timeslots.rb
+++ b/db/migrate/20251124033225_create_timeslots.rb
@@ -1,0 +1,16 @@
+class CreateTimeslots < ActiveRecord::Migration[8.1]
+  def change
+    create_table :timeslots do |t|
+      t.references :conference_program, null: false, foreign_key: true
+      t.datetime :start_time, null: false
+      t.datetime :end_time, null: false
+      t.integer :max_volunteers, default: 1, null: false
+      t.integer :current_volunteers_count, default: 0, null: false
+
+      t.timestamps
+    end
+
+    add_index :timeslots, [ :conference_program_id, :start_time ], unique: true
+    add_index :timeslots, :start_time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_24_024049) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_24_033225) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -67,6 +67,19 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_24_024049) do
     t.index ["name"], name: "index_roles_on_name", unique: true
   end
 
+  create_table "timeslots", force: :cascade do |t|
+    t.bigint "conference_program_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "current_volunteers_count", default: 0, null: false
+    t.datetime "end_time", null: false
+    t.integer "max_volunteers", default: 1, null: false
+    t.datetime "start_time", null: false
+    t.datetime "updated_at", null: false
+    t.index ["conference_program_id", "start_time"], name: "index_timeslots_on_conference_program_id_and_start_time", unique: true
+    t.index ["conference_program_id"], name: "index_timeslots_on_conference_program_id"
+    t.index ["start_time"], name: "index_timeslots_on_start_time"
+  end
+
   create_table "user_roles", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "role_id", null: false
@@ -108,6 +121,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_24_024049) do
   add_foreign_key "conference_roles", "users"
   add_foreign_key "conferences", "villages"
   add_foreign_key "programs", "villages"
+  add_foreign_key "timeslots", "conference_programs"
   add_foreign_key "user_roles", "roles"
   add_foreign_key "user_roles", "users"
 end

--- a/test/models/conference_timeslot_regeneration_test.rb
+++ b/test/models/conference_timeslot_regeneration_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class ConferenceTimeslotRegenerationTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @program = Program.create!(
+      name: "Test Program",
+      description: "A test program",
+      village: @village
+    )
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+  end
+
+  test "should regenerate timeslots when conference start_date changes" do
+    initial_count = @conference_program.timeslots.count
+    assert initial_count > 0
+
+    new_start_date = @conference.start_date + 1.day
+    @conference.update!(start_date: new_start_date)
+
+    # Timeslots should be regenerated with new dates
+    assert_equal initial_count, @conference_program.timeslots.count
+    first_timeslot = @conference_program.timeslots.order(:start_time).first
+    assert_equal new_start_date, first_timeslot.start_time.to_date
+  end
+
+  test "should regenerate timeslots when conference end_date changes" do
+    initial_count = @conference_program.timeslots.count
+
+    new_end_date = @conference.end_date + 1.day
+    @conference.update!(end_date: new_end_date)
+
+    # Timeslots should be regenerated
+    # Count might change if new day has enabled schedule
+    assert @conference_program.timeslots.count >= initial_count
+  end
+
+  test "should regenerate timeslots when conference hours change" do
+    initial_count = @conference_program.timeslots.count
+    assert initial_count > 0
+
+    @conference.update!(conference_hours_start: Time.zone.parse("2000-01-01 10:00"))
+
+    # Timeslots should be regenerated with new hours
+    # Note: This test assumes day_schedules don't specify hours, so it uses conference defaults
+    # If day_schedules specify hours, they won't change
+    assert @conference_program.timeslots.count > 0
+  end
+end

--- a/test/models/timeslot_test.rb
+++ b/test/models/timeslot_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class TimeslotTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 3.days,
+      conference_hours_start: Time.parse("09:00"),
+      conference_hours_end: Time.parse("17:00"),
+      village: @village
+    )
+    @program = Program.create!(
+      name: "Test Program",
+      description: "A test program",
+      village: @village
+    )
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      public_description: "Test description"
+    )
+  end
+
+  test "should be valid with all required fields" do
+    timeslot = Timeslot.new(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00"),
+      max_volunteers: 5
+    )
+    assert timeslot.valid?
+  end
+
+  test "should require conference_program" do
+    timeslot = Timeslot.new(
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00"),
+      max_volunteers: 5
+    )
+    assert_not timeslot.valid?
+    assert timeslot.errors[:conference_program].any?
+  end
+
+  test "should require start_time" do
+    timeslot = Timeslot.new(
+      conference_program: @conference_program,
+      max_volunteers: 5
+    )
+    assert_not timeslot.valid?
+    assert timeslot.errors[:start_time].any?
+  end
+
+  test "should calculate end_time as start_time plus 15 minutes" do
+    start_time = Time.zone.parse("#{@conference.start_date} 09:00")
+    timeslot = Timeslot.create!(
+      conference_program: @conference_program,
+      start_time: start_time,
+      max_volunteers: 5
+    )
+    assert_equal start_time + 15.minutes, timeslot.end_time
+  end
+
+  test "should default max_volunteers to 1" do
+    timeslot = Timeslot.new(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00")
+    )
+    assert_equal 1, timeslot.max_volunteers
+  end
+
+  test "should default current_volunteers_count to 0" do
+    timeslot = Timeslot.new(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00")
+    )
+    assert_equal 0, timeslot.current_volunteers_count
+  end
+
+  test "should belong to conference_program" do
+    timeslot = Timeslot.create!(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00"),
+      max_volunteers: 5
+    )
+    assert_equal @conference_program, timeslot.conference_program
+  end
+
+  test "should belong to conference through conference_program" do
+    timeslot = Timeslot.create!(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00"),
+      max_volunteers: 5
+    )
+    assert_equal @conference, timeslot.conference
+  end
+
+  test "should belong to program through conference_program" do
+    timeslot = Timeslot.create!(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00"),
+      max_volunteers: 5
+    )
+    assert_equal @program, timeslot.program
+  end
+end

--- a/test/services/timeslot_generator_test.rb
+++ b/test/services/timeslot_generator_test.rb
@@ -1,0 +1,126 @@
+require "test_helper"
+
+class TimeslotGeneratorTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    # Use Time.zone.parse to create times in the application timezone
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @program = Program.create!(
+      name: "Test Program",
+      description: "A test program",
+      village: @village
+    )
+  end
+
+  test "should generate timeslots for enabled days" do
+    day_schedules = {
+      "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" },
+      "1" => { "enabled" => false }
+    }
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: day_schedules
+    )
+
+    # Should generate 4 timeslots (09:00, 09:15, 09:30, 09:45) for day 0
+    assert_equal 4, @conference_program.timeslots.count
+    assert_equal Time.zone.parse("#{@conference.start_date} 09:00"), @conference_program.timeslots.first.start_time
+    assert_equal Time.zone.parse("#{@conference.start_date} 09:45"), @conference_program.timeslots.last.start_time
+  end
+
+  test "should not generate timeslots for disabled days" do
+    day_schedules = {
+      "0" => { "enabled" => false },
+      "1" => { "enabled" => false }
+    }
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: day_schedules
+    )
+
+    assert_equal 0, @conference_program.timeslots.count
+  end
+
+  test "should generate timeslots with different schedules per day" do
+    day_schedules = {
+      "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" },
+      "1" => { "enabled" => true, "start" => "10:00", "end" => "11:00" }
+    }
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: day_schedules
+    )
+
+    # Should generate 4 timeslots for day 0 and 4 for day 1
+    assert_equal 8, @conference_program.timeslots.count
+    day_0_timeslots = @conference_program.timeslots.where("start_time::date = ?", @conference.start_date)
+    day_1_timeslots = @conference_program.timeslots.where("start_time::date = ?", @conference.end_date)
+    assert_equal 4, day_0_timeslots.count
+    assert_equal 4, day_1_timeslots.count
+  end
+
+  test "should use conference default hours when day schedule hours not specified" do
+    day_schedules = {
+      "0" => { "enabled" => true }
+    }
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: day_schedules
+    )
+
+    # Should use conference hours (09:00 to 17:00) = 8 hours = 32 timeslots
+    assert_equal 32, @conference_program.timeslots.count
+    first_timeslot = @conference_program.timeslots.order(:start_time).first
+    assert_equal Time.zone.parse("#{@conference.start_date} 09:00"), first_timeslot.start_time
+  end
+
+  test "should generate 15-minute increments" do
+    day_schedules = {
+      "0" => { "enabled" => true, "start" => "09:00", "end" => "09:30" }
+    }
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: day_schedules
+    )
+
+    timeslots = @conference_program.timeslots.order(:start_time)
+    assert_equal 2, timeslots.count
+    assert_equal 15.minutes, timeslots[1].start_time - timeslots[0].start_time
+  end
+
+  test "should regenerate timeslots when day_schedules change" do
+    day_schedules = {
+      "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+    }
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: day_schedules
+    )
+
+    assert_equal 4, @conference_program.timeslots.count
+
+    # Update day_schedules
+    new_schedules = {
+      "0" => { "enabled" => true, "start" => "10:00", "end" => "11:00" }
+    }
+    @conference_program.update!(day_schedules: new_schedules)
+
+    # Should have regenerated timeslots
+    assert_equal 4, @conference_program.timeslots.count
+    assert_equal Time.zone.parse("#{@conference.start_date} 10:00"), @conference_program.timeslots.order(:start_time).first.start_time
+  end
+end


### PR DESCRIPTION
Implements issue #10: Timeslot Generation System

## Changes
- Created Timeslot model with 15-minute increments
- Created TimeslotGenerator service class to generate timeslots automatically
- Timeslots generated when program is enabled for conference
- Timeslots regenerated when conference dates/hours change
- Timeslots regenerated when conference program day_schedules change
- Added associations: Conference/Program/ConferenceProgram → Timeslots

## Features
- ✅ Generate 15-minute timeslots for each program enabled at a conference
- ✅ Timeslots only generated for days/hours specified in conference-program link
- ✅ Timeslots belong to a specific program and have a start_time
- ✅ Timeslots can have max_volunteers capacity (default: 1, can be set by conference lead/admin)
- ✅ Timeslots automatically generated when program is enabled
- ✅ Timeslots regenerated when conference schedule changes

## Data Model
- `Timeslot` model:
  - `conference_program_id` (belongs_to conference_program)
  - `start_time` (datetime) - specific date/time for this 15-minute slot
  - `end_time` (datetime) - start_time + 15 minutes (auto-calculated)
  - `max_volunteers` (integer, default: 1)
  - `current_volunteers_count` (integer, default: 0)
  - Unique index on `[conference_program_id, start_time]`

## Testing
- Model tests: ✅ All passing (9 tests)
- Generator service tests: ✅ All passing (6 tests)
- Conference regeneration tests: ✅ All passing (3 tests)
- Total: 18 new tests, all passing

## Technical Notes
- Timeslots generated in 15-minute increments
- Uses day_schedules from ConferenceProgram to determine which days/hours
- Falls back to conference default hours if day schedule doesn't specify
- Automatic regeneration via ActiveRecord callbacks