### PR TITLE
Add conference-specific programs for conference leads/admins

### DIFF
--- a/app/controllers/conference_programs_controller.rb
+++ b/app/controllers/conference_programs_controller.rb
@@ -4,7 +4,8 @@ class ConferenceProgramsController < ApplicationController
 
   def index
     @conference_programs = @conference.conference_programs.includes(:program).order("programs.name")
-    @available_programs = Program.where(village: @conference.village)
+    @available_programs = Program.for_conference(@conference)
+                                  .where(village: @conference.village)
                                   .where.not(id: @conference.programs.pluck(:id))
                                   .order(:name)
   end
@@ -16,7 +17,8 @@ class ConferenceProgramsController < ApplicationController
   def new
     @conference_program = @conference.conference_programs.build
     @conference_program.program_id = params[:program_id] if params[:program_id].present?
-    @available_programs = Program.where(village: @conference.village)
+    @available_programs = Program.for_conference(@conference)
+                                 .where(village: @conference.village)
                                  .where.not(id: @conference.programs.pluck(:id))
                                  .order(:name)
     authorize @conference_program, :create?, policy_class: ConferenceProgramPolicy
@@ -31,7 +33,8 @@ class ConferenceProgramsController < ApplicationController
     if @conference_program.save
       redirect_to conference_conference_programs_path(@conference), notice: "Program was successfully enabled for this conference."
     else
-      @available_programs = Program.where(village: @conference.village)
+      @available_programs = Program.for_conference(@conference)
+                                   .where(village: @conference.village)
                                    .where.not(id: @conference.programs.pluck(:id))
                                    .order(:name)
       render :new, status: :unprocessable_entity

--- a/app/controllers/custom_programs_controller.rb
+++ b/app/controllers/custom_programs_controller.rb
@@ -1,0 +1,65 @@
+class CustomProgramsController < ApplicationController
+  before_action :set_conference
+  before_action :set_program, only: [ :edit, :update, :destroy ]
+
+  def new
+    @program = Program.new(village: @conference.village, conference: @conference)
+    authorize @program, :create?, policy_class: ProgramPolicy
+  end
+
+  def create
+    @program = Program.new(program_params)
+    @program.village = @conference.village
+    @program.conference = @conference
+    authorize @program, :create?, policy_class: ProgramPolicy
+
+    if @program.save
+      redirect_to conference_conference_programs_path(@conference),
+                  notice: "Program '#{@program.name}' was created. You can now enable it for scheduling."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    authorize @program, :update?, policy_class: ProgramPolicy
+  end
+
+  def update
+    authorize @program, :update?, policy_class: ProgramPolicy
+
+    if @program.update(program_params)
+      redirect_to conference_conference_programs_path(@conference),
+                  notice: "Program was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    authorize @program, :destroy?, policy_class: ProgramPolicy
+    @program.destroy
+    redirect_to conference_conference_programs_path(@conference),
+                notice: "Program was successfully deleted."
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+    authorize @conference, :update?, policy_class: ConferencePolicy
+  end
+
+  def set_program
+    @program = Program.find(params[:id])
+    # Ensure program belongs to this conference
+    unless @program.conference_id == @conference.id
+      redirect_to conference_conference_programs_path(@conference),
+                  alert: "Program not found."
+    end
+  end
+
+  def program_params
+    params.require(:program).permit(:name, :description, :max_volunteers)
+  end
+end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -1,12 +1,26 @@
 class Program < ApplicationRecord
   belongs_to :village
+  belongs_to :conference, optional: true
   has_many :conference_programs, dependent: :destroy
-  has_many :conferences, through: :conference_programs
+  has_many :enabled_conferences, through: :conference_programs, source: :conference
   has_many :timeslots, through: :conference_programs
   has_many :program_qualifications, dependent: :destroy
   has_many :qualifications, through: :program_qualifications
 
   validates :name, presence: true
-  validates :name, uniqueness: { scope: :village_id, message: "must be unique within the village" }
+  validates :name, uniqueness: { scope: [ :village_id, :conference_id ], message: "must be unique within the village" }
   validates :max_volunteers, presence: true, numericality: { greater_than: 0 }
+
+  # Scopes
+  scope :village_level, -> { where(conference_id: nil) }
+  scope :for_conference, ->(conference) { where(conference_id: [ nil, conference.id ]) }
+
+  # Instance methods
+  def village_level?
+    conference_id.nil?
+  end
+
+  def conference_specific?
+    conference_id.present?
+  end
 end

--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -8,15 +8,39 @@ class ProgramPolicy < ApplicationPolicy
   end
 
   def create?
-    user&.village_admin?
+    return true if user&.village_admin?
+
+    # Handle case when checking permission against the Program class (not an instance)
+    return false unless record.is_a?(Program)
+
+    # Conference leads/admins can create conference-specific programs for their conference
+    if record.conference_specific?
+      user&.can_manage_conference?(record.conference)
+    else
+      false
+    end
   end
 
   def update?
-    user&.village_admin?
+    return true if user&.village_admin?
+
+    # Conference leads/admins can update conference-specific programs for their conference
+    if record.conference_specific?
+      user&.can_manage_conference?(record.conference)
+    else
+      false
+    end
   end
 
   def destroy?
-    user&.village_admin?
+    return true if user&.village_admin?
+
+    # Conference leads/admins can destroy conference-specific programs for their conference
+    if record.conference_specific?
+      user&.can_manage_conference?(record.conference)
+    else
+      false
+    end
   end
 
   class Scope < ApplicationPolicy::Scope

--- a/app/views/conference_programs/index.html.erb
+++ b/app/views/conference_programs/index.html.erb
@@ -4,9 +4,14 @@
       <h1>Programs for <%= @conference.name %></h1>
       <%= link_to "← Back to Conference", conference_path(@conference), class: "text-muted" %>
     </div>
-    <% if @available_programs.any? && policy(ConferenceProgram.new(conference: @conference)).create? %>
-      <%= link_to "Enable Program", conference_new_conference_program_path(@conference), class: "btn btn-primary" %>
-    <% end %>
+    <div>
+      <% if policy(ConferenceProgram.new(conference: @conference)).create? %>
+        <%= link_to "Create Conference Program", new_conference_custom_program_path(@conference), class: "btn btn-success me-2" %>
+        <% if @available_programs.any? %>
+          <%= link_to "Enable Existing Program", conference_new_conference_program_path(@conference), class: "btn btn-primary" %>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 
   <% if @conference_programs.any? %>
@@ -17,6 +22,9 @@
             <div class="card-body">
               <h5 class="card-title">
                 <%= cp.program.name %>
+                <% if cp.program.conference_specific? %>
+                  <span class="badge bg-info">Conference Only</span>
+                <% end %>
               </h5>
               <% if cp.public_description.present? %>
                 <p class="card-text text-muted">
@@ -42,12 +50,20 @@
             </div>
             <div class="card-footer bg-transparent">
               <% if policy(cp).update? %>
-                <%= link_to "Edit", edit_conference_conference_program_path(@conference, cp), class: "btn btn-sm btn-outline-primary" %>
+                <%= link_to "Edit Schedule", edit_conference_conference_program_path(@conference, cp), class: "btn btn-sm btn-outline-primary" %>
+              <% end %>
+              <% if cp.program.conference_specific? && policy(cp.program).update? %>
+                <%= link_to "Edit Program", edit_conference_custom_program_path(@conference, cp.program), class: "btn btn-sm btn-outline-secondary" %>
               <% end %>
               <% if policy(cp).destroy? %>
-                <%= link_to "Disable", conference_conference_program_path(@conference, cp), 
-                    data: { turbo_method: :delete, confirm: "Are you sure you want to disable this program for this conference?" },
+                <%= link_to "Disable", conference_conference_program_path(@conference, cp),
+                    data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to disable this program for this conference?" },
                     class: "btn btn-sm btn-outline-danger" %>
+              <% end %>
+              <% if cp.program.conference_specific? && policy(cp.program).destroy? %>
+                <%= link_to "Delete Program", conference_custom_program_path(@conference, cp.program),
+                    data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to permanently delete this program? This will also remove all schedules and volunteer signups." },
+                    class: "btn btn-sm btn-danger" %>
               <% end %>
             </div>
           </div>
@@ -58,8 +74,12 @@
     <div class="alert alert-info">
       <h5 class="alert-heading">No Programs Enabled</h5>
       <p class="mb-0">
-        <% if @available_programs.any? && policy(ConferenceProgram.new(conference: @conference)).create? %>
-          Get started by <%= link_to "enabling a program", conference_new_conference_program_path(@conference), class: "alert-link" %> for this conference.
+        <% if policy(ConferenceProgram.new(conference: @conference)).create? %>
+          Get started by <%= link_to "creating a new program", new_conference_custom_program_path(@conference), class: "alert-link" %>
+          <% if @available_programs.any? %>
+            or <%= link_to "enabling an existing program", conference_new_conference_program_path(@conference), class: "alert-link" %>
+          <% end %>
+          for this conference.
         <% else %>
           No programs have been enabled for this conference yet.
         <% end %>
@@ -76,6 +96,11 @@
           <li class="list-group-item d-flex justify-content-between align-items-center">
             <div>
               <strong><%= program.name %></strong>
+              <% if program.conference_specific? %>
+                <span class="badge bg-info ms-1">Conference Only</span>
+              <% else %>
+                <span class="badge bg-secondary ms-1">Village-Wide</span>
+              <% end %>
               <% if program.description.present? %>
                 <br><small class="text-muted"><%= truncate(program.description, length: 150) %></small>
               <% end %>

--- a/app/views/custom_programs/edit.html.erb
+++ b/app/views/custom_programs/edit.html.erb
@@ -1,0 +1,45 @@
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="card shadow">
+        <div class="card-header bg-primary text-white">
+          <h2 class="h4 mb-0">Edit Conference Program</h2>
+        </div>
+        <div class="card-body">
+          <%= form_with model: @program, url: conference_custom_program_path(@conference, @program), local: true do |form| %>
+            <% if @program.errors.any? %>
+              <div class="alert alert-danger">
+                <h5 class="alert-heading">Please fix the following errors:</h5>
+                <ul class="mb-0">
+                  <% @program.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+
+            <div class="mb-3">
+              <%= form.label :name, class: "form-label" %>
+              <%= form.text_field :name, class: "form-control", required: true, autofocus: true %>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :description, class: "form-label" %>
+              <%= form.text_area :description, rows: 4, class: "form-control" %>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :max_volunteers, "Volunteers Needed Per Shift", class: "form-label" %>
+              <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;" %>
+            </div>
+
+            <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+              <%= link_to "Cancel", conference_conference_programs_path(@conference), class: "btn btn-outline-secondary" %>
+              <%= form.submit "Update Program", class: "btn btn-primary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/custom_programs/new.html.erb
+++ b/app/views/custom_programs/new.html.erb
@@ -1,0 +1,51 @@
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="card shadow">
+        <div class="card-header bg-primary text-white">
+          <h2 class="h4 mb-0">Create Conference Program for <%= @conference.name %></h2>
+        </div>
+        <div class="card-body">
+          <%= form_with model: @program, url: conference_custom_programs_path(@conference), local: true do |form| %>
+            <% if @program.errors.any? %>
+              <div class="alert alert-danger">
+                <h5 class="alert-heading">Please fix the following errors:</h5>
+                <ul class="mb-0">
+                  <% @program.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+
+            <div class="alert alert-info">
+              <strong>Note:</strong> This program will only be available for <%= @conference.name %>.
+              To create a village-wide program available to all conferences, use the
+              <%= link_to "Programs management page", programs_path, class: "alert-link" %> instead.
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :name, class: "form-label" %>
+              <%= form.text_field :name, class: "form-control", required: true, autofocus: true %>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :description, class: "form-label" %>
+              <%= form.text_area :description, rows: 4, class: "form-control" %>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :max_volunteers, "Volunteers Needed Per Shift", class: "form-label" %>
+              <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;", value: @program.max_volunteers || 1 %>
+            </div>
+
+            <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+              <%= link_to "Cancel", conference_conference_programs_path(@conference), class: "btn btn-outline-secondary" %>
+              <%= form.submit "Create Program", class: "btn btn-primary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -17,9 +17,9 @@
           <% end %>
 
           <h5>Conferences</h5>
-          <% if @program.conferences.any? %>
+          <% if @program.enabled_conferences.any? %>
             <div class="mb-3">
-              <% @program.conferences.each do |conference| %>
+              <% @program.enabled_conferences.each do |conference| %>
                 <%= link_to conference.name, conference, class: "badge bg-primary text-decoration-none me-1" %>
               <% end %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     get "calendar_export", to: "calendar_exports#show", as: :calendar_export
     get "programs/new", to: "conference_programs#new", as: :new_conference_program
     resources :conference_programs, except: [ :new ], path: "programs"
+    resources :custom_programs, only: [ :new, :create, :edit, :update, :destroy ]
     resources :conference_roles, only: [ :create, :destroy ]
     get "calendar", to: "calendar#show", as: :calendar
     get "schedule", to: "schedule#show", as: :schedule

--- a/db/migrate/20251211173455_add_conference_to_programs.rb
+++ b/db/migrate/20251211173455_add_conference_to_programs.rb
@@ -1,0 +1,5 @@
+class AddConferenceToPrograms < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :programs, :conference, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_11_063449) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_11_173455) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -83,12 +83,14 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_11_063449) do
   end
 
   create_table "programs", force: :cascade do |t|
+    t.bigint "conference_id"
     t.datetime "created_at", null: false
     t.text "description"
     t.integer "max_volunteers", default: 1, null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.bigint "village_id", null: false
+    t.index ["conference_id"], name: "index_programs_on_conference_id"
     t.index ["village_id", "name"], name: "index_programs_on_village_id_and_name", unique: true
     t.index ["village_id"], name: "index_programs_on_village_id"
   end
@@ -200,6 +202,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_11_063449) do
   add_foreign_key "conferences", "villages"
   add_foreign_key "program_qualifications", "programs"
   add_foreign_key "program_qualifications", "qualifications"
+  add_foreign_key "programs", "conferences"
   add_foreign_key "programs", "villages"
   add_foreign_key "qualification_removals", "conferences"
   add_foreign_key "qualification_removals", "qualifications"

--- a/test/controllers/custom_programs_controller_test.rb
+++ b/test/controllers/custom_programs_controller_test.rb
@@ -1,0 +1,155 @@
+require "test_helper"
+
+class CustomProgramsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      village: @village,
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+
+    @village_admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.create!(user: @village_admin, role: village_admin_role)
+
+    @conference_lead = User.create!(
+      email: "lead@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: @conference_lead,
+      conference: @conference,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @conference_program = Program.create!(
+      name: "Conference Only Program",
+      village: @village,
+      conference: @conference
+    )
+  end
+
+  test "requires authentication for new" do
+    get new_conference_custom_program_path(@conference)
+    # Pundit redirects to root_path when unauthorized
+    assert_redirected_to root_path
+  end
+
+  test "conference lead can access new custom program form" do
+    sign_in @conference_lead
+    get new_conference_custom_program_path(@conference)
+    assert_response :success
+  end
+
+  test "conference lead can create custom program" do
+    sign_in @conference_lead
+    assert_difference("Program.count") do
+      post conference_custom_programs_path(@conference), params: {
+        program: {
+          name: "New Custom Program",
+          description: "A program just for this conference",
+          max_volunteers: 2
+        }
+      }
+    end
+
+    program = Program.last
+    assert_equal @conference, program.conference
+    assert program.conference_specific?
+    assert_redirected_to conference_conference_programs_path(@conference)
+  end
+
+  test "volunteer cannot access new custom program form" do
+    sign_in @volunteer
+    get new_conference_custom_program_path(@conference)
+    assert_redirected_to root_path
+  end
+
+  test "volunteer cannot create custom program" do
+    sign_in @volunteer
+    assert_no_difference("Program.count") do
+      post conference_custom_programs_path(@conference), params: {
+        program: {
+          name: "Sneaky Program",
+          max_volunteers: 1
+        }
+      }
+    end
+    assert_redirected_to root_path
+  end
+
+  test "conference lead can edit their conference-specific program" do
+    sign_in @conference_lead
+    get edit_conference_custom_program_path(@conference, @conference_program)
+    assert_response :success
+  end
+
+  test "conference lead can update their conference-specific program" do
+    sign_in @conference_lead
+    patch conference_custom_program_path(@conference, @conference_program), params: {
+      program: {
+        name: "Updated Program Name"
+      }
+    }
+
+    assert_redirected_to conference_conference_programs_path(@conference)
+    @conference_program.reload
+    assert_equal "Updated Program Name", @conference_program.name
+  end
+
+  test "conference lead can destroy their conference-specific program" do
+    sign_in @conference_lead
+    assert_difference("Program.count", -1) do
+      delete conference_custom_program_path(@conference, @conference_program)
+    end
+
+    assert_redirected_to conference_conference_programs_path(@conference)
+  end
+
+  test "conference lead cannot access programs from other conferences" do
+    other_conference = Conference.create!(
+      name: "Other Conference",
+      village: @village,
+      start_date: Date.tomorrow + 10.days,
+      end_date: Date.tomorrow + 13.days
+    )
+    other_program = Program.create!(
+      name: "Other Program",
+      village: @village,
+      conference: other_conference
+    )
+
+    sign_in @conference_lead
+    get edit_conference_custom_program_path(@conference, other_program)
+    assert_redirected_to conference_conference_programs_path(@conference)
+  end
+
+  test "village admin can create custom program" do
+    sign_in @village_admin
+    assert_difference("Program.count") do
+      post conference_custom_programs_path(@conference), params: {
+        program: {
+          name: "Admin Created Program",
+          max_volunteers: 3
+        }
+      }
+    end
+
+    program = Program.last
+    assert_equal @conference, program.conference
+    assert_redirected_to conference_conference_programs_path(@conference)
+  end
+end

--- a/test/policies/program_policy_test.rb
+++ b/test/policies/program_policy_test.rb
@@ -1,0 +1,149 @@
+require "test_helper"
+
+class ProgramPolicyTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      village: @village,
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+
+    @village_admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.create!(user: @village_admin, role: village_admin_role)
+
+    @conference_lead = User.create!(
+      email: "lead@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: @conference_lead,
+      conference: @conference,
+      role_name: ConferenceRole::CONFERENCE_LEAD
+    )
+
+    @conference_admin = User.create!(
+      email: "confadmin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    ConferenceRole.create!(
+      user: @conference_admin,
+      conference: @conference,
+      role_name: ConferenceRole::CONFERENCE_ADMIN
+    )
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @village_program = Program.create!(name: "Village Program", village: @village)
+    @conference_program = Program.create!(name: "Conference Program", village: @village, conference: @conference)
+  end
+
+  # Village-level program tests
+  test "village admin can create village-level programs" do
+    policy = ProgramPolicy.new(@village_admin, Program.new(village: @village))
+    assert policy.create?
+  end
+
+  test "conference lead cannot create village-level programs" do
+    policy = ProgramPolicy.new(@conference_lead, Program.new(village: @village))
+    assert_not policy.create?
+  end
+
+  test "volunteer cannot create village-level programs" do
+    policy = ProgramPolicy.new(@volunteer, Program.new(village: @village))
+    assert_not policy.create?
+  end
+
+  test "village admin can update village-level programs" do
+    policy = ProgramPolicy.new(@village_admin, @village_program)
+    assert policy.update?
+  end
+
+  test "conference lead cannot update village-level programs" do
+    policy = ProgramPolicy.new(@conference_lead, @village_program)
+    assert_not policy.update?
+  end
+
+  test "village admin can destroy village-level programs" do
+    policy = ProgramPolicy.new(@village_admin, @village_program)
+    assert policy.destroy?
+  end
+
+  test "conference lead cannot destroy village-level programs" do
+    policy = ProgramPolicy.new(@conference_lead, @village_program)
+    assert_not policy.destroy?
+  end
+
+  # Conference-specific program tests
+  test "conference lead can create conference-specific programs for their conference" do
+    policy = ProgramPolicy.new(@conference_lead, Program.new(village: @village, conference: @conference))
+    assert policy.create?
+  end
+
+  test "conference admin can create conference-specific programs for their conference" do
+    policy = ProgramPolicy.new(@conference_admin, Program.new(village: @village, conference: @conference))
+    assert policy.create?
+  end
+
+  test "conference lead cannot create programs for other conferences" do
+    other_conference = Conference.create!(
+      name: "Other Conference",
+      village: @village,
+      start_date: Date.tomorrow + 10.days,
+      end_date: Date.tomorrow + 13.days
+    )
+    policy = ProgramPolicy.new(@conference_lead, Program.new(village: @village, conference: other_conference))
+    assert_not policy.create?
+  end
+
+  test "conference lead can update their conference-specific programs" do
+    policy = ProgramPolicy.new(@conference_lead, @conference_program)
+    assert policy.update?
+  end
+
+  test "conference admin can update their conference-specific programs" do
+    policy = ProgramPolicy.new(@conference_admin, @conference_program)
+    assert policy.update?
+  end
+
+  test "conference lead cannot update programs for other conferences" do
+    other_conference = Conference.create!(
+      name: "Other Conference",
+      village: @village,
+      start_date: Date.tomorrow + 10.days,
+      end_date: Date.tomorrow + 13.days
+    )
+    other_program = Program.create!(name: "Other Program", village: @village, conference: other_conference)
+    policy = ProgramPolicy.new(@conference_lead, other_program)
+    assert_not policy.update?
+  end
+
+  test "conference lead can destroy their conference-specific programs" do
+    policy = ProgramPolicy.new(@conference_lead, @conference_program)
+    assert policy.destroy?
+  end
+
+  test "village admin can manage conference-specific programs" do
+    policy = ProgramPolicy.new(@village_admin, @conference_program)
+    assert policy.create?
+    assert policy.update?
+    assert policy.destroy?
+  end
+
+  test "volunteer cannot create conference-specific programs" do
+    policy = ProgramPolicy.new(@volunteer, Program.new(village: @village, conference: @conference))
+    assert_not policy.create?
+  end
+end


### PR DESCRIPTION
## Summary
- Allow conference leads/admins to create programs specific to their conference
- Programs can now be either village-level (available to all conferences) or conference-specific
- Conference leads/admins can manage their conference-specific programs while village admins retain full access

## Implementation Details
- Added optional `conference_id` to programs table (null = village-level)
- Added `village_level` and `for_conference` scopes to Program model
- Updated ProgramPolicy to allow conference leads/admins to manage their programs
- Created CustomProgramsController for conference-specific program CRUD
- Updated UI with badges distinguishing "Village-Wide" vs "Conference Only" programs
- Added "Create Conference Program" button and edit/delete actions for conference-specific programs

## Test plan
- [x] All 389 tests pass (0 failures, 0 errors)
- [x] Rubocop shows no offenses
- [ ] Conference lead can create a new conference-specific program
- [ ] Conference lead can edit/delete their conference-specific programs
- [ ] Conference lead can enable conference-specific programs for scheduling
- [ ] Conference lead cannot access programs from other conferences
- [ ] Village admin can see and manage all programs (village and conference-specific)
- [ ] Badges correctly show "Village-Wide" vs "Conference Only"

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)