### PR TITLE
Add conference reports for leads/admins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem "devise", "~> 4.9"
 # Authorization
 gem "pundit", "~> 2.3"
 
+# CSV support (needed in Ruby 3.4+)
+gem "csv"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.5)
     date (3.5.0)
     debug (1.11.0)
       irb (~> 1.10)
@@ -414,6 +415,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   cssbundling-rails
+  csv
   debug
   devise (~> 4.9)
   image_processing (~> 1.2)

--- a/app/controllers/conference_reports_controller.rb
+++ b/app/controllers/conference_reports_controller.rb
@@ -1,0 +1,104 @@
+require "csv"
+
+class ConferenceReportsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference
+  before_action :authorize_reports
+
+  def index
+    @programs = @conference.programs
+  end
+
+  def shift_assignments
+    @timeslots = filtered_timeslots
+                 .includes(:volunteer_signups, :users, conference_program: :program)
+                 .where("timeslots.current_volunteers_count > 0")
+                 .order(:start_time)
+
+    respond_to do |format|
+      format.html
+      format.csv { send_shift_assignments_csv }
+    end
+  end
+
+  def unmanned_shifts
+    @timeslots = filtered_timeslots
+                 .includes(conference_program: :program)
+                 .where("timeslots.current_volunteers_count < timeslots.max_volunteers")
+                 .order(:start_time)
+
+    respond_to do |format|
+      format.html
+      format.csv { send_unmanned_shifts_csv }
+    end
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+
+  def authorize_reports
+    authorize @conference, :update?, policy_class: ConferencePolicy
+  end
+
+  def filtered_timeslots
+    timeslots = @conference.timeslots
+
+    if params[:program_id].present?
+      timeslots = timeslots.joins(:conference_program)
+                           .where(conference_programs: { program_id: params[:program_id] })
+    end
+
+    if params[:date].present?
+      date = Date.parse(params[:date])
+      timeslots = timeslots.where("DATE(timeslots.start_time) = ?", date)
+    end
+
+    timeslots
+  end
+
+  def send_shift_assignments_csv
+    csv_data = CSV.generate(headers: true) do |csv|
+      csv << [ "Date", "Time", "Program", "Volunteer Name", "Volunteer Email" ]
+
+      @timeslots.each do |timeslot|
+        timeslot.users.each do |user|
+          csv << [
+            timeslot.start_time.strftime("%Y-%m-%d"),
+            "#{timeslot.start_time.strftime('%H:%M')} - #{timeslot.end_time.strftime('%H:%M')}",
+            timeslot.conference_program.program.name,
+            user.name || "N/A",
+            user.email
+          ]
+        end
+      end
+    end
+
+    send_data csv_data,
+              filename: "shift_assignments_#{@conference.name.parameterize}_#{Date.current}.csv",
+              type: "text/csv"
+  end
+
+  def send_unmanned_shifts_csv
+    csv_data = CSV.generate(headers: true) do |csv|
+      csv << [ "Date", "Time", "Program", "Current Volunteers", "Max Volunteers", "Spots Available" ]
+
+      @timeslots.each do |timeslot|
+        csv << [
+          timeslot.start_time.strftime("%Y-%m-%d"),
+          "#{timeslot.start_time.strftime('%H:%M')} - #{timeslot.end_time.strftime('%H:%M')}",
+          timeslot.conference_program.program.name,
+          timeslot.current_volunteers_count,
+          timeslot.max_volunteers,
+          timeslot.max_volunteers - timeslot.current_volunteers_count
+        ]
+      end
+    end
+
+    send_data csv_data,
+              filename: "unmanned_shifts_#{@conference.name.parameterize}_#{Date.current}.csv",
+              type: "text/csv"
+  end
+end

--- a/app/views/conference_dashboard/show.html.erb
+++ b/app/views/conference_dashboard/show.html.erb
@@ -75,6 +75,7 @@
         <div class="card-body">
           <div class="list-group list-group-flush">
             <%= link_to "Manage Programs", conference_conference_programs_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>
+            <%= link_to "View Reports", conference_reports_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>
             <%= link_to "View Schedule", conference_schedule_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>
             <%= link_to "View Calendar", conference_calendar_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>
             <%= link_to "View Leaderboard", conference_leaderboard_path(@conference), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-center" %>

--- a/app/views/conference_reports/index.html.erb
+++ b/app/views/conference_reports/index.html.erb
@@ -1,0 +1,64 @@
+<div class="container mt-5">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Reports: <%= @conference.name %></h1>
+    <%= link_to "Back to Dashboard", conference_dashboard_path(@conference), class: "btn btn-outline-secondary" %>
+  </div>
+
+  <div class="row">
+    <div class="col-md-6 mb-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-primary text-white">
+          <h5 class="mb-0">Shift Assignments</h5>
+        </div>
+        <div class="card-body">
+          <p class="card-text">View who is assigned to which shifts. Shows all volunteers and their scheduled timeslots.</p>
+          <div class="d-flex gap-2">
+            <%= link_to "View Report", shift_assignments_conference_reports_path(@conference), class: "btn btn-primary" %>
+            <%= link_to "Export CSV", shift_assignments_conference_reports_path(@conference, format: :csv), class: "btn btn-outline-secondary" %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-6 mb-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-warning text-dark">
+          <h5 class="mb-0">Unmanned Shifts</h5>
+        </div>
+        <div class="card-body">
+          <p class="card-text">View shifts that need more volunteers. Shows all timeslots with available spots.</p>
+          <div class="d-flex gap-2">
+            <%= link_to "View Report", unmanned_shifts_conference_reports_path(@conference), class: "btn btn-warning" %>
+            <%= link_to "Export CSV", unmanned_shifts_conference_reports_path(@conference, format: :csv), class: "btn btn-outline-secondary" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card shadow-sm mt-4">
+    <div class="card-header bg-light">
+      <h5 class="mb-0">Quick Stats</h5>
+    </div>
+    <div class="card-body">
+      <div class="row text-center">
+        <div class="col-md-3">
+          <h3 class="text-primary"><%= @conference.total_timeslots %></h3>
+          <p class="text-muted">Total Shifts</p>
+        </div>
+        <div class="col-md-3">
+          <h3 class="text-success"><%= @conference.filled_timeslots %></h3>
+          <p class="text-muted">Filled Shifts</p>
+        </div>
+        <div class="col-md-3">
+          <h3 class="text-warning"><%= @conference.unfilled_timeslots %></h3>
+          <p class="text-muted">Unmanned Shifts</p>
+        </div>
+        <div class="col-md-3">
+          <h3 class="text-info"><%= @conference.volunteer_count %></h3>
+          <p class="text-muted">Volunteers</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/conference_reports/shift_assignments.html.erb
+++ b/app/views/conference_reports/shift_assignments.html.erb
@@ -1,0 +1,72 @@
+<div class="container mt-5">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Shift Assignments: <%= @conference.name %></h1>
+    <div>
+      <%= link_to "Export CSV", shift_assignments_conference_reports_path(@conference, format: :csv, program_id: params[:program_id], date: params[:date]), class: "btn btn-success me-2" %>
+      <%= link_to "Back to Reports", conference_reports_path(@conference), class: "btn btn-outline-secondary" %>
+    </div>
+  </div>
+
+  <div class="card shadow-sm mb-4">
+    <div class="card-header bg-light">
+      <h5 class="mb-0">Filters</h5>
+    </div>
+    <div class="card-body">
+      <%= form_with url: shift_assignments_conference_reports_path(@conference), method: :get, local: true, class: "row g-3" do %>
+        <div class="col-md-4">
+          <label for="program_id" class="form-label">Program</label>
+          <%= select_tag :program_id,
+              options_from_collection_for_select(@conference.programs, :id, :name, params[:program_id]),
+              include_blank: "All Programs",
+              class: "form-select" %>
+        </div>
+        <div class="col-md-4">
+          <label for="date" class="form-label">Date</label>
+          <%= date_field_tag :date, params[:date], class: "form-control", min: @conference.start_date, max: @conference.end_date %>
+        </div>
+        <div class="col-md-4 d-flex align-items-end">
+          <%= submit_tag "Apply Filters", class: "btn btn-primary me-2" %>
+          <%= link_to "Clear", shift_assignments_conference_reports_path(@conference), class: "btn btn-outline-secondary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <% if @timeslots.any? %>
+    <div class="card shadow-sm">
+      <div class="table-responsive">
+        <table class="table table-hover mb-0">
+          <thead class="table-light">
+            <tr>
+              <th>Date</th>
+              <th>Time</th>
+              <th>Program</th>
+              <th>Volunteer</th>
+              <th>Email</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @timeslots.each do |timeslot| %>
+              <% timeslot.users.each do |user| %>
+                <tr>
+                  <td><%= timeslot.start_time.strftime("%A, %B %d") %></td>
+                  <td><%= timeslot.start_time.strftime("%l:%M %p") %> - <%= timeslot.end_time.strftime("%l:%M %p") %></td>
+                  <td><%= timeslot.conference_program.program.name %></td>
+                  <td><%= user.name || "N/A" %></td>
+                  <td><%= user.email %></td>
+                </tr>
+              <% end %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <p class="text-muted mt-3">
+      Showing <%= @timeslots.sum { |t| t.users.size } %> volunteer assignments across <%= @timeslots.size %> shifts.
+    </p>
+  <% else %>
+    <div class="alert alert-info">
+      <p class="mb-0">No volunteer assignments found for the selected filters.</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/conference_reports/unmanned_shifts.html.erb
+++ b/app/views/conference_reports/unmanned_shifts.html.erb
@@ -1,0 +1,82 @@
+<div class="container mt-5">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Unmanned Shifts: <%= @conference.name %></h1>
+    <div>
+      <%= link_to "Export CSV", unmanned_shifts_conference_reports_path(@conference, format: :csv, program_id: params[:program_id], date: params[:date]), class: "btn btn-success me-2" %>
+      <%= link_to "Back to Reports", conference_reports_path(@conference), class: "btn btn-outline-secondary" %>
+    </div>
+  </div>
+
+  <div class="card shadow-sm mb-4">
+    <div class="card-header bg-light">
+      <h5 class="mb-0">Filters</h5>
+    </div>
+    <div class="card-body">
+      <%= form_with url: unmanned_shifts_conference_reports_path(@conference), method: :get, local: true, class: "row g-3" do %>
+        <div class="col-md-4">
+          <label for="program_id" class="form-label">Program</label>
+          <%= select_tag :program_id,
+              options_from_collection_for_select(@conference.programs, :id, :name, params[:program_id]),
+              include_blank: "All Programs",
+              class: "form-select" %>
+        </div>
+        <div class="col-md-4">
+          <label for="date" class="form-label">Date</label>
+          <%= date_field_tag :date, params[:date], class: "form-control", min: @conference.start_date, max: @conference.end_date %>
+        </div>
+        <div class="col-md-4 d-flex align-items-end">
+          <%= submit_tag "Apply Filters", class: "btn btn-primary me-2" %>
+          <%= link_to "Clear", unmanned_shifts_conference_reports_path(@conference), class: "btn btn-outline-secondary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <% if @timeslots.any? %>
+    <div class="card shadow-sm">
+      <div class="table-responsive">
+        <table class="table table-hover mb-0">
+          <thead class="table-light">
+            <tr>
+              <th>Date</th>
+              <th>Time</th>
+              <th>Program</th>
+              <th>Current</th>
+              <th>Max</th>
+              <th>Spots Available</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @timeslots.each do |timeslot| %>
+              <% spots_available = timeslot.max_volunteers - timeslot.current_volunteers_count %>
+              <tr class="<%= timeslot.current_volunteers_count == 0 ? 'table-danger' : 'table-warning' %>">
+                <td><%= timeslot.start_time.strftime("%A, %B %d") %></td>
+                <td><%= timeslot.start_time.strftime("%l:%M %p") %> - <%= timeslot.end_time.strftime("%l:%M %p") %></td>
+                <td><%= timeslot.conference_program.program.name %></td>
+                <td><%= timeslot.current_volunteers_count %></td>
+                <td><%= timeslot.max_volunteers %></td>
+                <td><%= spots_available %></td>
+                <td>
+                  <% if timeslot.current_volunteers_count == 0 %>
+                    <span class="badge bg-danger">Unmanned</span>
+                  <% else %>
+                    <span class="badge bg-warning text-dark">Understaffed</span>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <p class="text-muted mt-3">
+      Showing <%= @timeslots.size %> shifts that need volunteers.
+      Total spots available: <%= @timeslots.sum { |t| t.max_volunteers - t.current_volunteers_count } %>
+    </p>
+  <% else %>
+    <div class="alert alert-success">
+      <p class="mb-0">All shifts are fully staffed! No unmanned shifts found.</p>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,12 @@ Rails.application.routes.draw do
         delete :remove_volunteer
       end
     end
+    resources :reports, controller: "conference_reports", only: [ :index ] do
+      collection do
+        get :shift_assignments
+        get :unmanned_shifts
+      end
+    end
   end
 
   # Program management

--- a/test/controllers/conference_reports_controller_test.rb
+++ b/test/controllers/conference_reports_controller_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConferenceReportsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      village: @village,
+      start_date: Date.current,
+      end_date: Date.current + 3.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00")
+    )
+    @program = Program.create!(name: "Test Program", max_volunteers: 2, village: @village)
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      max_volunteers: 2,
+      day_schedules: { "0" => { "enabled" => true, "start_time" => "09:00", "end_time" => "12:00" } }
+    )
+
+    @village_admin = User.create!(
+      email: "admin@test.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.find_or_create_by!(user: @village_admin, role: village_admin_role)
+    @village_admin.reload
+
+    @conference_lead = User.create!(
+      email: "lead@test.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: @conference_lead,
+      conference: @conference,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+
+    @regular_user = User.create!(
+      email: "regular@test.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  # Index (reports landing page)
+  test "reports index requires authentication" do
+    get conference_reports_path(@conference)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "regular users cannot access reports" do
+    sign_in @regular_user
+    get conference_reports_path(@conference)
+    assert_redirected_to root_path
+  end
+
+  test "conference lead can access reports index" do
+    sign_in @conference_lead
+    get conference_reports_path(@conference)
+    assert_response :success
+  end
+
+  test "village admin can access reports index" do
+    sign_in @village_admin
+    get conference_reports_path(@conference)
+    assert_response :success
+  end
+
+  # Shift assignments report
+  test "shift assignments report shows volunteers assigned to shifts" do
+    timeslot = @conference_program.timeslots.first
+    VolunteerSignup.create!(user: @regular_user, timeslot: timeslot)
+
+    sign_in @village_admin
+    get shift_assignments_conference_reports_path(@conference)
+    assert_response :success
+    assert_match @regular_user.email, response.body
+  end
+
+  test "shift assignments report can be exported as CSV" do
+    timeslot = @conference_program.timeslots.first
+    VolunteerSignup.create!(user: @regular_user, timeslot: timeslot)
+
+    sign_in @village_admin
+    get shift_assignments_conference_reports_path(@conference, format: :csv)
+    assert_response :success
+    assert_equal "text/csv", response.content_type.split(";").first
+  end
+
+  # Unmanned shifts report
+  test "unmanned shifts report shows shifts below capacity" do
+    sign_in @village_admin
+    get unmanned_shifts_conference_reports_path(@conference)
+    assert_response :success
+  end
+
+  test "unmanned shifts report can be exported as CSV" do
+    sign_in @village_admin
+    get unmanned_shifts_conference_reports_path(@conference, format: :csv)
+    assert_response :success
+    assert_equal "text/csv", response.content_type.split(";").first
+  end
+
+  # Filtering
+  test "shift assignments can be filtered by program" do
+    sign_in @village_admin
+    get shift_assignments_conference_reports_path(@conference, program_id: @program.id)
+    assert_response :success
+  end
+
+  test "shift assignments can be filtered by date" do
+    sign_in @village_admin
+    get shift_assignments_conference_reports_path(@conference, date: Date.current.to_s)
+    assert_response :success
+  end
+
+  test "unmanned shifts can be filtered by program" do
+    sign_in @village_admin
+    get unmanned_shifts_conference_reports_path(@conference, program_id: @program.id)
+    assert_response :success
+  end
+
+  test "unmanned shifts can be filtered by date" do
+    sign_in @village_admin
+    get unmanned_shifts_conference_reports_path(@conference, date: Date.current.to_s)
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## Summary
- Adds reports landing page with quick stats overview
- Adds shift assignments report showing who should be where and when
- Adds unmanned shifts report showing shifts needing more volunteers
- CSV export functionality for both reports
- Filters by program and date
- Reports link added to dashboard Quick Links

Closes #19

## Test plan
- [ ] Verify reports accessible to village admins
- [ ] Verify reports accessible to conference leads/admins
- [ ] Verify regular users are redirected (cannot access)
- [ ] Verify shift assignments report shows correct volunteer data
- [ ] Verify unmanned shifts report shows correct capacity info
- [ ] Verify CSV exports download correctly
- [ ] Verify program and date filters work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)