### PR TITLE
Add volunteer history and leaderboard

### DIFF
--- a/app/controllers/leaderboard_controller.rb
+++ b/app/controllers/leaderboard_controller.rb
@@ -1,0 +1,18 @@
+class LeaderboardController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference, only: [ :conference ]
+
+  def index
+    @top_volunteers = User.top_volunteers(25)
+  end
+
+  def conference
+    @top_volunteers = User.top_volunteers_for_conference(@conference, 25)
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+end

--- a/app/controllers/volunteer_history_controller.rb
+++ b/app/controllers/volunteer_history_controller.rb
@@ -1,0 +1,22 @@
+class VolunteerHistoryController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference, only: [ :show ]
+
+  def index
+    @user = current_user
+    @conferences = @user.conferences_participated.order(start_date: :desc)
+  end
+
+  def show
+    @user = current_user
+    @signups = @user.volunteer_signups_for_conference(@conference)
+                    .includes(timeslot: { conference_program: :program })
+                    .order("timeslots.start_time")
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:id])
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,4 +65,58 @@ class User < ApplicationRecord
   def has_qualification_for_program?(program)
     program.qualifications.all? { |qual| has_qualification?(qual) }
   end
+
+  # Volunteer statistics methods
+  def total_shifts
+    volunteer_signups.count
+  end
+
+  def total_volunteer_hours
+    # Each timeslot is 15 minutes = 0.25 hours
+    total_shifts * 0.25
+  end
+
+  def conferences_participated
+    Conference.joins(conference_programs: { timeslots: :volunteer_signups })
+              .where(volunteer_signups: { user_id: id })
+              .distinct
+  end
+
+  def conferences_participated_count
+    conferences_participated.count
+  end
+
+  def shifts_for_conference(conference)
+    volunteer_signups.joins(timeslot: :conference_program)
+                     .where(conference_programs: { conference_id: conference.id })
+                     .count
+  end
+
+  def hours_for_conference(conference)
+    shifts_for_conference(conference) * 0.25
+  end
+
+  def volunteer_signups_for_conference(conference)
+    volunteer_signups.joins(timeslot: :conference_program)
+                     .where(conference_programs: { conference_id: conference.id })
+                     .includes(timeslot: { conference_program: [ :conference, :program ] })
+  end
+
+  # Class methods for leaderboard
+  def self.top_volunteers(limit = 10)
+    select("users.*, COUNT(volunteer_signups.id) as shifts_count")
+      .joins(:volunteer_signups)
+      .group("users.id")
+      .order("shifts_count DESC")
+      .limit(limit)
+  end
+
+  def self.top_volunteers_for_conference(conference, limit = 10)
+    select("users.*, COUNT(volunteer_signups.id) as shifts_count")
+      .joins(volunteer_signups: { timeslot: :conference_program })
+      .where(conference_programs: { conference_id: conference.id })
+      .group("users.id")
+      .order("shifts_count DESC")
+      .limit(limit)
+  end
 end

--- a/app/views/conferences/show.html.erb
+++ b/app/views/conferences/show.html.erb
@@ -105,6 +105,7 @@
           <%= link_to "← Back to Conferences", conferences_path, class: "btn btn-link" %>
           <div>
             <%= link_to "My Shifts", conference_volunteer_signups_path(@conference), class: "btn btn-success me-2" %>
+            <%= link_to "Leaderboard", conference_leaderboard_path(@conference), class: "btn btn-secondary me-2" %>
             <%= link_to "View Schedule", conference_schedule_path(@conference), class: "btn btn-warning me-2" %>
             <%= link_to "View Calendar", conference_calendar_path(@conference), class: "btn btn-info me-2" %>
             <% if policy(@conference).update? %>

--- a/app/views/leaderboard/conference.html.erb
+++ b/app/views/leaderboard/conference.html.erb
@@ -1,0 +1,63 @@
+<div class="container mt-5">
+  <nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Conferences", conferences_path %></li>
+      <li class="breadcrumb-item"><%= link_to @conference.name, conference_path(@conference) %></li>
+      <li class="breadcrumb-item active" aria-current="page">Leaderboard</li>
+    </ol>
+  </nav>
+
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1><%= @conference.name %> Leaderboard</h1>
+    <%= link_to "Overall Leaderboard", leaderboard_index_path, class: "btn btn-outline-primary" %>
+  </div>
+
+  <p class="text-muted mb-4">Top volunteers for this conference, ranked by shifts.</p>
+
+  <% if @top_volunteers.any? %>
+    <div class="card shadow-sm">
+      <div class="table-responsive">
+        <table class="table table-hover mb-0">
+          <thead class="table-light">
+            <tr>
+              <th scope="col" class="text-center" style="width: 60px;">Rank</th>
+              <th scope="col">Volunteer</th>
+              <th scope="col" class="text-center">Shifts</th>
+              <th scope="col" class="text-center">Hours</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @top_volunteers.each_with_index do |volunteer, index| %>
+              <tr>
+                <td class="text-center">
+                  <% if index == 0 %>
+                    <span class="badge bg-warning text-dark fs-6">1</span>
+                  <% elsif index == 1 %>
+                    <span class="badge bg-secondary fs-6">2</span>
+                  <% elsif index == 2 %>
+                    <span class="badge bg-danger fs-6">3</span>
+                  <% else %>
+                    <span class="text-muted"><%= index + 1 %></span>
+                  <% end %>
+                </td>
+                <td>
+                  <strong><%= volunteer.name.presence || volunteer.email %></strong>
+                  <% if volunteer.handle.present? %>
+                    <br><small class="text-muted">@<%= volunteer.handle %></small>
+                  <% end %>
+                </td>
+                <td class="text-center"><%= volunteer.shifts_for_conference(@conference) %></td>
+                <td class="text-center"><%= number_with_precision(volunteer.hours_for_conference(@conference), precision: 1) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      <h5 class="alert-heading">No Volunteer Activity Yet</h5>
+      <p class="mb-0">No volunteers have signed up for shifts at this conference yet.</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/leaderboard/index.html.erb
+++ b/app/views/leaderboard/index.html.erb
@@ -1,0 +1,57 @@
+<div class="container mt-5">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Volunteer Leaderboard</h1>
+    <%= link_to "My History", volunteer_history_index_path, class: "btn btn-outline-primary" %>
+  </div>
+
+  <p class="text-muted mb-4">Top volunteers across all conferences, ranked by total shifts.</p>
+
+  <% if @top_volunteers.any? %>
+    <div class="card shadow-sm">
+      <div class="table-responsive">
+        <table class="table table-hover mb-0">
+          <thead class="table-light">
+            <tr>
+              <th scope="col" class="text-center" style="width: 60px;">Rank</th>
+              <th scope="col">Volunteer</th>
+              <th scope="col" class="text-center">Shifts</th>
+              <th scope="col" class="text-center">Hours</th>
+              <th scope="col" class="text-center">Conferences</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @top_volunteers.each_with_index do |volunteer, index| %>
+              <tr>
+                <td class="text-center">
+                  <% if index == 0 %>
+                    <span class="badge bg-warning text-dark fs-6">1</span>
+                  <% elsif index == 1 %>
+                    <span class="badge bg-secondary fs-6">2</span>
+                  <% elsif index == 2 %>
+                    <span class="badge bg-danger fs-6">3</span>
+                  <% else %>
+                    <span class="text-muted"><%= index + 1 %></span>
+                  <% end %>
+                </td>
+                <td>
+                  <strong><%= volunteer.name.presence || volunteer.email %></strong>
+                  <% if volunteer.handle.present? %>
+                    <br><small class="text-muted">@<%= volunteer.handle %></small>
+                  <% end %>
+                </td>
+                <td class="text-center"><%= volunteer.total_shifts %></td>
+                <td class="text-center"><%= number_with_precision(volunteer.total_volunteer_hours, precision: 1) %></td>
+                <td class="text-center"><%= volunteer.conferences_participated_count %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      <h5 class="alert-heading">No Volunteer Activity Yet</h5>
+      <p class="mb-0">No volunteers have signed up for shifts yet. Be the first!</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -63,6 +63,19 @@
               <% end %>
             </ul>
           </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="volunteerDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              Volunteers
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="volunteerDropdown">
+              <li>
+                <%= link_to "Leaderboard", leaderboard_index_path, class: "dropdown-item" %>
+              </li>
+              <li>
+                <%= link_to "My History", volunteer_history_index_path, class: "dropdown-item" %>
+              </li>
+            </ul>
+          </li>
           <% if policy(User).index? %>
             <li class="nav-item">
               <%= link_to "Users", managed_users_path, class: "nav-link" %>

--- a/app/views/volunteer_history/index.html.erb
+++ b/app/views/volunteer_history/index.html.erb
@@ -1,0 +1,63 @@
+<div class="container mt-5">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>My Volunteer History</h1>
+    <%= link_to "Leaderboard", leaderboard_index_path, class: "btn btn-outline-primary" %>
+  </div>
+
+  <div class="row mb-4">
+    <div class="col-md-4">
+      <div class="card shadow-sm text-center">
+        <div class="card-body">
+          <h2 class="display-4 text-primary"><%= @user.total_shifts %></h2>
+          <p class="text-muted mb-0">Total Shifts</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card shadow-sm text-center">
+        <div class="card-body">
+          <h2 class="display-4 text-success"><%= number_with_precision(@user.total_volunteer_hours, precision: 1) %></h2>
+          <p class="text-muted mb-0">Total Hours</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card shadow-sm text-center">
+        <div class="card-body">
+          <h2 class="display-4 text-info"><%= @user.conferences_participated_count %></h2>
+          <p class="text-muted mb-0">Conferences</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="mb-3">Conferences Participated</h2>
+
+  <% if @conferences.any? %>
+    <div class="row">
+      <% @conferences.each do |conference| %>
+        <div class="col-md-6 mb-4">
+          <div class="card shadow-sm h-100">
+            <div class="card-body">
+              <h5 class="card-title"><%= conference.name %></h5>
+              <p class="card-text text-muted">
+                <strong>Dates:</strong> <%= conference.start_date.strftime("%B %d") %> - <%= conference.end_date.strftime("%B %d, %Y") %><br>
+                <strong>Your Shifts:</strong> <%= @user.shifts_for_conference(conference) %><br>
+                <strong>Your Hours:</strong> <%= number_with_precision(@user.hours_for_conference(conference), precision: 1) %>
+              </p>
+            </div>
+            <div class="card-footer bg-transparent">
+              <%= link_to "View Shifts", volunteer_history_path(conference), class: "btn btn-sm btn-outline-primary" %>
+              <%= link_to "Conference Leaderboard", conference_leaderboard_path(conference), class: "btn btn-sm btn-outline-secondary" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      <h5 class="alert-heading">No Volunteer History Yet</h5>
+      <p class="mb-0">You haven't signed up for any shifts yet. <%= link_to "Browse conferences", conferences_path, class: "alert-link" %> to find volunteer opportunities.</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/volunteer_history/show.html.erb
+++ b/app/views/volunteer_history/show.html.erb
@@ -1,0 +1,63 @@
+<div class="container mt-5">
+  <nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "My History", volunteer_history_index_path %></li>
+      <li class="breadcrumb-item active" aria-current="page"><%= @conference.name %></li>
+    </ol>
+  </nav>
+
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>My Shifts: <%= @conference.name %></h1>
+    <%= link_to "Conference Leaderboard", conference_leaderboard_path(@conference), class: "btn btn-outline-primary" %>
+  </div>
+
+  <div class="row mb-4">
+    <div class="col-md-6">
+      <div class="card shadow-sm text-center">
+        <div class="card-body">
+          <h2 class="display-4 text-primary"><%= @user.shifts_for_conference(@conference) %></h2>
+          <p class="text-muted mb-0">Shifts</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="card shadow-sm text-center">
+        <div class="card-body">
+          <h2 class="display-4 text-success"><%= number_with_precision(@user.hours_for_conference(@conference), precision: 1) %></h2>
+          <p class="text-muted mb-0">Hours</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="mb-3">Shift Details</h2>
+
+  <% if @signups.any? %>
+    <div class="card shadow-sm">
+      <div class="table-responsive">
+        <table class="table table-hover mb-0">
+          <thead class="table-light">
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Time</th>
+              <th scope="col">Program</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @signups.each do |signup| %>
+              <tr>
+                <td><%= signup.timeslot.start_time.strftime("%A, %B %d, %Y") %></td>
+                <td><%= signup.timeslot.start_time.strftime("%l:%M %p") %> - <%= signup.timeslot.end_time.strftime("%l:%M %p") %></td>
+                <td><%= signup.timeslot.conference_program.program.name %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      <p class="mb-0">No shifts recorded for this conference.</p>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :conference_roles, only: [ :create, :destroy ]
     get "calendar", to: "calendar#show", as: :calendar
     get "schedule", to: "schedule#show", as: :schedule
+    get "leaderboard", to: "leaderboard#conference", as: :leaderboard
     resources :volunteer_signups, only: [ :index, :create, :destroy ]
     resources :timeslots, only: [ :update ] do
       member do
@@ -44,6 +45,12 @@ Rails.application.routes.draw do
   resources :programs do
     resources :program_qualifications, only: [ :create, :destroy ]
   end
+
+  # Leaderboard
+  resources :leaderboard, only: [ :index ]
+
+  # Volunteer history
+  resources :volunteer_history, only: [ :index, :show ]
 
   # Defines the root path route ("/")
   root "root#show"

--- a/test/controllers/leaderboard_controller_test.rb
+++ b/test/controllers/leaderboard_controller_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class LeaderboardControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @program = Program.create!(
+      name: "Test Program",
+      description: "A test program",
+      village: @village
+    )
+    @cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "12:00" }
+      }
+    )
+    @user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Test Volunteer"
+    )
+    @top_volunteer = User.create!(
+      email: "top@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Top Volunteer"
+    )
+    # Create signups for leaderboard
+    VolunteerSignup.create!(user: @top_volunteer, timeslot: @cp.timeslots.first)
+    VolunteerSignup.create!(user: @top_volunteer, timeslot: @cp.timeslots.second)
+    VolunteerSignup.create!(user: @user, timeslot: @cp.timeslots.third)
+  end
+
+  test "should get index when signed in" do
+    sign_in @user
+    get leaderboard_index_url
+    assert_response :success
+  end
+
+  test "should redirect to login when not signed in" do
+    get leaderboard_index_url
+    assert_redirected_to new_user_session_path
+  end
+
+  test "index displays top volunteers" do
+    sign_in @user
+    get leaderboard_index_url
+    assert_response :success
+    assert_select "table" do
+      assert_select "tr", minimum: 2 # header + at least one row
+    end
+  end
+
+  test "should get conference leaderboard" do
+    sign_in @user
+    get conference_leaderboard_url(@conference)
+    assert_response :success
+  end
+
+  test "conference leaderboard displays volunteers for that conference" do
+    sign_in @user
+    get conference_leaderboard_url(@conference)
+    assert_response :success
+    assert_match @top_volunteer.name, response.body
+  end
+end

--- a/test/controllers/volunteer_history_controller_test.rb
+++ b/test/controllers/volunteer_history_controller_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class VolunteerHistoryControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference1 = Conference.create!(
+      name: "Conference 2024",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @conference2 = Conference.create!(
+      name: "Conference 2023",
+      location: "Test Location 2",
+      start_date: Date.today + 10.days,
+      end_date: Date.today + 11.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @program = Program.create!(
+      name: "Test Program",
+      description: "A test program",
+      village: @village
+    )
+    @cp1 = ConferenceProgram.create!(
+      conference: @conference1,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+    @cp2 = ConferenceProgram.create!(
+      conference: @conference2,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+    @user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Test Volunteer"
+    )
+    # Create signups
+    VolunteerSignup.create!(user: @user, timeslot: @cp1.timeslots.first)
+    VolunteerSignup.create!(user: @user, timeslot: @cp1.timeslots.second)
+    VolunteerSignup.create!(user: @user, timeslot: @cp2.timeslots.first)
+  end
+
+  test "should get index when signed in" do
+    sign_in @user
+    get volunteer_history_index_url
+    assert_response :success
+  end
+
+  test "should redirect to login when not signed in" do
+    get volunteer_history_index_url
+    assert_redirected_to new_user_session_path
+  end
+
+  test "index displays user statistics" do
+    sign_in @user
+    get volunteer_history_index_url
+    assert_response :success
+    # Should display total shifts
+    assert_match(/3/, response.body) # 3 total shifts
+  end
+
+  test "index displays conferences participated" do
+    sign_in @user
+    get volunteer_history_index_url
+    assert_response :success
+    assert_match @conference1.name, response.body
+    assert_match @conference2.name, response.body
+  end
+
+  test "should get show for specific conference" do
+    sign_in @user
+    get volunteer_history_url(@conference1)
+    assert_response :success
+  end
+
+  test "show displays shifts for specific conference" do
+    sign_in @user
+    get volunteer_history_url(@conference1)
+    assert_response :success
+    assert_match @conference1.name, response.body
+    assert_match @program.name, response.body
+  end
+end

--- a/test/models/user_volunteer_stats_test.rb
+++ b/test/models/user_volunteer_stats_test.rb
@@ -1,0 +1,220 @@
+require "test_helper"
+
+class UserVolunteerStatsTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference1 = Conference.create!(
+      name: "Conference 2024",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @conference2 = Conference.create!(
+      name: "Conference 2023",
+      location: "Test Location 2",
+      start_date: Date.today + 10.days,
+      end_date: Date.today + 11.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @program = Program.create!(
+      name: "Test Program",
+      description: "A test program",
+      village: @village
+    )
+    @cp1 = ConferenceProgram.create!(
+      conference: @conference1,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+    @cp2 = ConferenceProgram.create!(
+      conference: @conference2,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+    @user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Test Volunteer"
+    )
+  end
+
+  test "total_shifts returns 0 for user with no signups" do
+    assert_equal 0, @user.total_shifts
+  end
+
+  test "total_shifts counts all volunteer signups" do
+    timeslot1 = @cp1.timeslots.first
+    timeslot2 = @cp1.timeslots.second
+    VolunteerSignup.create!(user: @user, timeslot: timeslot1)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot2)
+
+    assert_equal 2, @user.total_shifts
+  end
+
+  test "total_volunteer_hours returns 0 for user with no signups" do
+    assert_equal 0.0, @user.total_volunteer_hours
+  end
+
+  test "total_volunteer_hours calculates hours from 15-minute timeslots" do
+    # Each timeslot is 15 minutes = 0.25 hours
+    timeslot1 = @cp1.timeslots.first
+    timeslot2 = @cp1.timeslots.second
+    VolunteerSignup.create!(user: @user, timeslot: timeslot1)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot2)
+
+    # 2 timeslots * 15 minutes = 30 minutes = 0.5 hours
+    assert_equal 0.5, @user.total_volunteer_hours
+  end
+
+  test "conferences_participated returns empty array for user with no signups" do
+    assert_empty @user.conferences_participated
+  end
+
+  test "conferences_participated returns unique conferences" do
+    timeslot1 = @cp1.timeslots.first
+    timeslot2 = @cp1.timeslots.second
+    timeslot3 = @cp2.timeslots.first
+
+    VolunteerSignup.create!(user: @user, timeslot: timeslot1)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot2)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot3)
+
+    conferences = @user.conferences_participated
+    assert_equal 2, conferences.count
+    assert_includes conferences, @conference1
+    assert_includes conferences, @conference2
+  end
+
+  test "conferences_participated_count returns count of unique conferences" do
+    timeslot1 = @cp1.timeslots.first
+    timeslot2 = @cp1.timeslots.second
+    timeslot3 = @cp2.timeslots.first
+
+    VolunteerSignup.create!(user: @user, timeslot: timeslot1)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot2)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot3)
+
+    assert_equal 2, @user.conferences_participated_count
+  end
+
+  test "shifts_for_conference returns shifts for specific conference" do
+    timeslot1 = @cp1.timeslots.first
+    timeslot2 = @cp1.timeslots.second
+    timeslot3 = @cp2.timeslots.first
+
+    VolunteerSignup.create!(user: @user, timeslot: timeslot1)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot2)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot3)
+
+    assert_equal 2, @user.shifts_for_conference(@conference1)
+    assert_equal 1, @user.shifts_for_conference(@conference2)
+  end
+
+  test "hours_for_conference returns hours for specific conference" do
+    timeslot1 = @cp1.timeslots.first
+    timeslot2 = @cp1.timeslots.second
+
+    VolunteerSignup.create!(user: @user, timeslot: timeslot1)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot2)
+
+    # 2 timeslots * 15 minutes = 0.5 hours
+    assert_equal 0.5, @user.hours_for_conference(@conference1)
+  end
+
+  test "volunteer_signups_for_conference returns signups for specific conference" do
+    timeslot1 = @cp1.timeslots.first
+    timeslot2 = @cp2.timeslots.first
+
+    signup1 = VolunteerSignup.create!(user: @user, timeslot: timeslot1)
+    VolunteerSignup.create!(user: @user, timeslot: timeslot2)
+
+    signups = @user.volunteer_signups_for_conference(@conference1)
+    assert_equal 1, signups.count
+    assert_includes signups, signup1
+  end
+
+  # Class method tests for leaderboard
+  test "top_volunteers returns users ordered by total shifts descending" do
+    user2 = User.create!(
+      email: "volunteer2@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Top Volunteer"
+    )
+
+    # user2 has 3 shifts, @user has 1 shift
+    VolunteerSignup.create!(user: @user, timeslot: @cp1.timeslots.first)
+    VolunteerSignup.create!(user: user2, timeslot: @cp1.timeslots.second)
+    VolunteerSignup.create!(user: user2, timeslot: @cp1.timeslots.third)
+    VolunteerSignup.create!(user: user2, timeslot: @cp2.timeslots.first)
+
+    top = User.top_volunteers(10)
+    assert_equal user2, top.first
+    assert_equal @user, top.second
+  end
+
+  test "top_volunteers limits results" do
+    # Create a program with more timeslots
+    cp_large = ConferenceProgram.create!(
+      conference: @conference1,
+      program: Program.create!(name: "Large Program", description: "Many slots", village: @village),
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "12:00" }
+      }
+    )
+
+    5.times do |i|
+      user = User.create!(
+        email: "volunteer#{i}@example.com",
+        password: "password123",
+        password_confirmation: "password123"
+      )
+      VolunteerSignup.create!(user: user, timeslot: cp_large.timeslots[i])
+    end
+
+    assert_equal 3, User.top_volunteers(3).to_a.size
+  end
+
+  test "top_volunteers excludes users with no shifts" do
+    User.create!(
+      email: "inactive@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    VolunteerSignup.create!(user: @user, timeslot: @cp1.timeslots.first)
+
+    top = User.top_volunteers(10).to_a
+    assert_equal 1, top.size
+    assert_equal @user, top.first
+  end
+
+  test "top_volunteers_for_conference returns users for specific conference" do
+    user2 = User.create!(
+      email: "volunteer2@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    # @user has shifts in both conferences, user2 only in conference2
+    VolunteerSignup.create!(user: @user, timeslot: @cp1.timeslots.first)
+    VolunteerSignup.create!(user: user2, timeslot: @cp2.timeslots.first)
+    VolunteerSignup.create!(user: user2, timeslot: @cp2.timeslots.second)
+
+    top_c1 = User.top_volunteers_for_conference(@conference1, 10).to_a
+    assert_equal 1, top_c1.size
+    assert_equal @user, top_c1.first
+
+    top_c2 = User.top_volunteers_for_conference(@conference2, 10).to_a
+    assert_equal user2, top_c2.first
+  end
+end


### PR DESCRIPTION
## Summary
- Add volunteer statistics methods to User model (total shifts, hours, conferences participated)
- Create overall leaderboard showing top volunteers ranked by shifts
- Create conference-specific leaderboard
- Create personal volunteer history dashboard with per-conference breakdown
- Add "Volunteers" dropdown to navbar with Leaderboard and My History links
- Add Leaderboard button on conference show page

## Features
| Feature | Route | Description |
|---------|-------|-------------|
| Overall Leaderboard | `/leaderboard` | Top 25 volunteers across all conferences |
| Conference Leaderboard | `/conferences/:id/leaderboard` | Top volunteers for specific conference |
| My History | `/volunteer_history` | Personal stats and conferences participated |
| Conference History | `/volunteer_history/:id` | Detailed shift list for a conference |

## Test plan
- [x] All 259 tests pass (`bin/rails test:all`)
- [x] Rubocop passes with no offenses
- [ ] Verify leaderboard displays correctly with volunteer data
- [ ] Verify personal history shows correct statistics
- [ ] Verify navigation links work from navbar and conference page

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)