### PR TITLE
Add conference-specific qualifications system

### DIFF
--- a/app/controllers/conference_qualifications_controller.rb
+++ b/app/controllers/conference_qualifications_controller.rb
@@ -1,0 +1,64 @@
+class ConferenceQualificationsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference
+  before_action :set_qualification, only: [ :show, :edit, :update, :destroy ]
+  before_action :authorize_manage
+
+  def index
+    @qualifications = @conference.conference_qualifications.order(:name)
+  end
+
+  def show
+  end
+
+  def new
+    @qualification = @conference.conference_qualifications.new
+  end
+
+  def create
+    @qualification = @conference.conference_qualifications.new(qualification_params)
+
+    if @qualification.save
+      redirect_to conference_conference_qualification_path(@conference, @qualification),
+                  notice: "Qualification was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @qualification.update(qualification_params)
+      redirect_to conference_conference_qualification_path(@conference, @qualification),
+                  notice: "Qualification was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @qualification.destroy
+    redirect_to conference_conference_qualifications_path(@conference),
+                notice: "Qualification was successfully deleted."
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+
+  def set_qualification
+    @qualification = @conference.conference_qualifications.find(params[:id])
+  end
+
+  def authorize_manage
+    authorize @conference, :update?, policy_class: ConferencePolicy
+  end
+
+  def qualification_params
+    params.require(:conference_qualification).permit(:name, :description)
+  end
+end

--- a/app/controllers/conference_user_qualifications_controller.rb
+++ b/app/controllers/conference_user_qualifications_controller.rb
@@ -1,0 +1,40 @@
+class ConferenceUserQualificationsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference
+  before_action :authorize_manage
+
+  def create
+    @qualification = @conference.conference_qualifications.find(params[:conference_qualification_id])
+    @user = User.find(params[:user_id])
+
+    ConferenceUserQualification.find_or_create_by!(
+      user: @user,
+      conference_qualification: @qualification
+    )
+
+    redirect_to conference_conference_qualification_path(@conference, @qualification),
+                notice: "Qualification granted successfully."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to conference_conference_qualification_path(@conference, @qualification),
+                alert: "Could not grant qualification: #{e.message}"
+  end
+
+  def destroy
+    @user_qualification = ConferenceUserQualification.find(params[:id])
+    @qualification = @user_qualification.conference_qualification
+
+    @user_qualification.destroy
+    redirect_to conference_conference_qualification_path(@conference, @qualification),
+                notice: "Qualification revoked successfully."
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+
+  def authorize_manage
+    authorize @conference, :update?, policy_class: ConferencePolicy
+  end
+end

--- a/app/controllers/qualification_removals_controller.rb
+++ b/app/controllers/qualification_removals_controller.rb
@@ -1,0 +1,50 @@
+class QualificationRemovalsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference
+  before_action :set_village
+  before_action :authorize_manage
+
+  def index
+    @global_qualifications = @village.qualifications.order(:name)
+    @removals = @conference.qualification_removals.includes(:user, :qualification)
+  end
+
+  def create
+    @user = User.find(params[:user_id])
+    @qualification = Qualification.find(params[:qualification_id])
+
+    QualificationRemoval.find_or_create_by!(
+      user: @user,
+      qualification: @qualification,
+      conference: @conference
+    )
+
+    redirect_to conference_qualification_removals_path(@conference),
+                notice: "Qualification removed for this conference."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to conference_qualification_removals_path(@conference),
+                alert: "Could not remove qualification: #{e.message}"
+  end
+
+  def destroy
+    @removal = QualificationRemoval.find(params[:id])
+    @removal.destroy
+    redirect_to conference_qualification_removals_path(@conference),
+                notice: "Qualification restored for this conference."
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+
+  def set_village
+    @village = Village.first
+    redirect_to setup_path if @village.nil?
+  end
+
+  def authorize_manage
+    authorize @conference, :update?, policy_class: ConferencePolicy
+  end
+end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -5,6 +5,8 @@ class Conference < ApplicationRecord
   has_many :conference_programs, dependent: :destroy
   has_many :programs, through: :conference_programs
   has_many :timeslots, through: :conference_programs
+  has_many :conference_qualifications, dependent: :destroy
+  has_many :qualification_removals, dependent: :destroy
 
   validates :name, presence: true
   validates :start_date, presence: true

--- a/app/models/conference_qualification.rb
+++ b/app/models/conference_qualification.rb
@@ -1,0 +1,8 @@
+class ConferenceQualification < ApplicationRecord
+  belongs_to :conference
+  has_many :conference_user_qualifications, dependent: :destroy
+  has_many :users, through: :conference_user_qualifications
+
+  validates :name, presence: true, uniqueness: { scope: :conference_id }
+  validates :description, presence: true
+end

--- a/app/models/conference_user_qualification.rb
+++ b/app/models/conference_user_qualification.rb
@@ -1,0 +1,6 @@
+class ConferenceUserQualification < ApplicationRecord
+  belongs_to :user
+  belongs_to :conference_qualification
+
+  validates :user, uniqueness: { scope: :conference_qualification_id }
+end

--- a/app/models/qualification_removal.rb
+++ b/app/models/qualification_removal.rb
@@ -1,0 +1,7 @@
+class QualificationRemoval < ApplicationRecord
+  belongs_to :user
+  belongs_to :qualification
+  belongs_to :conference
+
+  validates :user, uniqueness: { scope: [ :qualification_id, :conference_id ] }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,9 @@ class User < ApplicationRecord
   # Qualification associations
   has_many :user_qualifications, dependent: :destroy
   has_many :qualifications, through: :user_qualifications
+  has_many :conference_user_qualifications, dependent: :destroy
+  has_many :conference_qualifications, through: :conference_user_qualifications
+  has_many :qualification_removals, dependent: :destroy
   # Volunteer signup associations
   has_many :volunteer_signups, dependent: :destroy
   has_many :timeslots, through: :volunteer_signups
@@ -64,6 +67,20 @@ class User < ApplicationRecord
 
   def has_qualification_for_program?(program)
     program.qualifications.all? { |qual| has_qualification?(qual) }
+  end
+
+  # Conference-specific qualification methods
+  def has_conference_qualification?(conference_qualification)
+    conference_user_qualifications.exists?(conference_qualification: conference_qualification)
+  end
+
+  def qualification_removed_for_conference?(qualification, conference)
+    qualification_removals.exists?(qualification: qualification, conference: conference)
+  end
+
+  def effective_qualification_for_conference?(qualification, conference)
+    return false unless has_qualification?(qualification)
+    !qualification_removed_for_conference?(qualification, conference)
   end
 
   # Volunteer statistics methods

--- a/app/models/volunteer_signup.rb
+++ b/app/models/volunteer_signup.rb
@@ -41,9 +41,12 @@ class VolunteerSignup < ApplicationRecord
     return unless user && timeslot
 
     program = timeslot.program
+    conference = timeslot.conference_program.conference
     required_qualifications = program.qualifications
 
-    missing_qualifications = required_qualifications.reject { |qual| user.has_qualification?(qual) }
+    missing_qualifications = required_qualifications.reject do |qual|
+      user.effective_qualification_for_conference?(qual, conference)
+    end
 
     if missing_qualifications.any?
       errors.add(:base, "You do not have the required qualifications: #{missing_qualifications.map(&:name).join(', ')}")

--- a/app/views/conference_qualifications/_form.html.erb
+++ b/app/views/conference_qualifications/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with model: [@conference, qualification], local: true do |f| %>
+  <% if qualification.errors.any? %>
+    <div class="alert alert-danger">
+      <h4 class="alert-heading"><%= pluralize(qualification.errors.count, "error") %> prohibited this qualification from being saved:</h4>
+      <ul class="mb-0">
+        <% qualification.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= f.label :name, class: "form-label" %>
+    <%= f.text_field :name, class: "form-control", required: true %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :description, class: "form-label" %>
+    <%= f.text_area :description, class: "form-control", rows: 4, required: true %>
+  </div>
+
+  <div class="d-flex gap-2">
+    <%= f.submit class: "btn btn-primary" %>
+    <%= link_to "Cancel", conference_conference_qualifications_path(@conference), class: "btn btn-outline-secondary" %>
+  </div>
+<% end %>

--- a/app/views/conference_qualifications/edit.html.erb
+++ b/app/views/conference_qualifications/edit.html.erb
@@ -1,0 +1,22 @@
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-md-8 offset-md-2">
+      <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><%= link_to @conference.name, @conference %></li>
+          <li class="breadcrumb-item"><%= link_to "Conference Qualifications", conference_conference_qualifications_path(@conference) %></li>
+          <li class="breadcrumb-item active" aria-current="page">Edit</li>
+        </ol>
+      </nav>
+
+      <div class="card">
+        <div class="card-header">
+          <h2>Edit Conference Qualification</h2>
+        </div>
+        <div class="card-body">
+          <%= render "form", qualification: @qualification %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/conference_qualifications/index.html.erb
+++ b/app/views/conference_qualifications/index.html.erb
@@ -1,0 +1,51 @@
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-12">
+      <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><%= link_to @conference.name, @conference %></li>
+          <li class="breadcrumb-item active" aria-current="page">Conference Qualifications</li>
+        </ol>
+      </nav>
+
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1>Conference Qualifications: <%= @conference.name %></h1>
+        <%= link_to "New Qualification", new_conference_conference_qualification_path(@conference), class: "btn btn-primary" %>
+      </div>
+
+      <div class="alert alert-info mb-4">
+        <strong>Note:</strong> These qualifications are specific to this conference only.
+        For global qualifications that apply across all conferences, use the
+        <%= link_to "Global Qualifications", qualifications_path %> page.
+      </div>
+
+      <% if @qualifications.any? %>
+        <div class="row">
+          <% @qualifications.each do |qualification| %>
+            <div class="col-md-6 mb-3">
+              <div class="card">
+                <div class="card-body">
+                  <h5 class="card-title"><%= qualification.name %></h5>
+                  <p class="card-text"><%= qualification.description %></p>
+                  <p class="text-muted small">
+                    <%= pluralize(qualification.users.count, "user") %> with this qualification
+                  </p>
+                  <div class="d-flex gap-2">
+                    <%= link_to "View", conference_conference_qualification_path(@conference, qualification), class: "btn btn-sm btn-outline-primary" %>
+                    <%= link_to "Edit", edit_conference_conference_qualification_path(@conference, qualification), class: "btn btn-sm btn-outline-secondary" %>
+                    <%= link_to "Delete", conference_conference_qualification_path(@conference, qualification), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-sm btn-outline-danger" %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="alert alert-secondary">
+          No conference-specific qualifications have been created yet.
+          <%= link_to "Create the first qualification", new_conference_conference_qualification_path(@conference), class: "alert-link" %>.
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/conference_qualifications/new.html.erb
+++ b/app/views/conference_qualifications/new.html.erb
@@ -1,0 +1,22 @@
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-md-8 offset-md-2">
+      <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><%= link_to @conference.name, @conference %></li>
+          <li class="breadcrumb-item"><%= link_to "Conference Qualifications", conference_conference_qualifications_path(@conference) %></li>
+          <li class="breadcrumb-item active" aria-current="page">New</li>
+        </ol>
+      </nav>
+
+      <div class="card">
+        <div class="card-header">
+          <h2>New Conference Qualification</h2>
+        </div>
+        <div class="card-body">
+          <%= render "form", qualification: @qualification %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/conference_qualifications/show.html.erb
+++ b/app/views/conference_qualifications/show.html.erb
@@ -1,0 +1,57 @@
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-12">
+      <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><%= link_to @conference.name, @conference %></li>
+          <li class="breadcrumb-item"><%= link_to "Conference Qualifications", conference_conference_qualifications_path(@conference) %></li>
+          <li class="breadcrumb-item active" aria-current="page"><%= @qualification.name %></li>
+        </ol>
+      </nav>
+
+      <div class="card">
+        <div class="card-header">
+          <h2><%= @qualification.name %></h2>
+          <span class="badge bg-info">Conference-Specific</span>
+        </div>
+        <div class="card-body">
+          <p><strong>Description:</strong></p>
+          <p><%= @qualification.description %></p>
+
+          <div class="mt-4">
+            <h5>Users with this Qualification</h5>
+            <% if @qualification.users.any? %>
+              <ul class="list-group mb-3">
+                <% @qualification.users.each do |user| %>
+                  <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <%= user.name || user.email %>
+                    <%= link_to "Revoke", conference_conference_user_qualification_path(@conference, @qualification.conference_user_qualifications.find_by(user: user)), data: { turbo_method: :delete, turbo_confirm: "Revoke this qualification from #{user.name || user.email}?" }, class: "btn btn-sm btn-outline-danger" %>
+                  </li>
+                <% end %>
+              </ul>
+            <% else %>
+              <p class="text-muted">No users have been granted this qualification yet.</p>
+            <% end %>
+          </div>
+
+          <div class="mt-4">
+            <h5>Grant Qualification to User</h5>
+            <%= form_with url: conference_conference_user_qualifications_path(@conference), method: :post, class: "row g-3" do |f| %>
+              <%= hidden_field_tag :conference_qualification_id, @qualification.id %>
+              <div class="col-md-8">
+                <%= select_tag :user_id, options_from_collection_for_select(User.order(:email), :id, :email), include_blank: "Select a user...", class: "form-select" %>
+              </div>
+              <div class="col-md-4">
+                <%= submit_tag "Grant Qualification", class: "btn btn-primary" %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+        <div class="card-footer">
+          <%= link_to "Back to Conference Qualifications", conference_conference_qualifications_path(@conference), class: "btn btn-link" %>
+          <%= link_to "Edit", edit_conference_conference_qualification_path(@conference, @qualification), class: "btn btn-primary" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/qualification_removals/index.html.erb
+++ b/app/views/qualification_removals/index.html.erb
@@ -1,0 +1,75 @@
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-12">
+      <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><%= link_to @conference.name, @conference %></li>
+          <li class="breadcrumb-item active" aria-current="page">Qualification Removals</li>
+        </ol>
+      </nav>
+
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1>Qualification Removals: <%= @conference.name %></h1>
+      </div>
+
+      <div class="alert alert-info mb-4">
+        <strong>About Qualification Removals:</strong>
+        Sometimes a volunteer has a global qualification but should not use it for this specific conference.
+        Use this page to remove a global qualification from a user for this conference only.
+        This does not affect their global qualification status.
+      </div>
+
+      <div class="row">
+        <div class="col-md-6">
+          <div class="card mb-4">
+            <div class="card-header">
+              <h5 class="mb-0">Remove a Qualification</h5>
+            </div>
+            <div class="card-body">
+              <%= form_with url: conference_qualification_removals_path(@conference), method: :post, class: "mb-0" do %>
+                <div class="mb-3">
+                  <label for="user_id" class="form-label">User</label>
+                  <%= select_tag :user_id, options_from_collection_for_select(User.joins(:user_qualifications).distinct.order(:email), :id, :email), include_blank: "Select a user...", class: "form-select", required: true %>
+                </div>
+                <div class="mb-3">
+                  <label for="qualification_id" class="form-label">Global Qualification to Remove</label>
+                  <%= select_tag :qualification_id, options_from_collection_for_select(@global_qualifications, :id, :name), include_blank: "Select a qualification...", class: "form-select", required: true %>
+                </div>
+                <%= submit_tag "Remove Qualification for This Conference", class: "btn btn-warning" %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-md-6">
+          <div class="card">
+            <div class="card-header">
+              <h5 class="mb-0">Current Removals</h5>
+            </div>
+            <div class="card-body">
+              <% if @removals.any? %>
+                <ul class="list-group list-group-flush">
+                  <% @removals.each do |removal| %>
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                      <div>
+                        <strong><%= removal.user.name || removal.user.email %></strong>
+                        <br>
+                        <small class="text-muted">
+                          <span class="badge bg-secondary"><%= removal.qualification.name %></span>
+                          removed for this conference
+                        </small>
+                      </div>
+                      <%= link_to "Restore", conference_qualification_removal_path(@conference, removal), data: { turbo_method: :delete, turbo_confirm: "Restore #{removal.qualification.name} for #{removal.user.name || removal.user.email}?" }, class: "btn btn-sm btn-outline-success" %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="text-muted mb-0">No qualifications have been removed for this conference.</p>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ Rails.application.routes.draw do
         get :unmanned_shifts
       end
     end
+    resources :conference_qualifications, path: "qualifications"
+    resources :conference_user_qualifications, only: [ :create, :destroy ]
+    resources :qualification_removals, only: [ :index, :create, :destroy ]
   end
 
   # Program management

--- a/db/migrate/20251206184120_create_conference_qualifications.rb
+++ b/db/migrate/20251206184120_create_conference_qualifications.rb
@@ -1,0 +1,13 @@
+class CreateConferenceQualifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :conference_qualifications do |t|
+      t.string :name, null: false
+      t.text :description, null: false
+      t.references :conference, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :conference_qualifications, [ :conference_id, :name ], unique: true
+  end
+end

--- a/db/migrate/20251206184124_create_conference_user_qualifications.rb
+++ b/db/migrate/20251206184124_create_conference_user_qualifications.rb
@@ -1,0 +1,12 @@
+class CreateConferenceUserQualifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :conference_user_qualifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :conference_qualification, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :conference_user_qualifications, [ :user_id, :conference_qualification_id ], unique: true, name: "idx_conf_user_quals_on_user_and_qual"
+  end
+end

--- a/db/migrate/20251206184129_create_qualification_removals.rb
+++ b/db/migrate/20251206184129_create_qualification_removals.rb
@@ -1,0 +1,13 @@
+class CreateQualificationRemovals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :qualification_removals do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :qualification, null: false, foreign_key: true
+      t.references :conference, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :qualification_removals, [ :user_id, :qualification_id, :conference_id ], unique: true, name: "idx_qual_removals_on_user_qual_conf"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_26_055153) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_06_184129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -27,6 +27,16 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_26_055153) do
     t.index ["program_id"], name: "index_conference_programs_on_program_id"
   end
 
+  create_table "conference_qualifications", force: :cascade do |t|
+    t.bigint "conference_id", null: false
+    t.datetime "created_at", null: false
+    t.text "description", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["conference_id", "name"], name: "index_conference_qualifications_on_conference_id_and_name", unique: true
+    t.index ["conference_id"], name: "index_conference_qualifications_on_conference_id"
+  end
+
   create_table "conference_roles", force: :cascade do |t|
     t.bigint "conference_id", null: false
     t.datetime "created_at", null: false
@@ -36,6 +46,16 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_26_055153) do
     t.index ["conference_id"], name: "index_conference_roles_on_conference_id"
     t.index ["user_id", "conference_id", "role_name"], name: "index_conference_roles_unique", unique: true
     t.index ["user_id"], name: "index_conference_roles_on_user_id"
+  end
+
+  create_table "conference_user_qualifications", force: :cascade do |t|
+    t.bigint "conference_qualification_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["conference_qualification_id"], name: "idx_on_conference_qualification_id_bd2242d465"
+    t.index ["user_id", "conference_qualification_id"], name: "idx_conf_user_quals_on_user_and_qual", unique: true
+    t.index ["user_id"], name: "index_conference_user_qualifications_on_user_id"
   end
 
   create_table "conferences", force: :cascade do |t|
@@ -69,6 +89,18 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_26_055153) do
     t.bigint "village_id", null: false
     t.index ["village_id", "name"], name: "index_programs_on_village_id_and_name", unique: true
     t.index ["village_id"], name: "index_programs_on_village_id"
+  end
+
+  create_table "qualification_removals", force: :cascade do |t|
+    t.bigint "conference_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "qualification_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["conference_id"], name: "index_qualification_removals_on_conference_id"
+    t.index ["qualification_id"], name: "index_qualification_removals_on_qualification_id"
+    t.index ["user_id", "qualification_id", "conference_id"], name: "idx_qual_removals_on_user_qual_conf", unique: true
+    t.index ["user_id"], name: "index_qualification_removals_on_user_id"
   end
 
   create_table "qualifications", force: :cascade do |t|
@@ -158,12 +190,18 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_26_055153) do
 
   add_foreign_key "conference_programs", "conferences"
   add_foreign_key "conference_programs", "programs"
+  add_foreign_key "conference_qualifications", "conferences"
   add_foreign_key "conference_roles", "conferences"
   add_foreign_key "conference_roles", "users"
+  add_foreign_key "conference_user_qualifications", "conference_qualifications"
+  add_foreign_key "conference_user_qualifications", "users"
   add_foreign_key "conferences", "villages"
   add_foreign_key "program_qualifications", "programs"
   add_foreign_key "program_qualifications", "qualifications"
   add_foreign_key "programs", "villages"
+  add_foreign_key "qualification_removals", "conferences"
+  add_foreign_key "qualification_removals", "qualifications"
+  add_foreign_key "qualification_removals", "users"
   add_foreign_key "qualifications", "villages"
   add_foreign_key "timeslots", "conference_programs"
   add_foreign_key "user_qualifications", "qualifications"

--- a/test/controllers/conference_qualifications_controller_test.rb
+++ b/test/controllers/conference_qualifications_controller_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+class ConferenceQualificationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.create!(user: @admin, role: admin_role)
+
+    @conference_lead = User.create!(
+      email: "lead@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: @conference_lead,
+      conference: @conference,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @qualification = ConferenceQualification.create!(
+      name: "Test Qualification",
+      description: "A test qualification",
+      conference: @conference
+    )
+  end
+
+  test "should redirect to login when not signed in" do
+    get conference_conference_qualifications_url(@conference)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "should get index for conference lead" do
+    sign_in @conference_lead
+    get conference_conference_qualifications_url(@conference)
+    assert_response :success
+  end
+
+  test "should get index for village admin" do
+    sign_in @admin
+    get conference_conference_qualifications_url(@conference)
+    assert_response :success
+  end
+
+  test "should redirect volunteer from index" do
+    sign_in @volunteer
+    get conference_conference_qualifications_url(@conference)
+    assert_redirected_to root_path
+  end
+
+  test "should get new for conference lead" do
+    sign_in @conference_lead
+    get new_conference_conference_qualification_url(@conference)
+    assert_response :success
+  end
+
+  test "should create qualification for conference lead" do
+    sign_in @conference_lead
+    assert_difference("ConferenceQualification.count") do
+      post conference_conference_qualifications_url(@conference), params: {
+        conference_qualification: {
+          name: "New Qualification",
+          description: "A new qualification"
+        }
+      }
+    end
+    assert_redirected_to conference_conference_qualification_url(@conference, ConferenceQualification.last)
+  end
+
+  test "should get edit for conference lead" do
+    sign_in @conference_lead
+    get edit_conference_conference_qualification_url(@conference, @qualification)
+    assert_response :success
+  end
+
+  test "should update qualification for conference lead" do
+    sign_in @conference_lead
+    patch conference_conference_qualification_url(@conference, @qualification), params: {
+      conference_qualification: {
+        name: "Updated Name",
+        description: "Updated description"
+      }
+    }
+    assert_redirected_to conference_conference_qualification_url(@conference, @qualification)
+    @qualification.reload
+    assert_equal "Updated Name", @qualification.name
+  end
+
+  test "should destroy qualification for conference lead" do
+    sign_in @conference_lead
+    assert_difference("ConferenceQualification.count", -1) do
+      delete conference_conference_qualification_url(@conference, @qualification)
+    end
+    assert_redirected_to conference_conference_qualifications_url(@conference)
+  end
+end

--- a/test/controllers/conference_user_qualifications_controller_test.rb
+++ b/test/controllers/conference_user_qualifications_controller_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+class ConferenceUserQualificationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @conference_lead = User.create!(
+      email: "lead@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: @conference_lead,
+      conference: @conference,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @qualification = ConferenceQualification.create!(
+      name: "Test Qualification",
+      description: "A test qualification",
+      conference: @conference
+    )
+  end
+
+  test "should grant qualification to user" do
+    sign_in @conference_lead
+    assert_difference("ConferenceUserQualification.count") do
+      post conference_conference_user_qualifications_url(@conference), params: {
+        user_id: @volunteer.id,
+        conference_qualification_id: @qualification.id
+      }
+    end
+    assert_redirected_to conference_conference_qualification_url(@conference, @qualification)
+  end
+
+  test "should not duplicate qualification grant" do
+    ConferenceUserQualification.create!(
+      user: @volunteer,
+      conference_qualification: @qualification
+    )
+
+    sign_in @conference_lead
+    assert_no_difference("ConferenceUserQualification.count") do
+      post conference_conference_user_qualifications_url(@conference), params: {
+        user_id: @volunteer.id,
+        conference_qualification_id: @qualification.id
+      }
+    end
+  end
+
+  test "should revoke qualification from user" do
+    user_qual = ConferenceUserQualification.create!(
+      user: @volunteer,
+      conference_qualification: @qualification
+    )
+
+    sign_in @conference_lead
+    assert_difference("ConferenceUserQualification.count", -1) do
+      delete conference_conference_user_qualification_url(@conference, user_qual)
+    end
+    assert_redirected_to conference_conference_qualification_url(@conference, @qualification)
+  end
+
+  test "volunteer cannot grant qualifications" do
+    sign_in @volunteer
+    assert_no_difference("ConferenceUserQualification.count") do
+      post conference_conference_user_qualifications_url(@conference), params: {
+        user_id: @volunteer.id,
+        conference_qualification_id: @qualification.id
+      }
+    end
+    assert_redirected_to root_path
+  end
+end

--- a/test/controllers/qualification_removals_controller_test.rb
+++ b/test/controllers/qualification_removals_controller_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class QualificationRemovalsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @conference_lead = User.create!(
+      email: "lead@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: @conference_lead,
+      conference: @conference,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @global_qualification = Qualification.create!(
+      name: "Global Qualification",
+      description: "A global qualification",
+      village: @village
+    )
+    # Give volunteer the global qualification
+    UserQualification.create!(user: @volunteer, qualification: @global_qualification)
+  end
+
+  test "should get index showing users with removable qualifications" do
+    sign_in @conference_lead
+    get conference_qualification_removals_url(@conference)
+    assert_response :success
+  end
+
+  test "should create removal for user's global qualification" do
+    sign_in @conference_lead
+    assert_difference("QualificationRemoval.count") do
+      post conference_qualification_removals_url(@conference), params: {
+        user_id: @volunteer.id,
+        qualification_id: @global_qualification.id
+      }
+    end
+    assert_redirected_to conference_qualification_removals_url(@conference)
+  end
+
+  test "should not duplicate removal" do
+    QualificationRemoval.create!(
+      user: @volunteer,
+      qualification: @global_qualification,
+      conference: @conference
+    )
+
+    sign_in @conference_lead
+    assert_no_difference("QualificationRemoval.count") do
+      post conference_qualification_removals_url(@conference), params: {
+        user_id: @volunteer.id,
+        qualification_id: @global_qualification.id
+      }
+    end
+  end
+
+  test "should destroy removal to restore qualification" do
+    removal = QualificationRemoval.create!(
+      user: @volunteer,
+      qualification: @global_qualification,
+      conference: @conference
+    )
+
+    sign_in @conference_lead
+    assert_difference("QualificationRemoval.count", -1) do
+      delete conference_qualification_removal_url(@conference, removal)
+    end
+    assert_redirected_to conference_qualification_removals_url(@conference)
+  end
+
+  test "volunteer cannot create removals" do
+    sign_in @volunteer
+    assert_no_difference("QualificationRemoval.count") do
+      post conference_qualification_removals_url(@conference), params: {
+        user_id: @volunteer.id,
+        qualification_id: @global_qualification.id
+      }
+    end
+    assert_redirected_to root_path
+  end
+end

--- a/test/models/conference_qualification_test.rb
+++ b/test/models/conference_qualification_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class ConferenceQualificationTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+  end
+
+  test "valid conference qualification" do
+    qualification = ConferenceQualification.new(
+      name: "Badge Check Training",
+      description: "Training for badge checking",
+      conference: @conference
+    )
+    assert qualification.valid?
+  end
+
+  test "requires name" do
+    qualification = ConferenceQualification.new(
+      description: "Training for badge checking",
+      conference: @conference
+    )
+    assert_not qualification.valid?
+    assert_includes qualification.errors[:name], "can't be blank"
+  end
+
+  test "requires description" do
+    qualification = ConferenceQualification.new(
+      name: "Badge Check Training",
+      conference: @conference
+    )
+    assert_not qualification.valid?
+    assert_includes qualification.errors[:description], "can't be blank"
+  end
+
+  test "requires conference" do
+    qualification = ConferenceQualification.new(
+      name: "Badge Check Training",
+      description: "Training for badge checking"
+    )
+    assert_not qualification.valid?
+    assert_includes qualification.errors[:conference], "must exist"
+  end
+
+  test "name is unique within conference" do
+    ConferenceQualification.create!(
+      name: "Badge Check Training",
+      description: "Training for badge checking",
+      conference: @conference
+    )
+
+    duplicate = ConferenceQualification.new(
+      name: "Badge Check Training",
+      description: "Another description",
+      conference: @conference
+    )
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:name], "has already been taken"
+  end
+
+  test "same name allowed in different conferences" do
+    another_conference = Conference.create!(
+      name: "Another Conference",
+      location: "Another Location",
+      start_date: Date.today + 10.days,
+      end_date: Date.today + 11.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+
+    ConferenceQualification.create!(
+      name: "Badge Check Training",
+      description: "Training for badge checking",
+      conference: @conference
+    )
+
+    qualification = ConferenceQualification.new(
+      name: "Badge Check Training",
+      description: "Training for badge checking",
+      conference: another_conference
+    )
+    assert qualification.valid?
+  end
+end

--- a/test/models/conference_user_qualification_test.rb
+++ b/test/models/conference_user_qualification_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class ConferenceUserQualificationTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @qualification = ConferenceQualification.create!(
+      name: "Badge Check Training",
+      description: "Training for badge checking",
+      conference: @conference
+    )
+    @user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  test "valid conference user qualification" do
+    user_qual = ConferenceUserQualification.new(
+      user: @user,
+      conference_qualification: @qualification
+    )
+    assert user_qual.valid?
+  end
+
+  test "requires user" do
+    user_qual = ConferenceUserQualification.new(
+      conference_qualification: @qualification
+    )
+    assert_not user_qual.valid?
+    assert_includes user_qual.errors[:user], "must exist"
+  end
+
+  test "requires conference qualification" do
+    user_qual = ConferenceUserQualification.new(
+      user: @user
+    )
+    assert_not user_qual.valid?
+    assert_includes user_qual.errors[:conference_qualification], "must exist"
+  end
+
+  test "user can only have qualification once" do
+    ConferenceUserQualification.create!(
+      user: @user,
+      conference_qualification: @qualification
+    )
+
+    duplicate = ConferenceUserQualification.new(
+      user: @user,
+      conference_qualification: @qualification
+    )
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:user], "has already been taken"
+  end
+
+  test "different users can have same qualification" do
+    ConferenceUserQualification.create!(
+      user: @user,
+      conference_qualification: @qualification
+    )
+
+    another_user = User.create!(
+      email: "another@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    user_qual = ConferenceUserQualification.new(
+      user: another_user,
+      conference_qualification: @qualification
+    )
+    assert user_qual.valid?
+  end
+end

--- a/test/models/qualification_removal_test.rb
+++ b/test/models/qualification_removal_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class QualificationRemovalTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      location: "Test Location",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @qualification = Qualification.create!(
+      name: "Radio License",
+      description: "Ham radio license",
+      village: @village
+    )
+    @user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    # Give user the global qualification
+    UserQualification.create!(user: @user, qualification: @qualification)
+  end
+
+  test "valid qualification removal" do
+    removal = QualificationRemoval.new(
+      user: @user,
+      qualification: @qualification,
+      conference: @conference
+    )
+    assert removal.valid?
+  end
+
+  test "requires user" do
+    removal = QualificationRemoval.new(
+      qualification: @qualification,
+      conference: @conference
+    )
+    assert_not removal.valid?
+    assert_includes removal.errors[:user], "must exist"
+  end
+
+  test "requires qualification" do
+    removal = QualificationRemoval.new(
+      user: @user,
+      conference: @conference
+    )
+    assert_not removal.valid?
+    assert_includes removal.errors[:qualification], "must exist"
+  end
+
+  test "requires conference" do
+    removal = QualificationRemoval.new(
+      user: @user,
+      qualification: @qualification
+    )
+    assert_not removal.valid?
+    assert_includes removal.errors[:conference], "must exist"
+  end
+
+  test "same removal cannot exist twice" do
+    QualificationRemoval.create!(
+      user: @user,
+      qualification: @qualification,
+      conference: @conference
+    )
+
+    duplicate = QualificationRemoval.new(
+      user: @user,
+      qualification: @qualification,
+      conference: @conference
+    )
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:user], "has already been taken"
+  end
+
+  test "same user-qualification can be removed in different conferences" do
+    another_conference = Conference.create!(
+      name: "Another Conference",
+      location: "Another Location",
+      start_date: Date.today + 10.days,
+      end_date: Date.today + 11.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+
+    QualificationRemoval.create!(
+      user: @user,
+      qualification: @qualification,
+      conference: @conference
+    )
+
+    removal = QualificationRemoval.new(
+      user: @user,
+      qualification: @qualification,
+      conference: another_conference
+    )
+    assert removal.valid?
+  end
+end


### PR DESCRIPTION
## Summary
- Added `ConferenceQualification` model for conference-specific qualifications
- Added `ConferenceUserQualification` model for granting conference qualifications to users
- Added `QualificationRemoval` model for removing global qualifications per conference
- Conference leads/admins can now create, manage, and grant conference-specific qualifications
- Conference leads/admins can remove global qualifications for their conference only (without affecting the global grant)
- Updated volunteer signup validation to respect qualification removals

## Test plan
- [ ] Sign in as conference lead/admin
- [ ] Navigate to conference qualifications page
- [ ] Create a new conference-specific qualification
- [ ] Grant it to a user
- [ ] Verify user can sign up for shifts requiring that qualification
- [ ] Test qualification removal: remove a global qualification for a user at conference level
- [ ] Verify user cannot sign up for shifts requiring that removed qualification

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)