### PR TITLE
Complete qualification system - user view & signup checks (Issue #11)

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -105,6 +105,28 @@
 
           <hr class="my-4">
 
+          <h5 class="mb-3">My Qualifications</h5>
+          <div class="card border-success mb-4">
+            <div class="card-body">
+              <% if resource.qualifications.any? %>
+                <ul class="list-unstyled mb-0">
+                  <% resource.qualifications.each do |qualification| %>
+                    <li class="mb-2">
+                      <span class="badge bg-success me-2"><%= qualification.name %></span>
+                      <% if qualification.description.present? %>
+                        <small class="text-muted"><%= qualification.description %></small>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="text-muted mb-0">You don't have any qualifications yet. Contact a village administrator to have qualifications assigned to you.</p>
+              <% end %>
+            </div>
+          </div>
+
+          <hr class="my-4">
+
           <h5 class="mb-3 text-danger">Danger Zone</h5>
           <div class="card border-danger">
             <div class="card-body">

--- a/test/system/profile_qualifications_test.rb
+++ b/test/system/profile_qualifications_test.rb
@@ -1,0 +1,62 @@
+require "application_system_test_case"
+
+class ProfileQualificationsTest < ApplicationSystemTestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @user = User.create!(
+      email: "user@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    @qualification = Qualification.create!(
+      name: "Licensed Amateur Radio Operator",
+      description: "FCC license required",
+      village: @village
+    )
+  end
+
+  def login_as(user)
+    visit new_user_session_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    find('input[type="submit"][value="Log in"]').click
+    assert_text "Logout" # Wait for successful login
+  end
+
+  test "user sees their qualifications on profile page" do
+    # Grant qualification to user
+    UserQualification.create!(user: @user, qualification: @qualification)
+
+    # Sign in and visit profile
+    login_as @user
+    visit edit_user_registration_path
+
+    # Should see qualifications section
+    assert_text "My Qualifications"
+    assert_text "Licensed Amateur Radio Operator"
+  end
+
+  test "user sees message when they have no qualifications" do
+    login_as @user
+    visit edit_user_registration_path
+
+    assert_text "My Qualifications"
+    assert_text "You don't have any qualifications yet"
+  end
+
+  test "user with multiple qualifications sees all of them" do
+    qual2 = Qualification.create!(
+      name: "Volunteer Examiner",
+      description: "VE certification",
+      village: @village
+    )
+    UserQualification.create!(user: @user, qualification: @qualification)
+    UserQualification.create!(user: @user, qualification: qual2)
+
+    login_as @user
+    visit edit_user_registration_path
+
+    assert_text "Licensed Amateur Radio Operator"
+    assert_text "Volunteer Examiner"
+  end
+end


### PR DESCRIPTION
## Summary

Completes the remaining acceptance criteria for Issue #11:

- **Users can view their qualifications**: Added "My Qualifications" section to profile page showing user's granted qualifications
- **Qualification checks during signup**: Already implemented in VolunteerSignup model - added tests to verify

## Changes

- `app/views/devise/registrations/edit.html.erb` - Added qualifications display
- `test/system/profile_qualifications_test.rb` - System tests for profile qualifications view
- `test/models/volunteer_signup_test.rb` - Unit tests for qualification validation during signup

## Test plan

- [x] 205 tests pass (0 failures, 0 errors)
- [x] Rubocop passes
- [ ] Manual: View profile, see qualifications section
- [ ] Manual: Try to sign up for shift requiring qualification you don't have

🤖 Generated with [Claude Code](https://claude.com/claude-code)