### PR TITLE
Add user management UI for qualification system (Issue #11)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,15 +28,30 @@ Ruby on Rails app for hacker conference village organizers to manage volunteer s
 6. **Always branch from main**: Never from another feature branch unless explicitly requested
 7. **No direct commits to main**: All work goes through branches and PRs
 
-### Before Creating PRs (MANDATORY)
+### Test-Driven Development (MANDATORY)
 
-1. **All tests must pass**: Run `bin/rails test:all`
-2. **Run linter**: `bin/rubocop -a`
-3. **Fix any remaining rubocop warnings manually**
+Follow TDD for all new functionality:
+
+1. **Write a failing test first** - Define expected behavior before implementation
+2. **Write minimum code to pass** - Only enough to make the test green
+3. **Refactor** - Clean up while keeping tests green
+4. **Repeat** - Next test for next piece of functionality
+
+Do NOT write implementation code before tests. The test file should be created and failing before the implementation file exists.
+
+### Before Commits and PRs (MANDATORY)
+
+Before suggesting ANY commit or PR:
+
+1. **Run ALL tests**: `bin/rails test:all` (includes system tests)
+2. **Verify 0 failures, 0 errors** - Do not proceed if tests fail
+3. **Run linter**: `bin/rubocop -a`
+4. **Fix any remaining rubocop warnings manually**
 
 ### Testing Commands
 
-- `bin/rails test:all` - Run all tests (use before finalizing)
+- `bin/rails test:all` - Run ALL tests including system tests (REQUIRED before commits/PRs)
+- `bin/rails test` - Run unit/controller/integration tests only (faster, for iterating)
 - `bin/rails test test/path/to/file_test.rb` - Run specific test file
 - `bin/rails test test/models/` - Run directory tests
 - `bin/rails test:system` - System tests only

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -8,6 +8,7 @@ class ProgramsController < ApplicationController
 
   def show
     authorize @program, :show?, policy_class: ProgramPolicy
+    @qualifications = Qualification.where(village: @village).order(:name)
   end
 
   def new

--- a/app/controllers/user_qualifications_controller.rb
+++ b/app/controllers/user_qualifications_controller.rb
@@ -11,9 +11,9 @@ class UserQualificationsController < ApplicationController
       qualification: @qualification
     )
 
-    redirect_to @user, notice: "Qualification granted successfully."
+    redirect_to managed_user_path(@user), notice: "Qualification granted successfully."
   rescue ActiveRecord::RecordInvalid => e
-    redirect_to @user, alert: "Could not grant qualification: #{e.message}"
+    redirect_to managed_user_path(@user), alert: "Could not grant qualification: #{e.message}"
   end
 
   def destroy
@@ -22,13 +22,13 @@ class UserQualificationsController < ApplicationController
     authorize @qualification, :update?, policy_class: QualificationPolicy
 
     @user_qualification.destroy
-    redirect_to @user, notice: "Qualification removed successfully."
+    redirect_to managed_user_path(@user), notice: "Qualification removed successfully."
   end
 
   private
 
   def set_user
-    @user = User.find(params[:user_id])
+    @user = User.find(params[:managed_user_id])
   end
 
   def set_village

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,25 @@
+class UsersController < ApplicationController
+  before_action :set_user, only: [ :show ]
+  before_action :set_village
+
+  def index
+    authorize User, :index?, policy_class: UserPolicy
+    @users = User.order(:email)
+  end
+
+  def show
+    authorize @user, :show?, policy_class: UserPolicy
+    @qualifications = Qualification.where(village: @village).order(:name)
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def set_village
+    @village = Village.first
+    redirect_to setup_path if @village.nil?
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,23 @@
+class UserPolicy < ApplicationPolicy
+  def index?
+    user&.village_admin?
+  end
+
+  def show?
+    user&.village_admin?
+  end
+
+  def grant_qualification?
+    user&.village_admin?
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      if user&.village_admin?
+        scope.all
+      else
+        scope.none
+      end
+    end
+  end
+end

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -16,16 +16,61 @@
             </div>
           <% end %>
 
-          <dl class="row">
-            <dt class="col-sm-3">Village:</dt>
-            <dd class="col-sm-9"><%= @program.village.name %></dd>
-          </dl>
+          <h5>Conferences</h5>
+          <% if @program.conferences.any? %>
+            <div class="mb-3">
+              <% @program.conferences.each do |conference| %>
+                <%= link_to conference.name, conference, class: "badge bg-primary text-decoration-none me-1" %>
+              <% end %>
+            </div>
+          <% else %>
+            <p class="text-muted">Not enabled at any conferences yet.</p>
+          <% end %>
+
+          <hr>
+
+          <div class="card bg-light">
+            <div class="card-body">
+              <h5 class="card-title">Required Qualifications</h5>
+              <% if @program.qualifications.any? %>
+                <ul class="list-group list-group-flush mb-3">
+                  <% @program.qualifications.each do |qualification| %>
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                      <%= qualification.name %>
+                      <% if policy(@program).update? %>
+                        <%= link_to "Remove", program_program_qualification_path(@program, @program.program_qualifications.find_by(qualification: qualification)),
+                            data: { turbo_method: :delete, turbo_confirm: "Remove this qualification requirement?" },
+                            class: "btn btn-sm btn-outline-danger" %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="text-muted">No qualifications required for this program.</p>
+              <% end %>
+
+              <% if policy(@program).update? %>
+                <% available_qualifications = @qualifications - @program.qualifications %>
+                <% if available_qualifications.any? %>
+                  <%= form_with url: program_program_qualifications_path(@program), method: :post, local: true, class: "d-flex gap-2" do |f| %>
+                    <select name="qualification_id" class="form-select form-select-sm" required>
+                      <option value="">Select qualification...</option>
+                      <% available_qualifications.each do |qual| %>
+                        <option value="<%= qual.id %>"><%= qual.name %></option>
+                      <% end %>
+                    </select>
+                    <%= f.submit "Add", class: "btn btn-sm btn-primary" %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
         </div>
         <div class="card-footer">
           <%= link_to "← Back to Programs", programs_path, class: "btn btn-link" %>
           <% if policy(@program).destroy? %>
-            <%= link_to "Delete", program_path(@program), method: :delete, 
-                data: { confirm: "Are you sure you want to delete this program?" }, 
+            <%= link_to "Delete", program_path(@program), method: :delete,
+                data: { confirm: "Are you sure you want to delete this program?" },
                 class: "btn btn-danger btn-sm float-end" %>
           <% end %>
         </div>
@@ -33,4 +78,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -63,6 +63,11 @@
               <% end %>
             </ul>
           </li>
+          <% if policy(User).index? %>
+            <li class="nav-item">
+              <%= link_to "Users", managed_users_path, class: "nav-link" %>
+            </li>
+          <% end %>
           <li class="nav-item">
             <%= link_to "Profile", edit_user_registration_path, class: "nav-link" %>
           </li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,50 @@
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-12">
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1>Users</h1>
+      </div>
+
+      <% if @users.any? %>
+        <div class="table-responsive">
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>Email</th>
+                <th>Name</th>
+                <th>Handle</th>
+                <th>Qualifications</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @users.each do |user| %>
+                <tr>
+                  <td><%= user.email %></td>
+                  <td><%= user.name %></td>
+                  <td><%= user.handle %></td>
+                  <td>
+                    <% if user.qualifications.any? %>
+                      <% user.qualifications.each do |qual| %>
+                        <span class="badge bg-success"><%= qual.name %></span>
+                      <% end %>
+                    <% else %>
+                      <span class="text-muted">None</span>
+                    <% end %>
+                  </td>
+                  <td>
+                    <%= link_to "View", managed_user_path(user), class: "btn btn-sm btn-outline-primary" %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div class="alert alert-info">
+          No users have registered yet.
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,98 @@
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-md-8">
+      <div class="card">
+        <div class="card-header">
+          <h2><%= @user.email %></h2>
+        </div>
+        <div class="card-body">
+          <dl class="row">
+            <% if @user.name.present? %>
+              <dt class="col-sm-3">Name:</dt>
+              <dd class="col-sm-9"><%= @user.name %></dd>
+            <% end %>
+
+            <% if @user.handle.present? %>
+              <dt class="col-sm-3">Handle:</dt>
+              <dd class="col-sm-9"><%= @user.handle %></dd>
+            <% end %>
+
+            <% if @user.phone.present? %>
+              <dt class="col-sm-3">Phone:</dt>
+              <dd class="col-sm-9"><%= @user.phone %></dd>
+            <% end %>
+
+            <% if @user.twitter.present? %>
+              <dt class="col-sm-3">Twitter:</dt>
+              <dd class="col-sm-9"><%= @user.twitter %></dd>
+            <% end %>
+
+            <% if @user.signal.present? %>
+              <dt class="col-sm-3">Signal:</dt>
+              <dd class="col-sm-9"><%= @user.signal %></dd>
+            <% end %>
+
+            <% if @user.discord.present? %>
+              <dt class="col-sm-3">Discord:</dt>
+              <dd class="col-sm-9"><%= @user.discord %></dd>
+            <% end %>
+          </dl>
+
+          <hr>
+
+          <h5>Roles</h5>
+          <% if @user.village_admin? %>
+            <span class="badge bg-danger">Village Admin</span>
+          <% end %>
+          <% @user.conference_lead_conferences.each do |conference| %>
+            <span class="badge bg-primary">Lead: <%= conference.name %></span>
+          <% end %>
+          <% @user.conference_admin_conferences.each do |conference| %>
+            <span class="badge bg-info">Admin: <%= conference.name %></span>
+          <% end %>
+          <% unless @user.village_admin? || @user.conference_lead_conferences.any? || @user.conference_admin_conferences.any? %>
+            <span class="badge bg-secondary">Volunteer</span>
+          <% end %>
+
+          <hr>
+
+          <div class="card bg-light">
+            <div class="card-body">
+              <h5 class="card-title">Qualifications</h5>
+              <% if @user.qualifications.any? %>
+                <ul class="list-group list-group-flush mb-3">
+                  <% @user.qualifications.each do |qualification| %>
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                      <%= qualification.name %>
+                      <%= link_to "Remove", managed_user_user_qualification_path(@user, @user.user_qualifications.find_by(qualification: qualification)),
+                          data: { turbo_method: :delete, turbo_confirm: "Remove this qualification from #{@user.email}?" },
+                          class: "btn btn-sm btn-outline-danger" %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="text-muted">No qualifications granted yet.</p>
+              <% end %>
+
+              <% available_qualifications = @qualifications - @user.qualifications %>
+              <% if available_qualifications.any? %>
+                <%= form_with url: managed_user_user_qualifications_path(@user), method: :post, local: true, class: "d-flex gap-2" do |f| %>
+                  <select name="qualification_id" class="form-select form-select-sm" required>
+                    <option value="">Select qualification...</option>
+                    <% available_qualifications.each do |qual| %>
+                      <option value="<%= qual.id %>"><%= qual.name %></option>
+                    <% end %>
+                  </select>
+                  <%= f.submit "Grant", class: "btn btn-sm btn-primary" %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+        <div class="card-footer">
+          <%= link_to "← Back to Users", managed_users_path, class: "btn btn-link" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
 
   # Qualification management
   resources :qualifications
-  resources :users do
+  resources :managed_users, controller: "users", path: "manage/users" do
     resources :user_qualifications, only: [ :create, :destroy ]
   end
   resources :programs do

--- a/test/controllers/program_qualifications_controller_test.rb
+++ b/test/controllers/program_qualifications_controller_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+class ProgramQualificationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @village_admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.find_or_create_by!(user: @village_admin, role: village_admin_role)
+    @village_admin.reload
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @program = Program.create!(
+      name: "Test Program",
+      description: "A test program",
+      village: @village
+    )
+
+    @qualification = Qualification.create!(
+      name: "Test Qualification",
+      description: "A test qualification",
+      village: @village
+    )
+  end
+
+  def sign_in_user(user)
+    post user_session_path, params: {
+      user: {
+        email: user.email,
+        password: "password123"
+      }
+    }
+  end
+
+  test "village admin can add qualification requirement to program" do
+    sign_in_user(@village_admin)
+    assert_difference("ProgramQualification.count") do
+      post program_program_qualifications_url(@program), params: {
+        qualification_id: @qualification.id
+      }
+    end
+    assert_redirected_to program_url(@program)
+    assert @program.reload.qualifications.include?(@qualification)
+  end
+
+  test "village admin can remove qualification requirement from program" do
+    program_qualification = ProgramQualification.create!(
+      program: @program,
+      qualification: @qualification
+    )
+    sign_in_user(@village_admin)
+    assert_difference("ProgramQualification.count", -1) do
+      delete program_program_qualification_url(@program, program_qualification)
+    end
+    assert_redirected_to program_url(@program)
+    assert_not @program.reload.qualifications.include?(@qualification)
+  end
+
+  test "volunteer cannot add qualification requirement to program" do
+    sign_in_user(@volunteer)
+    assert_no_difference("ProgramQualification.count") do
+      post program_program_qualifications_url(@program), params: {
+        qualification_id: @qualification.id
+      }
+    end
+    assert_redirected_to root_path
+  end
+
+  test "volunteer cannot remove qualification requirement from program" do
+    program_qualification = ProgramQualification.create!(
+      program: @program,
+      qualification: @qualification
+    )
+    sign_in_user(@volunteer)
+    assert_no_difference("ProgramQualification.count") do
+      delete program_program_qualification_url(@program, program_qualification)
+    end
+    assert_redirected_to root_path
+  end
+end

--- a/test/controllers/user_qualifications_controller_test.rb
+++ b/test/controllers/user_qualifications_controller_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class UserQualificationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @village_admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.find_or_create_by!(user: @village_admin, role: village_admin_role)
+    @village_admin.reload
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @qualification = Qualification.create!(
+      name: "Test Qualification",
+      description: "A test qualification",
+      village: @village
+    )
+  end
+
+  def sign_in_user(user)
+    post user_session_path, params: {
+      user: {
+        email: user.email,
+        password: "password123"
+      }
+    }
+  end
+
+  test "village admin can grant qualification to user" do
+    sign_in_user(@village_admin)
+    assert_difference("UserQualification.count") do
+      post managed_user_user_qualifications_url(@volunteer), params: {
+        qualification_id: @qualification.id
+      }
+    end
+    assert_redirected_to managed_user_url(@volunteer)
+    assert @volunteer.reload.has_qualification?(@qualification)
+  end
+
+  test "village admin can remove qualification from user" do
+    user_qualification = UserQualification.create!(
+      user: @volunteer,
+      qualification: @qualification
+    )
+    sign_in_user(@village_admin)
+    assert_difference("UserQualification.count", -1) do
+      delete managed_user_user_qualification_url(@volunteer, user_qualification)
+    end
+    assert_redirected_to managed_user_url(@volunteer)
+    assert_not @volunteer.reload.has_qualification?(@qualification)
+  end
+
+  test "volunteer cannot grant qualification to user" do
+    sign_in_user(@volunteer)
+    assert_no_difference("UserQualification.count") do
+      post managed_user_user_qualifications_url(@volunteer), params: {
+        qualification_id: @qualification.id
+      }
+    end
+    assert_redirected_to root_path
+  end
+
+  test "volunteer cannot remove qualification from user" do
+    user_qualification = UserQualification.create!(
+      user: @volunteer,
+      qualification: @qualification
+    )
+    sign_in_user(@volunteer)
+    assert_no_difference("UserQualification.count") do
+      delete managed_user_user_qualification_url(@volunteer, user_qualification)
+    end
+    assert_redirected_to root_path
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @village_admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Admin User",
+      handle: "admin"
+    )
+    village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.find_or_create_by!(user: @village_admin, role: village_admin_role)
+    @village_admin.reload
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Volunteer User",
+      handle: "volunteer"
+    )
+
+    @qualification = Qualification.create!(
+      name: "Test Qualification",
+      description: "A test qualification",
+      village: @village
+    )
+  end
+
+  def sign_in_user(user)
+    post user_session_path, params: {
+      user: {
+        email: user.email,
+        password: "password123"
+      }
+    }
+  end
+
+  test "should get index as village admin" do
+    sign_in_user(@village_admin)
+    get managed_users_url
+    assert_response :success
+  end
+
+  test "should not get index as volunteer" do
+    sign_in_user(@volunteer)
+    get managed_users_url
+    assert_redirected_to root_path
+  end
+
+  test "should show user as village admin" do
+    sign_in_user(@village_admin)
+    get managed_user_url(@volunteer)
+    assert_response :success
+  end
+
+  test "should not show user as volunteer" do
+    sign_in_user(@volunteer)
+    get managed_user_url(@village_admin)
+    assert_redirected_to root_path
+  end
+
+  test "should display user qualifications on show page" do
+    UserQualification.create!(user: @volunteer, qualification: @qualification)
+    sign_in_user(@village_admin)
+    get managed_user_url(@volunteer)
+    assert_response :success
+    assert_match @qualification.name, response.body
+  end
+
+  test "should list all users on index page" do
+    sign_in_user(@village_admin)
+    get managed_users_url
+    assert_response :success
+    assert_match @volunteer.email, response.body
+    assert_match @village_admin.email, response.body
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,9 @@ require "rails/test_help"
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers
-    parallelize(workers: :number_of_processors)
+    # Disabled (threshold: 500) due to Devise mapping race conditions with parallel processes
+    # TODO: Re-enable when Devise fixes parallel test support or we have 500+ tests
+    parallelize(workers: :number_of_processors, threshold: 500)
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all


### PR DESCRIPTION
## Summary

- Adds `/manage/users` for village admins to view all users and manage their qualifications
- Adds qualification requirements panel to program show page
- Programs now show linked conference badges instead of redundant village name
- Qualifications displayed as subcards within main cards for cleaner UX

## Technical Changes

- `UsersController` with index/show actions (village admin only)
- `UserPolicy` for authorization
- Routes use `/manage/users` path to avoid Devise `resources :users` conflict
- Fixed parallel test race conditions by raising parallelization threshold to 500
- Updated CLAUDE.md: TDD required, must run `bin/rails test:all` before commits/PRs

## Test plan

- [x] All 198 tests pass (0 failures, 0 errors)
- [x] Rubocop passes with no offenses
- [x] Manual test: Login as village admin, navigate to Users, view user, grant/remove qualifications
- [ ] Manual test: View program, add/remove qualification requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)