### PR TITLE
Fix: Sign in user after completing setup

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -19,6 +19,9 @@ class SetupController < ApplicationController
       village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
       UserRole.find_or_create_by!(user: @user, role: village_admin_role)
 
+      # Sign in the user after setup
+      sign_in(@user)
+
       redirect_to root_path, notice: "Setup complete! Welcome to #{@village.name}."
     else
       render :show, status: :unprocessable_entity

--- a/test/controllers/setup_controller_test.rb
+++ b/test/controllers/setup_controller_test.rb
@@ -34,6 +34,27 @@ class SetupControllerTest < ActionDispatch::IntegrationTest
     assert user.village_admin?, "Setup user should be assigned village admin role"
   end
 
+  test "should sign in user after successful setup" do
+    post setup_url, params: {
+      village: { name: "Ham Radio Village" },
+      user: {
+        email: "admin@example.com",
+        password: "password123",
+        password_confirmation: "password123"
+      }
+    }
+
+    assert_redirected_to root_path
+
+    # Follow redirect and verify user is signed in
+    follow_redirect!
+    assert_response :success
+
+    # User should be signed in - verify by checking session or making authenticated request
+    user = User.find_by(email: "admin@example.com")
+    assert_equal user.id, session["warden.user.user.key"]&.first&.first
+  end
+
   test "should not create village with invalid data" do
     assert_no_difference [ "Village.count", "User.count" ] do
       post setup_url, params: {


### PR DESCRIPTION
## Summary
- Users are now automatically signed in after completing initial setup
- Previously, users were redirected to the dashboard but not authenticated, which was an RBAC violation

## Test plan
- [ ] Complete initial setup wizard with new village and admin account
- [ ] Verify you are signed in after setup completes (check navbar shows logged in state)
- [ ] Verify you can access protected pages without having to log in again

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)