### PR TITLE
Add My Shifts view for volunteers (Issue #13)

### DIFF
--- a/app/views/conferences/show.html.erb
+++ b/app/views/conferences/show.html.erb
@@ -104,6 +104,7 @@
         <div class="card-footer d-flex justify-content-between">
           <%= link_to "← Back to Conferences", conferences_path, class: "btn btn-link" %>
           <div>
+            <%= link_to "My Shifts", conference_volunteer_signups_path(@conference), class: "btn btn-success me-2" %>
             <%= link_to "View Calendar", conference_calendar_path(@conference), class: "btn btn-info me-2" %>
             <% if policy(@conference).update? %>
               <%= link_to "Manage Programs", conference_conference_programs_path(@conference), class: "btn btn-primary" %>

--- a/app/views/volunteer_signups/index.html.erb
+++ b/app/views/volunteer_signups/index.html.erb
@@ -1,0 +1,65 @@
+<div class="container mt-4">
+  <div class="row mb-4">
+    <div class="col-12">
+      <div class="d-flex justify-content-between align-items-center">
+        <h1>My Shifts - <%= @conference.name %></h1>
+        <div>
+          <%= link_to "View Calendar", conference_calendar_path(@conference), class: "btn btn-primary me-2" %>
+          <%= link_to "← Back to Conference", @conference, class: "btn btn-outline-secondary" %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <% if @my_signups.any? %>
+    <div class="row">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header bg-success text-white">
+            <h5 class="mb-0">Your Signed Up Shifts (<%= @my_signups.count %>)</h5>
+          </div>
+          <div class="card-body p-0">
+            <div class="table-responsive">
+              <table class="table table-striped mb-0">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Time</th>
+                    <th>Program</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @my_signups.each do |signup| %>
+                    <tr>
+                      <td><%= signup.timeslot.start_time.strftime("%A, %B %d") %></td>
+                      <td>
+                        <%= signup.timeslot.start_time.strftime("%l:%M %p").strip %> -
+                        <%= signup.timeslot.end_time.strftime("%l:%M %p").strip %>
+                      </td>
+                      <td><%= signup.timeslot.program.name %></td>
+                      <td>
+                        <%= link_to "Cancel", conference_volunteer_signup_path(@conference, signup),
+                            data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to cancel this shift?" },
+                            class: "btn btn-sm btn-outline-danger" %>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% else %>
+    <div class="row">
+      <div class="col-12">
+        <div class="alert alert-info">
+          <h5>No Shifts Yet</h5>
+          <p class="mb-0">You haven't signed up for any shifts yet. <%= link_to "View the calendar", conference_calendar_path(@conference) %> to find available timeslots.</p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/test/system/my_shifts_test.rb
+++ b/test/system/my_shifts_test.rb
@@ -1,0 +1,86 @@
+require "application_system_test_case"
+
+class MyShiftsTest < ApplicationSystemTestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @program = Program.create!(
+      name: "Test Program",
+      description: "A test program",
+      village: @village
+    )
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+    @timeslot = @conference_program.timeslots.first
+    @user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  def login_as(user)
+    visit new_user_session_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    find('input[type="submit"][value="Log in"]').click
+    assert_text "Logout"
+  end
+
+  test "volunteer can view their signed up shifts" do
+    VolunteerSignup.create!(user: @user, timeslot: @timeslot)
+
+    login_as @user
+    visit conference_volunteer_signups_path(@conference)
+
+    assert_text "My Shifts"
+    assert_text @program.name
+    assert_text @timeslot.start_time.strftime("%l:%M %p").strip
+  end
+
+  test "volunteer sees message when they have no shifts" do
+    login_as @user
+    visit conference_volunteer_signups_path(@conference)
+
+    assert_text "My Shifts"
+    assert_text "You haven't signed up for any shifts yet"
+  end
+
+  test "volunteer can cancel shift from my shifts page" do
+    VolunteerSignup.create!(user: @user, timeslot: @timeslot)
+
+    login_as @user
+    visit conference_volunteer_signups_path(@conference)
+
+    assert_text @program.name
+    accept_confirm do
+      click_on "Cancel"
+    end
+
+    # After cancellation, should show empty state
+    assert_text "You haven't signed up for any shifts yet"
+  end
+
+  test "my shifts page is accessible from conference show page" do
+    login_as @user
+    visit conference_path(@conference)
+
+    click_on "My Shifts"
+
+    assert_text "My Shifts"
+    assert_current_path conference_volunteer_signups_path(@conference)
+  end
+end


### PR DESCRIPTION
## Summary

Completes the final acceptance criterion for Issue #13 - volunteers can now view their signed-up shifts in a dedicated page.

## Changes

- `app/views/volunteer_signups/index.html.erb` - New "My Shifts" page showing all signed-up shifts
- `app/views/conferences/show.html.erb` - Added "My Shifts" button
- `test/system/my_shifts_test.rb` - System tests for the new view

## Test plan

- [x] 209 tests pass (0 failures, 0 errors)
- [x] Rubocop passes
- [x] Manual: Navigate to conference → click "My Shifts" → see shifts list
- [x] Manual: Sign up for shift via calendar, verify it appears in My Shifts
- [x] Manual: Cancel shift from My Shifts page

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)