### PR TITLE
Add conference dashboard for leads/admins

### DIFF
--- a/app/controllers/conference_dashboard_controller.rb
+++ b/app/controllers/conference_dashboard_controller.rb
@@ -1,0 +1,15 @@
+class ConferenceDashboardController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference
+
+  def show
+    authorize @conference, :update?, policy_class: ConferencePolicy
+    @recent_signups = @conference.recent_signups(5)
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+end

--- a/app/views/conference_dashboard/show.html.erb
+++ b/app/views/conference_dashboard/show.html.erb
@@ -1,0 +1,115 @@
+<div class="container mt-5">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Dashboard: <%= @conference.name %></h1>
+    <%= link_to "Back to Conference", @conference, class: "btn btn-outline-secondary" %>
+  </div>
+
+  <div class="row mb-4">
+    <div class="col-md-3">
+      <div class="card shadow-sm text-center h-100">
+        <div class="card-body">
+          <h2 class="display-4 text-primary"><%= @conference.total_timeslots %></h2>
+          <p class="text-muted mb-0">Total Shifts</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card shadow-sm text-center h-100">
+        <div class="card-body">
+          <h2 class="display-4 text-success"><%= @conference.filled_timeslots %></h2>
+          <p class="text-muted mb-0">Filled Shifts</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card shadow-sm text-center h-100">
+        <div class="card-body">
+          <h2 class="display-4 text-warning"><%= @conference.unfilled_timeslots %></h2>
+          <p class="text-muted mb-0">Unfilled Shifts</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card shadow-sm text-center h-100">
+        <div class="card-body">
+          <h2 class="display-4 text-info"><%= number_with_precision(@conference.fill_rate, precision: 1) %>%</h2>
+          <p class="text-muted mb-0">Fill Rate</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row mb-4">
+    <div class="col-md-4">
+      <div class="card shadow-sm text-center h-100">
+        <div class="card-body">
+          <h2 class="display-4 text-secondary"><%= @conference.programs_count %></h2>
+          <p class="text-muted mb-0">Programs</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card shadow-sm text-center h-100">
+        <div class="card-body">
+          <h2 class="display-4 text-primary"><%= @conference.volunteer_count %></h2>
+          <p class="text-muted mb-0">Volunteers</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card shadow-sm text-center h-100">
+        <div class="card-body">
+          <h2 class="display-4 text-success"><%= number_with_precision(@conference.total_volunteer_hours, precision: 1) %></h2>
+          <p class="text-muted mb-0">Volunteer Hours</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-6">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-light">
+          <h5 class="mb-0">Quick Links</h5>
+        </div>
+        <div class="card-body">
+          <div class="list-group list-group-flush">
+            <%= link_to "Manage Programs", conference_conference_programs_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>
+            <%= link_to "View Schedule", conference_schedule_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>
+            <%= link_to "View Calendar", conference_calendar_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>
+            <%= link_to "View Leaderboard", conference_leaderboard_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>
+            <%= link_to "Edit Conference", edit_conference_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-light">
+          <h5 class="mb-0">Recent Activity</h5>
+        </div>
+        <div class="card-body">
+          <% if @recent_signups.any? %>
+            <ul class="list-group list-group-flush">
+              <% @recent_signups.each do |signup| %>
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <div>
+                    <strong><%= signup.user.name || signup.user.email %></strong>
+                    <br>
+                    <small class="text-muted">
+                      <%= signup.timeslot.conference_program.program.name %> -
+                      <%= signup.timeslot.start_time.strftime("%b %d, %l:%M %p") %>
+                    </small>
+                  </div>
+                  <small class="text-muted"><%= time_ago_in_words(signup.created_at) %> ago</small>
+                </li>
+              <% end %>
+            </ul>
+          <% else %>
+            <p class="text-muted mb-0">No recent volunteer signups.</p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/conferences/show.html.erb
+++ b/app/views/conferences/show.html.erb
@@ -109,6 +109,7 @@
             <%= link_to "View Schedule", conference_schedule_path(@conference), class: "btn btn-warning me-2" %>
             <%= link_to "View Calendar", conference_calendar_path(@conference), class: "btn btn-info me-2" %>
             <% if policy(@conference).update? %>
+              <%= link_to "Dashboard", conference_dashboard_path(@conference), class: "btn btn-outline-primary me-2" %>
               <%= link_to "Manage Programs", conference_conference_programs_path(@conference), class: "btn btn-primary" %>
             <% end %>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
   # Conference management
   resources :conferences do
+    get "dashboard", to: "conference_dashboard#show", as: :dashboard
     get "programs/new", to: "conference_programs#new", as: :new_conference_program
     resources :conference_programs, except: [ :new ], path: "programs"
     resources :conference_roles, only: [ :create, :destroy ]

--- a/test/controllers/conference_dashboard_controller_test.rb
+++ b/test/controllers/conference_dashboard_controller_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConferenceDashboardControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      village: @village,
+      start_date: Date.current,
+      end_date: Date.current + 3.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00")
+    )
+    @village_admin = User.create!(
+      email: "admin@test.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.find_or_create_by!(user: @village_admin, role: village_admin_role)
+    @village_admin.reload
+    @conference_lead = User.create!(
+      email: "lead@test.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: @conference_lead,
+      conference: @conference,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+    @conference_admin = User.create!(
+      email: "confadmin@test.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: @conference_admin,
+      conference: @conference,
+      role_name: ConferenceRole::CONFERENCE_ADMIN
+    )
+    @regular_user = User.create!(
+      email: "regular@test.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  # Access tests
+  test "dashboard requires authentication" do
+    get conference_dashboard_path(@conference)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "regular users cannot access dashboard" do
+    sign_in @regular_user
+    get conference_dashboard_path(@conference)
+    # Pundit redirects unauthorized users instead of returning 403
+    assert_redirected_to root_path
+  end
+
+  test "village admin can access dashboard" do
+    sign_in @village_admin
+    get conference_dashboard_path(@conference)
+    assert_response :success
+  end
+
+  test "conference lead can access dashboard" do
+    sign_in @conference_lead
+    get conference_dashboard_path(@conference)
+    assert_response :success
+  end
+
+  test "conference admin can access dashboard" do
+    sign_in @conference_admin
+    get conference_dashboard_path(@conference)
+    assert_response :success
+  end
+
+  # Content tests
+  test "dashboard shows conference name" do
+    sign_in @village_admin
+    get conference_dashboard_path(@conference)
+    assert_select "h1", /#{@conference.name}/
+  end
+
+  test "dashboard shows key metrics" do
+    sign_in @village_admin
+    get conference_dashboard_path(@conference)
+
+    # Check for metric card titles or labels
+    assert_select ".card" do
+      assert_select ".card-body"
+    end
+  end
+
+  test "dashboard shows quick links" do
+    sign_in @village_admin
+    get conference_dashboard_path(@conference)
+
+    # Check for links to common actions
+    assert_select "a[href=?]", conference_conference_programs_path(@conference)
+    assert_select "a[href=?]", conference_schedule_path(@conference)
+  end
+
+  test "dashboard shows recent signups section" do
+    sign_in @village_admin
+    get conference_dashboard_path(@conference)
+    assert_select "h5", /Recent Activity/
+  end
+
+  # Conference with data tests
+  test "dashboard displays correct metrics with volunteer data" do
+    program = Program.create!(name: "Test Program", max_volunteers: 2, village: @village)
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: program,
+      max_volunteers: 1,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "10:00" } }
+    )
+
+    timeslot = conference_program.timeslots.first
+    VolunteerSignup.create!(user: @regular_user, timeslot: timeslot)
+
+    sign_in @village_admin
+    get conference_dashboard_path(@conference)
+    assert_response :success
+
+    # Verify the page loads with the data
+    assert_select ".card"
+  end
+end

--- a/test/models/conference_dashboard_test.rb
+++ b/test/models/conference_dashboard_test.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConferenceDashboardTest < ActiveSupport::TestCase
+  def setup
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      village: @village,
+      start_date: Date.current,
+      end_date: Date.current + 3.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00")
+    )
+    @program = Program.create!(name: "Test Program", max_volunteers: 2, village: @village)
+  end
+
+  test "total_timeslots returns count of all timeslots" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "10:00" } }
+    )
+
+    assert @conference.total_timeslots > 0
+    expected_count = @conference.timeslots.count
+    assert_equal expected_count, @conference.total_timeslots
+  end
+
+  test "total_timeslots returns zero when no programs" do
+    assert_equal 0, @conference.total_timeslots
+  end
+
+  test "filled_timeslots returns count of timeslots at max capacity" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 1,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "09:30" } }
+    )
+
+    timeslot = conference_program.timeslots.first
+    assert timeslot.present?
+
+    user = create_test_user
+    VolunteerSignup.create!(user: user, timeslot: timeslot)
+
+    assert_equal 1, @conference.filled_timeslots
+  end
+
+  test "filled_timeslots returns zero when no timeslots are full" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 2,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "09:30" } }
+    )
+
+    assert_equal 0, @conference.filled_timeslots
+  end
+
+  test "unfilled_timeslots returns count of timeslots with available spots" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 2,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "09:30" } }
+    )
+
+    total = @conference.total_timeslots
+    assert total > 0
+    assert_equal total, @conference.unfilled_timeslots
+  end
+
+  test "unfilled_timeslots decreases when timeslots are filled" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 1,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "09:30" } }
+    )
+
+    total_before = @conference.total_timeslots
+    unfilled_before = @conference.unfilled_timeslots
+    assert_equal total_before, unfilled_before
+
+    timeslot = conference_program.timeslots.first
+    user = create_test_user
+    VolunteerSignup.create!(user: user, timeslot: timeslot)
+
+    assert_equal unfilled_before - 1, @conference.unfilled_timeslots
+  end
+
+  test "volunteer_count returns count of unique volunteers" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 3,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "10:00" } }
+    )
+
+    timeslots = conference_program.timeslots.first(2)
+    user1 = create_test_user(email: "user1@test.com")
+    user2 = create_test_user(email: "user2@test.com")
+
+    # User1 signs up for two timeslots
+    VolunteerSignup.create!(user: user1, timeslot: timeslots[0])
+    VolunteerSignup.create!(user: user1, timeslot: timeslots[1])
+    # User2 signs up for one timeslot
+    VolunteerSignup.create!(user: user2, timeslot: timeslots[0])
+
+    assert_equal 2, @conference.volunteer_count
+  end
+
+  test "volunteer_count returns zero when no signups" do
+    assert_equal 0, @conference.volunteer_count
+  end
+
+  test "programs_count returns count of conference programs" do
+    assert_equal 0, @conference.programs_count
+
+    ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "10:00" } }
+    )
+
+    assert_equal 1, @conference.programs_count
+  end
+
+  test "total_volunteer_hours returns sum of filled timeslots in hours" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 1,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "10:00" } }
+    )
+
+    # Each timeslot is 15 minutes = 0.25 hours
+    timeslots = conference_program.timeslots.first(4)
+    user = create_test_user
+
+    timeslots.each do |ts|
+      VolunteerSignup.create!(user: user, timeslot: ts)
+    end
+
+    # 4 signups * 0.25 hours = 1.0 hour
+    assert_equal 1.0, @conference.total_volunteer_hours
+  end
+
+  test "total_volunteer_hours returns zero when no signups" do
+    assert_equal 0.0, @conference.total_volunteer_hours
+  end
+
+  test "fill_rate returns percentage of filled timeslots" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 1,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "09:30" } }
+    )
+
+    total = @conference.total_timeslots
+    assert total > 0
+
+    # Fill half the timeslots
+    timeslots_to_fill = conference_program.timeslots.first(total / 2)
+    timeslots_to_fill.each_with_index do |ts, i|
+      user = create_test_user(email: "user#{i}@test.com")
+      VolunteerSignup.create!(user: user, timeslot: ts)
+    end
+
+    expected_rate = (timeslots_to_fill.size.to_f / total * 100).round(1)
+    assert_equal expected_rate, @conference.fill_rate
+  end
+
+  test "fill_rate returns zero when no timeslots" do
+    assert_equal 0.0, @conference.fill_rate
+  end
+
+  test "recent_signups returns signups ordered by creation" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 3,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "10:00" } }
+    )
+
+    timeslots = conference_program.timeslots.first(3)
+    user1 = create_test_user(email: "user1@test.com")
+    user2 = create_test_user(email: "user2@test.com")
+    user3 = create_test_user(email: "user3@test.com")
+
+    signup1 = VolunteerSignup.create!(user: user1, timeslot: timeslots[0])
+    signup2 = VolunteerSignup.create!(user: user2, timeslot: timeslots[1])
+    signup3 = VolunteerSignup.create!(user: user3, timeslot: timeslots[2])
+
+    recent = @conference.recent_signups(2)
+    assert_equal 2, recent.count
+    assert_equal signup3.id, recent.first.id
+    assert_equal signup2.id, recent.second.id
+  end
+
+  test "recent_signups defaults to 5 signups" do
+    conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 10,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "12:00" } }
+    )
+
+    timeslots = conference_program.timeslots.first(7)
+    7.times do |i|
+      user = create_test_user(email: "user#{i}@test.com")
+      VolunteerSignup.create!(user: user, timeslot: timeslots[i])
+    end
+
+    assert_equal 5, @conference.recent_signups.count
+  end
+
+  private
+
+  def create_test_user(email: "test#{SecureRandom.hex(4)}@test.com")
+    User.create!(
+      email: email,
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- Adds dashboard view for conference leads/admins with key metrics (total/filled/unfilled shifts, fill rate, volunteer count, programs, volunteer hours)
- Displays quick links to common actions (Manage Programs, Schedule, Calendar, Leaderboard, Edit)
- Shows recent volunteer signups in activity section
- Dashboard link added to conference show page for authorized users

Closes #18

## Test plan
- [ ] Verify dashboard accessible to village admins
- [ ] Verify dashboard accessible to conference leads
- [ ] Verify dashboard accessible to conference admins
- [ ] Verify regular users are redirected (cannot access)
- [ ] Verify metrics display correctly with volunteer signup data
- [ ] Verify quick links navigate to correct pages
- [ ] Verify recent activity shows recent signups

🤖 Generated with [Claude Code](https://claude.com/claude-code)