### PR TITLE
Split conference location into country, state, and city fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,10 @@ gem "devise", "~> 4.9"
 # Authorization
 gem "pundit", "~> 2.3"
 
+# Country/State/City selection
+gem "country_select", "~> 11.0"
+gem "city-state"
+
 # CSV support (needed in Ruby 3.4+)
 gem "csv"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,8 +102,14 @@ GEM
       xpath (~> 3.2)
     childprocess (5.1.0)
       logger (~> 1.5)
+    city-state (1.1.0)
+      rubyzip (>= 2.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.5)
+    countries (8.0.4)
+      unaccent (~> 0.3)
+    country_select (11.0.0)
+      countries (> 6.0, < 9.0)
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
@@ -383,6 +389,7 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
@@ -420,6 +427,8 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara
+  city-state
+  country_select (~> 11.0)
   cssbundling-rails
   csv
   debug

--- a/app/controllers/calendar_exports_controller.rb
+++ b/app/controllers/calendar_exports_controller.rb
@@ -20,7 +20,7 @@ class CalendarExportsController < ApplicationController
         event.dtend = Icalendar::Values::DateTime.new(timeslot.end_time)
         event.summary = "Volunteer: #{program.name}"
         event.description = "Volunteer shift for #{program.name} at #{@conference.name}"
-        event.location = @conference.location
+        event.location = @conference.display_location
         event.uid = "volunteer-signup-#{signup.id}@villagers"
       end
     end

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -89,6 +89,6 @@ class ConferencesController < ApplicationController
   end
 
   def conference_params
-    params.require(:conference).permit(:name, :location, :start_date, :end_date, :conference_hours_start, :conference_hours_end)
+    params.require(:conference).permit(:name, :country, :state, :city, :start_date, :end_date, :conference_hours_start, :conference_hours_end)
   end
 end

--- a/app/controllers/states_controller.rb
+++ b/app/controllers/states_controller.rb
@@ -1,0 +1,10 @@
+class StatesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    country_code = params[:country]
+    states = CS.states(country_code.to_sym)
+
+    render json: states.map { |code, name| { code: code.to_s, name: name } }
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import LocationFieldsController from "./location_fields_controller"
+application.register("location-fields", LocationFieldsController)

--- a/app/javascript/controllers/location_fields_controller.js
+++ b/app/javascript/controllers/location_fields_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="location-fields"
+export default class extends Controller {
+  static targets = ["country", "state", "stateContainer"]
+  static values = { statesUrl: String }
+
+  connect() {
+    this.loadStates()
+  }
+
+  countryChanged() {
+    this.loadStates()
+  }
+
+  async loadStates() {
+    const country = this.countryTarget.value
+    if (!country) {
+      this.hideStateField()
+      return
+    }
+
+    try {
+      const response = await fetch(`${this.statesUrlValue}?country=${country}`)
+      const states = await response.json()
+
+      if (states.length > 0) {
+        this.populateStates(states)
+        this.showStateField()
+      } else {
+        this.hideStateField()
+      }
+    } catch (error) {
+      console.error("Error loading states:", error)
+      this.hideStateField()
+    }
+  }
+
+  populateStates(states) {
+    const currentValue = this.stateTarget.value
+    this.stateTarget.innerHTML = '<option value="">Select state/province...</option>'
+
+    states.forEach(state => {
+      const option = document.createElement("option")
+      option.value = state.code
+      option.textContent = state.name
+      if (state.code === currentValue) {
+        option.selected = true
+      }
+      this.stateTarget.appendChild(option)
+    })
+  }
+
+  showStateField() {
+    this.stateContainerTarget.style.display = "block"
+  }
+
+  hideStateField() {
+    this.stateContainerTarget.style.display = "none"
+    this.stateTarget.value = ""
+  }
+}

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -59,6 +59,18 @@ class Conference < ApplicationRecord
                    .limit(limit)
   end
 
+  # Location display methods
+  def display_location
+    return "Not specified" if city.blank?
+
+    if country == "US"
+      state.present? ? "#{city}, #{state}" : city
+    else
+      country_name = ISO3166::Country.new(country)&.common_name || country
+      "#{city}, #{country_name}"
+    end
+  end
+
   private
 
   def end_date_after_start_date

--- a/app/views/conferences/_location_fields.html.erb
+++ b/app/views/conferences/_location_fields.html.erb
@@ -1,0 +1,18 @@
+<div data-controller="location-fields" data-location-fields-states-url-value="<%= states_path %>">
+  <div class="row">
+    <div class="col-md-4 mb-3">
+      <%= form.label :country, class: "form-label" %>
+      <%= form.country_select :country,
+          { priority_countries: ["US", "CA", "GB", "DE", "AU"], include_blank: "Select country..." },
+          { class: "form-select", data: { location_fields_target: "country", action: "change->location-fields#countryChanged" } } %>
+    </div>
+    <div class="col-md-4 mb-3" data-location-fields-target="stateContainer">
+      <%= form.label :state, "State/Province", class: "form-label" %>
+      <%= form.select :state, [], { include_blank: "Select state/province..." }, { class: "form-select", data: { location_fields_target: "state" } } %>
+    </div>
+    <div class="col-md-4 mb-3">
+      <%= form.label :city, class: "form-label" %>
+      <%= form.text_field :city, class: "form-control", placeholder: "City name" %>
+    </div>
+  </div>
+</div>

--- a/app/views/conferences/edit.html.erb
+++ b/app/views/conferences/edit.html.erb
@@ -23,10 +23,7 @@
               <%= form.text_field :name, class: "form-control", required: true, autofocus: true %>
             </div>
 
-            <div class="mb-3">
-              <%= form.label :location, class: "form-label" %>
-              <%= form.text_field :location, class: "form-control" %>
-            </div>
+            <%= render "location_fields", form: form %>
 
             <div class="row">
               <div class="col-md-6 mb-3">

--- a/app/views/conferences/index.html.erb
+++ b/app/views/conferences/index.html.erb
@@ -16,7 +16,7 @@
                 <%= link_to conference.name, conference_path(conference), class: "text-decoration-none" %>
               </h5>
               <p class="card-text text-muted">
-                <strong>Location:</strong> <%= conference.location || "TBD" %><br>
+                <strong>Location:</strong> <%= conference.display_location %><br>
                 <strong>Dates:</strong> <%= conference.start_date.strftime("%B %d") %> - <%= conference.end_date.strftime("%B %d, %Y") %>
               </p>
               <% if conference.conference_hours_start && conference.conference_hours_end %>

--- a/app/views/conferences/new.html.erb
+++ b/app/views/conferences/new.html.erb
@@ -23,10 +23,7 @@
               <%= form.text_field :name, class: "form-control", required: true, autofocus: true %>
             </div>
 
-            <div class="mb-3">
-              <%= form.label :location, class: "form-label" %>
-              <%= form.text_field :location, class: "form-control" %>
-            </div>
+            <%= render "location_fields", form: form %>
 
             <div class="row">
               <div class="col-md-6 mb-3">

--- a/app/views/conferences/show.html.erb
+++ b/app/views/conferences/show.html.erb
@@ -11,7 +11,7 @@
         <div class="card-body">
           <dl class="row">
             <dt class="col-sm-3">Location:</dt>
-            <dd class="col-sm-9"><%= @conference.location || "Not specified" %></dd>
+            <dd class="col-sm-9"><%= @conference.display_location %></dd>
 
             <dt class="col-sm-3">Start Date:</dt>
             <dd class="col-sm-9"><%= @conference.start_date.strftime("%B %d, %Y") %></dd>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
   get "setup", to: "setup#show", as: :setup
   post "setup", to: "setup#create"
 
+  # API endpoints for dynamic form fields
+  get "states", to: "states#index", as: :states
+
   # Village management
   resource :village, only: [ :show, :edit, :update ]
 

--- a/db/migrate/20251211063449_add_location_fields_to_conferences.rb
+++ b/db/migrate/20251211063449_add_location_fields_to_conferences.rb
@@ -1,0 +1,8 @@
+class AddLocationFieldsToConferences < ActiveRecord::Migration[8.1]
+  def change
+    add_column :conferences, :country, :string, default: "US"
+    add_column :conferences, :state, :string
+    add_column :conferences, :city, :string
+    remove_column :conferences, :location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_06_184129) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_11_063449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -59,13 +59,15 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_06_184129) do
   end
 
   create_table "conferences", force: :cascade do |t|
+    t.string "city"
     t.time "conference_hours_end"
     t.time "conference_hours_start"
+    t.string "country", default: "US"
     t.datetime "created_at", null: false
     t.date "end_date"
-    t.string "location"
     t.string "name"
     t.date "start_date"
+    t.string "state"
     t.datetime "updated_at", null: false
     t.bigint "village_id", null: false
     t.index ["village_id"], name: "index_conferences_on_village_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,9 @@ UserRole.find_or_create_by!(user: village_admin, role: village_admin_role)
 
 # Create conference
 conference = Conference.find_or_create_by!(name: "DEF CON 32", village: village) do |c|
-  c.location = "Las Vegas, NV"
+  c.country = "US"
+  c.state = "NV"
+  c.city = "Las Vegas"
   c.start_date = Date.new(2024, 8, 8)
   c.end_date = Date.new(2024, 8, 11)
   c.conference_hours_start = Time.parse("09:00")

--- a/test/controllers/calendar_controller_test.rb
+++ b/test/controllers/calendar_controller_test.rb
@@ -5,7 +5,7 @@ class CalendarControllerTest < ActionDispatch::IntegrationTest
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/controllers/calendar_exports_controller_test.rb
+++ b/test/controllers/calendar_exports_controller_test.rb
@@ -5,7 +5,7 @@ class CalendarExportsControllerTest < ActionDispatch::IntegrationTest
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference 2024",
-      location: "Las Vegas Convention Center",
+      city: "Las Vegas", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
@@ -82,7 +82,7 @@ class CalendarExportsControllerTest < ActionDispatch::IntegrationTest
   test "should include conference location" do
     sign_in @user
     get conference_calendar_export_url(@conference)
-    assert_match "Las Vegas Convention Center", response.body
+    assert_match "Las Vegas", response.body
   end
 
   test "should only include user's own shifts" do

--- a/test/controllers/conference_programs_controller_test.rb
+++ b/test/controllers/conference_programs_controller_test.rb
@@ -30,7 +30,7 @@ class ConferenceProgramsControllerTest < ActionDispatch::IntegrationTest
     @conference = Conference.create!(
       village: @village,
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 3.days,
       conference_hours_start: Time.parse("09:00"),

--- a/test/controllers/conference_qualifications_controller_test.rb
+++ b/test/controllers/conference_qualifications_controller_test.rb
@@ -5,7 +5,7 @@ class ConferenceQualificationsControllerTest < ActionDispatch::IntegrationTest
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/controllers/conference_user_qualifications_controller_test.rb
+++ b/test/controllers/conference_user_qualifications_controller_test.rb
@@ -5,7 +5,7 @@ class ConferenceUserQualificationsControllerTest < ActionDispatch::IntegrationTe
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/controllers/conferences_controller_test.rb
+++ b/test/controllers/conferences_controller_test.rb
@@ -67,7 +67,9 @@ class ConferencesControllerTest < ActionDispatch::IntegrationTest
       post conferences_url, params: {
         conference: {
           name: "New Conference",
-          location: "Test Location",
+          country: "US",
+          state: "NV",
+          city: "Las Vegas",
           start_date: Date.today,
           end_date: Date.tomorrow,
           conference_hours_start: "09:00",
@@ -80,6 +82,9 @@ class ConferencesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to conference_path(Conference.last)
     conference = Conference.last
     assert_equal "New Conference", conference.name
+    assert_equal "Las Vegas", conference.city
+    assert_equal "NV", conference.state
+    assert_equal "US", conference.country
     assert conference.conference_roles.exists?(user: @conference_lead, role_name: ConferenceRole::CONFERENCE_LEAD)
   end
 
@@ -125,13 +130,17 @@ class ConferencesControllerTest < ActionDispatch::IntegrationTest
     patch conference_url(@conference), params: {
       conference: {
         name: "Updated Conference",
-        location: "New Location"
+        country: "US",
+        state: "CA",
+        city: "San Francisco"
       }
     }
     assert_redirected_to @conference
     @conference.reload
     assert_equal "Updated Conference", @conference.name
-    assert_equal "New Location", @conference.location
+    assert_equal "San Francisco", @conference.city
+    assert_equal "CA", @conference.state
+    assert_equal "US", @conference.country
   end
 
   test "should update conference lead" do

--- a/test/controllers/leaderboard_controller_test.rb
+++ b/test/controllers/leaderboard_controller_test.rb
@@ -5,7 +5,7 @@ class LeaderboardControllerTest < ActionDispatch::IntegrationTest
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/controllers/qualification_removals_controller_test.rb
+++ b/test/controllers/qualification_removals_controller_test.rb
@@ -5,7 +5,7 @@ class QualificationRemovalsControllerTest < ActionDispatch::IntegrationTest
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/controllers/states_controller_test.rb
+++ b/test/controllers/states_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class StatesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @user = User.create!(
+      email: "statesuser@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  test "should require authentication" do
+    get states_path(country: "US"), as: :json
+    assert_response :unauthorized
+  end
+
+  test "should get states for US" do
+    sign_in @user
+    get states_path(country: "US"), as: :json
+    assert_response :success
+
+    json_response = JSON.parse(response.body)
+    assert json_response.is_a?(Array)
+    assert json_response.any? { |s| s["code"] == "NV" && s["name"] == "Nevada" }
+    assert json_response.any? { |s| s["code"] == "CA" && s["name"] == "California" }
+  end
+
+  test "should get states for Germany" do
+    sign_in @user
+    get states_path(country: "DE"), as: :json
+    assert_response :success
+
+    json_response = JSON.parse(response.body)
+    assert json_response.is_a?(Array)
+    # Germany has states/Bundesländer
+    assert json_response.length > 0
+  end
+
+  test "should return empty array for country without states" do
+    sign_in @user
+    get states_path(country: "VA"), as: :json  # Vatican City has no states
+    assert_response :success
+
+    json_response = JSON.parse(response.body)
+    assert json_response.is_a?(Array)
+  end
+end

--- a/test/controllers/volunteer_history_controller_test.rb
+++ b/test/controllers/volunteer_history_controller_test.rb
@@ -5,7 +5,7 @@ class VolunteerHistoryControllerTest < ActionDispatch::IntegrationTest
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference1 = Conference.create!(
       name: "Conference 2024",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
@@ -14,7 +14,7 @@ class VolunteerHistoryControllerTest < ActionDispatch::IntegrationTest
     )
     @conference2 = Conference.create!(
       name: "Conference 2023",
-      location: "Test Location 2",
+      city: "Other City", state: "CA", country: "US",
       start_date: Date.today + 10.days,
       end_date: Date.today + 11.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/models/conference_program_test.rb
+++ b/test/models/conference_program_test.rb
@@ -5,7 +5,7 @@ class ConferenceProgramTest < ActiveSupport::TestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 3.days,
       conference_hours_start: Time.parse("09:00"),

--- a/test/models/conference_qualification_test.rb
+++ b/test/models/conference_qualification_test.rb
@@ -5,7 +5,7 @@ class ConferenceQualificationTest < ActiveSupport::TestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
@@ -69,7 +69,7 @@ class ConferenceQualificationTest < ActiveSupport::TestCase
   test "same name allowed in different conferences" do
     another_conference = Conference.create!(
       name: "Another Conference",
-      location: "Another Location",
+      city: "Another City", state: "TX", country: "US",
       start_date: Date.today + 10.days,
       end_date: Date.today + 11.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/models/conference_test.rb
+++ b/test/models/conference_test.rb
@@ -1,7 +1,80 @@
 require "test_helper"
 
 class ConferenceTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+  end
+
+  test "conference has country, state, and city attributes" do
+    conference = Conference.new(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days,
+      country: "US",
+      state: "NV",
+      city: "Las Vegas"
+    )
+    assert conference.valid?
+    assert_equal "US", conference.country
+    assert_equal "NV", conference.state
+    assert_equal "Las Vegas", conference.city
+  end
+
+  test "conference country defaults to US" do
+    conference = Conference.new(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    assert_equal "US", conference.country
+  end
+
+  test "conference is valid without state for non-US country" do
+    conference = Conference.new(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days,
+      country: "DE",
+      city: "Berlin"
+    )
+    assert conference.valid?
+  end
+
+  test "display_location returns city and state for US" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days,
+      country: "US",
+      state: "NV",
+      city: "Las Vegas"
+    )
+    assert_equal "Las Vegas, NV", conference.display_location
+  end
+
+  test "display_location returns city and country for non-US" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days,
+      country: "DE",
+      city: "Berlin"
+    )
+    assert_equal "Berlin, Germany", conference.display_location
+  end
+
+  test "display_location returns Not specified when no location" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    assert_equal "Not specified", conference.display_location
+  end
 end

--- a/test/models/conference_timeslot_regeneration_test.rb
+++ b/test/models/conference_timeslot_regeneration_test.rb
@@ -5,7 +5,7 @@ class ConferenceTimeslotRegenerationTest < ActiveSupport::TestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/models/conference_user_qualification_test.rb
+++ b/test/models/conference_user_qualification_test.rb
@@ -5,7 +5,7 @@ class ConferenceUserQualificationTest < ActiveSupport::TestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/models/qualification_removal_test.rb
+++ b/test/models/qualification_removal_test.rb
@@ -5,7 +5,7 @@ class QualificationRemovalTest < ActiveSupport::TestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
@@ -81,7 +81,7 @@ class QualificationRemovalTest < ActiveSupport::TestCase
   test "same user-qualification can be removed in different conferences" do
     another_conference = Conference.create!(
       name: "Another Conference",
-      location: "Another Location",
+      city: "Another City", state: "TX", country: "US",
       start_date: Date.today + 10.days,
       end_date: Date.today + 11.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/models/timeslot_test.rb
+++ b/test/models/timeslot_test.rb
@@ -5,7 +5,7 @@ class TimeslotTest < ActiveSupport::TestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 3.days,
       conference_hours_start: Time.parse("09:00"),

--- a/test/models/user_volunteer_stats_test.rb
+++ b/test/models/user_volunteer_stats_test.rb
@@ -5,7 +5,7 @@ class UserVolunteerStatsTest < ActiveSupport::TestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference1 = Conference.create!(
       name: "Conference 2024",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
@@ -14,7 +14,7 @@ class UserVolunteerStatsTest < ActiveSupport::TestCase
     )
     @conference2 = Conference.create!(
       name: "Conference 2023",
-      location: "Test Location 2",
+      city: "Other City", state: "CA", country: "US",
       start_date: Date.today + 10.days,
       end_date: Date.today + 11.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/models/volunteer_signup_test.rb
+++ b/test/models/volunteer_signup_test.rb
@@ -5,7 +5,7 @@ class VolunteerSignupTest < ActiveSupport::TestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
@@ -201,7 +201,7 @@ class VolunteerSignupTest < ActiveSupport::TestCase
     # Qualification removed for a different conference
     other_conference = Conference.create!(
       name: "Other Conference",
-      location: "Other Location",
+      city: "Other City", state: "CA", country: "US",
       start_date: Date.today + 10.days,
       end_date: Date.today + 11.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/policies/conference_program_policy_test.rb
+++ b/test/policies/conference_program_policy_test.rb
@@ -5,7 +5,7 @@ class ConferenceProgramPolicyTest < ActiveSupport::TestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 3.days,
       conference_hours_start: Time.parse("09:00"),
@@ -61,7 +61,7 @@ class ConferenceProgramPolicyTest < ActiveSupport::TestCase
 
     @other_conference = Conference.create!(
       name: "Other Conference",
-      location: "Other Location",
+      city: "Other City", state: "CA", country: "US",
       start_date: Date.today + 10.days,
       end_date: Date.today + 12.days,
       conference_hours_start: Time.parse("09:00"),

--- a/test/services/timeslot_generator_test.rb
+++ b/test/services/timeslot_generator_test.rb
@@ -6,7 +6,7 @@ class TimeslotGeneratorTest < ActiveSupport::TestCase
     # Use Time.zone.parse to create times in the application timezone
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/system/my_shifts_test.rb
+++ b/test/system/my_shifts_test.rb
@@ -5,7 +5,7 @@ class MyShiftsTest < ApplicationSystemTestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today + 1.day,
       end_date: Date.today + 2.days,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/system/schedule_test.rb
+++ b/test/system/schedule_test.rb
@@ -5,7 +5,7 @@ class ScheduleTest < ApplicationSystemTestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today,
       end_date: Date.today + 1.day,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),

--- a/test/system/shift_management_test.rb
+++ b/test/system/shift_management_test.rb
@@ -5,7 +5,7 @@ class ShiftManagementTest < ApplicationSystemTestCase
     @village = Village.create!(name: "Test Village", setup_complete: true)
     @conference = Conference.create!(
       name: "Test Conference",
-      location: "Test Location",
+      city: "Test City", state: "NV", country: "US",
       start_date: Date.today,
       end_date: Date.today,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),


### PR DESCRIPTION
## Summary
- Replace single location text field with structured country/state/city fields
- Country dropdown defaults to US with priority countries (US, CA, GB, DE, AU)
- State/province dropdown dynamically loads based on selected country (no page refresh)
- City remains a text input
- Display format: "Las Vegas, NV" (US) or "Berlin, Germany" (international)

## Implementation Details
- Added `country_select` and `city-state` gems for location data
- Created `/states` API endpoint for dynamic state loading
- Added Stimulus controller for dynamic form updates
- Added `display_location` helper method on Conference model
- Updated all forms, views, seeds, and tests

## Test plan
- [x] All 354 tests pass (0 failures, 0 errors)
- [x] Rubocop shows no offenses
- [ ] Create new conference with US location - verify state dropdown populates
- [ ] Change country to Germany - verify state dropdown updates dynamically
- [ ] Change country to Vatican City (no states) - verify state dropdown hides
- [ ] Verify location displays correctly on index and show pages
- [ ] Verify calendar export includes location

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)