### PR TITLE
Add calendar export (iCal/ICS) for volunteer shifts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem "pundit", "~> 2.3"
 # CSV support (needed in Ruby 3.4+)
 gem "csv"
 
+# Calendar export (iCal/ICS)
+gem "icalendar"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,12 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    icalendar (2.12.1)
+      base64
+      ice_cube (~> 0.16)
+      logger
+      ostruct
+    ice_cube (0.17.0)
     image_processing (1.14.0)
       mini_magick (>= 4.9.5, < 6)
       ruby-vips (>= 2.0.17, < 3)
@@ -418,6 +424,7 @@ DEPENDENCIES
   csv
   debug
   devise (~> 4.9)
+  icalendar
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/controllers/calendar_exports_controller.rb
+++ b/app/controllers/calendar_exports_controller.rb
@@ -1,0 +1,38 @@
+require "icalendar"
+
+class CalendarExportsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference
+
+  def show
+    signups = current_user.volunteer_signups_for_conference(@conference)
+                          .includes(timeslot: { conference_program: :program })
+
+    calendar = Icalendar::Calendar.new
+    calendar.prodid = "-//Villagers//Volunteer Shifts//EN"
+
+    signups.each do |signup|
+      timeslot = signup.timeslot
+      program = timeslot.conference_program.program
+
+      calendar.event do |event|
+        event.dtstart = Icalendar::Values::DateTime.new(timeslot.start_time)
+        event.dtend = Icalendar::Values::DateTime.new(timeslot.end_time)
+        event.summary = "Volunteer: #{program.name}"
+        event.description = "Volunteer shift for #{program.name} at #{@conference.name}"
+        event.location = @conference.location
+        event.uid = "volunteer-signup-#{signup.id}@villagers"
+      end
+    end
+
+    send_data calendar.to_ical,
+              filename: "volunteer_shifts_#{@conference.name.parameterize}_#{Date.current}.ics",
+              type: "text/calendar"
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+end

--- a/app/views/volunteer_history/show.html.erb
+++ b/app/views/volunteer_history/show.html.erb
@@ -8,7 +8,10 @@
 
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>My Shifts: <%= @conference.name %></h1>
-    <%= link_to "Conference Leaderboard", conference_leaderboard_path(@conference), class: "btn btn-outline-primary" %>
+    <div>
+      <%= link_to "Export to Calendar", conference_calendar_export_path(@conference), class: "btn btn-success me-2" %>
+      <%= link_to "Conference Leaderboard", conference_leaderboard_path(@conference), class: "btn btn-outline-primary" %>
+    </div>
   </div>
 
   <div class="row mb-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   # Conference management
   resources :conferences do
     get "dashboard", to: "conference_dashboard#show", as: :dashboard
+    get "calendar_export", to: "calendar_exports#show", as: :calendar_export
     get "programs/new", to: "conference_programs#new", as: :new_conference_program
     resources :conference_programs, except: [ :new ], path: "programs"
     resources :conference_roles, only: [ :create, :destroy ]

--- a/test/controllers/calendar_exports_controller_test.rb
+++ b/test/controllers/calendar_exports_controller_test.rb
@@ -1,0 +1,117 @@
+require "test_helper"
+
+class CalendarExportsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference 2024",
+      location: "Las Vegas Convention Center",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @program = Program.create!(
+      name: "Registration Desk",
+      description: "Help with attendee registration",
+      village: @village
+    )
+    @cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "12:00" }
+      }
+    )
+    @user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Test Volunteer"
+    )
+    # Create signups for the user
+    VolunteerSignup.create!(user: @user, timeslot: @cp.timeslots.first)
+    VolunteerSignup.create!(user: @user, timeslot: @cp.timeslots.second)
+  end
+
+  test "should redirect to login when not signed in" do
+    get conference_calendar_export_url(@conference)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "should get calendar export for signed in user" do
+    sign_in @user
+    get conference_calendar_export_url(@conference)
+    assert_response :success
+  end
+
+  test "should return ICS content type" do
+    sign_in @user
+    get conference_calendar_export_url(@conference)
+    assert_equal "text/calendar", response.content_type
+  end
+
+  test "should have correct filename in content disposition" do
+    sign_in @user
+    get conference_calendar_export_url(@conference)
+    assert_match(/filename="volunteer_shifts_test-conference-2024/, response.headers["Content-Disposition"])
+    assert_match(/\.ics"/, response.headers["Content-Disposition"])
+  end
+
+  test "should include VCALENDAR header" do
+    sign_in @user
+    get conference_calendar_export_url(@conference)
+    assert_match "BEGIN:VCALENDAR", response.body
+    assert_match "END:VCALENDAR", response.body
+  end
+
+  test "should include VEVENT for each shift" do
+    sign_in @user
+    get conference_calendar_export_url(@conference)
+    # Should have 2 events (2 signups)
+    assert_equal 2, response.body.scan("BEGIN:VEVENT").count
+  end
+
+  test "should include program name in event summary" do
+    sign_in @user
+    get conference_calendar_export_url(@conference)
+    assert_match "Registration Desk", response.body
+  end
+
+  test "should include conference location" do
+    sign_in @user
+    get conference_calendar_export_url(@conference)
+    assert_match "Las Vegas Convention Center", response.body
+  end
+
+  test "should only include user's own shifts" do
+    other_user = User.create!(
+      email: "other@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Other Volunteer"
+    )
+    VolunteerSignup.create!(user: other_user, timeslot: @cp.timeslots.third)
+
+    sign_in @user
+    get conference_calendar_export_url(@conference)
+    # Should only have 2 events (user's 2 signups, not other_user's signup)
+    assert_equal 2, response.body.scan("BEGIN:VEVENT").count
+  end
+
+  test "should return empty calendar when user has no shifts" do
+    other_user = User.create!(
+      email: "noshifts@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "No Shifts User"
+    )
+
+    sign_in other_user
+    get conference_calendar_export_url(@conference)
+    assert_response :success
+    # Should have no events
+    assert_equal 0, response.body.scan("BEGIN:VEVENT").count
+  end
+end


### PR DESCRIPTION
## Summary
- Volunteers can export their shifts for a conference as an iCal/ICS file
- File can be imported into Google Calendar, Apple Calendar, Outlook, etc.
- Export includes program name, timeslot, and conference location
- Added "Export to Calendar" button on volunteer's shift view

## Test plan
- [ ] Sign in as a volunteer with shifts
- [ ] Navigate to My History → select a conference
- [ ] Click "Export to Calendar" button
- [ ] Verify ICS file downloads
- [ ] Import into calendar app and verify events appear correctly

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)