### PR TITLE
Add Conference Lead Dashboard Card

### DIFF
--- a/app/views/root/show.html.erb
+++ b/app/views/root/show.html.erb
@@ -10,5 +10,24 @@
     <h4 class="alert-heading">Welcome to <%= @village.name %>!</h4>
     <p>Dashboard coming soon.</p>
   </div>
+
+  <% if user_signed_in? && current_user.conference_lead_conferences.any? %>
+    <div class="card mt-4">
+      <div class="card-header bg-primary text-white">
+        <h5 class="mb-0">My Conferences</h5>
+      </div>
+      <div class="card-body">
+        <p class="text-muted">Conferences you lead:</p>
+        <ul class="list-group list-group-flush">
+          <% current_user.conference_lead_conferences.each do |conference| %>
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+              <%= link_to conference.name, conference_path(conference), class: "text-decoration-none" %>
+              <span class="badge bg-primary">Lead</span>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
 </div>
 

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -1,8 +1,11 @@
 require "test_helper"
 
 class RootControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+  end
+
   test "should get root when setup is complete" do
-    Village.create!(name: "Test Village", setup_complete: true)
     get root_url
     assert_response :success
   end
@@ -14,7 +17,6 @@ class RootControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get root when signed in" do
-    Village.create!(name: "Test Village", setup_complete: true)
     user = User.create!(
       email: "user@example.com",
       password: "password123",
@@ -23,5 +25,81 @@ class RootControllerTest < ActionDispatch::IntegrationTest
     sign_in user
     get root_url
     assert_response :success
+  end
+
+  test "should show conference lead dashboard card when user is conference lead" do
+    conference = Conference.create!(
+      name: "Test Conference",
+      village: @village,
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    user = User.create!(
+      email: "lead@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: user,
+      conference: conference,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+
+    sign_in user
+    get root_url
+
+    assert_response :success
+    assert_select ".card-header", text: /My Conferences/
+    assert_select ".card-body", text: /Test Conference/
+  end
+
+  test "should not show conference lead dashboard card when user is not a conference lead" do
+    user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    sign_in user
+    get root_url
+
+    assert_response :success
+    assert_select ".card-header", text: /My Conferences/, count: 0
+  end
+
+  test "should show multiple conferences when user is lead of multiple conferences" do
+    conference1 = Conference.create!(
+      name: "Conference Alpha",
+      village: @village,
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    conference2 = Conference.create!(
+      name: "Conference Beta",
+      village: @village,
+      start_date: Date.tomorrow + 7.days,
+      end_date: Date.tomorrow + 10.days
+    )
+    user = User.create!(
+      email: "multlead@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(user: user, conference: conference1, role_name: ConferenceRole::CONFERENCE_LEAD)
+    ConferenceRole.create!(user: user, conference: conference2, role_name: ConferenceRole::CONFERENCE_LEAD)
+
+    sign_in user
+    get root_url
+
+    assert_response :success
+    assert_select ".card-body", text: /Conference Alpha/
+    assert_select ".card-body", text: /Conference Beta/
+  end
+
+  test "should not show conference lead card for unauthenticated users" do
+    get root_url
+
+    assert_response :success
+    assert_select ".card-header", text: /My Conferences/, count: 0
   end
 end


### PR DESCRIPTION
## Summary
- Add a dashboard card on the root page showing conferences where the current user is a conference lead
- Card displays conference names with links to their respective pages, using Bootstrap styling
- Refactors root_controller_test.rb to use setup method for better test isolation with Devise

## Test plan
- [x] All 348 tests pass (0 failures, 0 errors)
- [x] Rubocop shows no offenses
- [ ] Manually verify card appears for conference leads on dashboard
- [ ] Manually verify card is hidden for regular volunteers
- [ ] Manually verify card is hidden for unauthenticated users

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)