### PR TITLE
Add bulk update feature for timeslot capacity when program default changes

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -1,5 +1,5 @@
 class ProgramsController < ApplicationController
-  before_action :set_program, only: [ :show, :edit, :update, :destroy ]
+  before_action :set_program, only: [ :show, :edit, :update, :destroy, :affected_conferences, :bulk_update_capacity ]
   before_action :set_village
 
   def index
@@ -46,6 +46,48 @@ class ProgramsController < ApplicationController
     authorize @program, :destroy?, policy_class: ProgramPolicy
     @program.destroy
     redirect_to programs_path, notice: "Program was successfully deleted."
+  end
+
+  # Returns JSON with affected open conferences for the bulk update modal
+  def affected_conferences
+    authorize @program, :update?, policy_class: ProgramPolicy
+    new_max_volunteers = params[:new_max_volunteers].to_i
+
+    conferences_data = @program.conference_programs
+      .joins(:conference)
+      .where("conferences.end_date >= ?", Date.today)
+      .includes(:conference, :timeslots)
+      .map do |cp|
+        timeslots_count = cp.timeslots.count
+        over_capacity_count = cp.timeslots.where("current_volunteers_count > ?", new_max_volunteers).count
+
+        {
+          conference_program_id: cp.id,
+          conference_name: cp.conference.name,
+          current_max_volunteers: cp.effective_max_volunteers,
+          timeslots_count: timeslots_count,
+          over_capacity_count: over_capacity_count,
+          has_override: cp.max_volunteers.present?
+        }
+      end
+
+    render json: { conferences: conferences_data }
+  end
+
+  # Enqueues bulk update jobs for selected conference programs
+  def bulk_update_capacity
+    authorize @program, :update?, policy_class: ProgramPolicy
+    new_max_volunteers = params[:new_max_volunteers].to_i
+    conference_program_ids = params[:conference_program_ids] || []
+
+    conference_program_ids.each do |cp_id|
+      UpdateTimeslotCapacityJob.perform_later(cp_id.to_i, new_max_volunteers)
+    end
+
+    render json: {
+      success: true,
+      message: "Updating #{conference_program_ids.count} conference(s) in the background."
+    }
   end
 
   private

--- a/app/javascript/controllers/bulk_capacity_update_controller.js
+++ b/app/javascript/controllers/bulk_capacity_update_controller.js
@@ -1,0 +1,141 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="bulk-capacity-update"
+export default class extends Controller {
+  static targets = ["maxVolunteers", "modal", "conferenceList", "selectAll", "submitBtn", "loading"]
+  static values = {
+    programId: Number,
+    originalValue: Number,
+    affectedConferencesUrl: String,
+    bulkUpdateUrl: String
+  }
+
+  connect() {
+    this.originalValueValue = parseInt(this.maxVolunteersTarget.value) || 1
+  }
+
+  async checkForChanges(event) {
+    const newValue = parseInt(this.maxVolunteersTarget.value)
+
+    // If value changed, check for affected conferences
+    if (newValue !== this.originalValueValue && newValue > 0) {
+      await this.loadAffectedConferences(newValue)
+    }
+  }
+
+  async loadAffectedConferences(newMaxVolunteers) {
+    try {
+      const response = await fetch(`${this.affectedConferencesUrlValue}?new_max_volunteers=${newMaxVolunteers}`)
+      const data = await response.json()
+
+      if (data.conferences && data.conferences.length > 0) {
+        this.renderConferenceList(data.conferences, newMaxVolunteers)
+        this.showModal()
+      }
+    } catch (error) {
+      console.error("Error loading affected conferences:", error)
+    }
+  }
+
+  renderConferenceList(conferences, newMaxVolunteers) {
+    let html = ""
+    conferences.forEach(conf => {
+      const warningBadge = conf.over_capacity_count > 0
+        ? `<span class="badge bg-warning text-dark ms-2">${conf.over_capacity_count} over capacity</span>`
+        : ""
+      const overrideBadge = conf.has_override
+        ? `<span class="badge bg-secondary ms-2">Has override</span>`
+        : ""
+
+      html += `
+        <div class="form-check mb-2 p-3 border rounded">
+          <input class="form-check-input conference-checkbox" type="checkbox"
+                 value="${conf.conference_program_id}" id="conf_${conf.conference_program_id}"
+                 ${conf.has_override ? "" : "checked"}>
+          <label class="form-check-label w-100" for="conf_${conf.conference_program_id}">
+            <div class="d-flex justify-content-between align-items-start">
+              <div>
+                <strong>${conf.conference_name}</strong>
+                ${overrideBadge}
+                ${warningBadge}
+                <br>
+                <small class="text-muted">
+                  Current: ${conf.current_max_volunteers} volunteers/shift |
+                  ${conf.timeslots_count} timeslots
+                </small>
+              </div>
+              <div class="text-end">
+                <span class="badge bg-primary">${conf.current_max_volunteers} → ${newMaxVolunteers}</span>
+              </div>
+            </div>
+          </label>
+        </div>
+      `
+    })
+    this.conferenceListTarget.innerHTML = html
+  }
+
+  showModal() {
+    this.modalTarget.classList.add("show")
+    this.modalTarget.style.display = "block"
+    document.body.classList.add("modal-open")
+  }
+
+  hideModal() {
+    this.modalTarget.classList.remove("show")
+    this.modalTarget.style.display = "none"
+    document.body.classList.remove("modal-open")
+  }
+
+  toggleSelectAll() {
+    const checkboxes = this.conferenceListTarget.querySelectorAll(".conference-checkbox")
+    const allChecked = this.selectAllTarget.checked
+    checkboxes.forEach(cb => cb.checked = allChecked)
+  }
+
+  async submitBulkUpdate() {
+    const checkboxes = this.conferenceListTarget.querySelectorAll(".conference-checkbox:checked")
+    const conferenceProgrmIds = Array.from(checkboxes).map(cb => cb.value)
+    const newMaxVolunteers = parseInt(this.maxVolunteersTarget.value)
+
+    if (conferenceProgrmIds.length === 0) {
+      this.hideModal()
+      return
+    }
+
+    this.submitBtnTarget.disabled = true
+    this.loadingTarget.classList.remove("d-none")
+
+    try {
+      const response = await fetch(this.bulkUpdateUrlValue, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": document.querySelector("[name='csrf-token']").content
+        },
+        body: JSON.stringify({
+          new_max_volunteers: newMaxVolunteers,
+          conference_program_ids: conferenceProgrmIds
+        })
+      })
+
+      const data = await response.json()
+      if (data.success) {
+        this.hideModal()
+        // Update original value to prevent modal showing again
+        this.originalValueValue = newMaxVolunteers
+      }
+    } catch (error) {
+      console.error("Error updating capacity:", error)
+    } finally {
+      this.submitBtnTarget.disabled = false
+      this.loadingTarget.classList.add("d-none")
+    }
+  }
+
+  skipUpdate() {
+    this.hideModal()
+    // Update original value to prevent modal showing again on re-save
+    this.originalValueValue = parseInt(this.maxVolunteersTarget.value)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import BulkCapacityUpdateController from "./bulk_capacity_update_controller"
+application.register("bulk-capacity-update", BulkCapacityUpdateController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/jobs/update_timeslot_capacity_job.rb
+++ b/app/jobs/update_timeslot_capacity_job.rb
@@ -1,0 +1,24 @@
+class UpdateTimeslotCapacityJob < ApplicationJob
+  queue_as :default
+
+  def perform(conference_program_id, new_max_volunteers)
+    conference_program = ConferenceProgram.find_by(id: conference_program_id)
+    return { updated: 0, skipped: 0 } unless conference_program
+
+    updated_count = 0
+    skipped_count = 0
+
+    conference_program.timeslots.find_each do |timeslot|
+      # Don't reduce capacity below current signups
+      if timeslot.current_volunteers_count > new_max_volunteers
+        skipped_count += 1
+        next
+      end
+
+      timeslot.update!(max_volunteers: new_max_volunteers)
+      updated_count += 1
+    end
+
+    { updated: updated_count, skipped: skipped_count }
+  end
+end

--- a/app/views/programs/edit.html.erb
+++ b/app/views/programs/edit.html.erb
@@ -1,4 +1,7 @@
-<div class="container mt-5">
+<div class="container mt-5" data-controller="bulk-capacity-update"
+     data-bulk-capacity-update-program-id-value="<%= @program.id %>"
+     data-bulk-capacity-update-affected-conferences-url-value="<%= affected_conferences_program_path(@program) %>"
+     data-bulk-capacity-update-bulk-update-url-value="<%= bulk_update_capacity_program_path(@program) %>">
   <div class="row justify-content-center">
     <div class="col-md-8">
       <div class="card shadow">
@@ -32,7 +35,8 @@
 
             <div class="mb-3">
               <%= form.label :max_volunteers, "Default Volunteers Per Shift", class: "form-label" %>
-              <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;" %>
+              <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;",
+                  data: { bulk_capacity_update_target: "maxVolunteers", action: "blur->bulk-capacity-update#checkForChanges" } %>
               <div class="form-text">Default number of volunteers needed per 15-minute shift. Can be overridden per conference.</div>
             </div>
 
@@ -41,6 +45,50 @@
               <%= form.submit "Update Program", class: "btn btn-primary btn-lg" %>
             </div>
           <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Bulk Update Modal -->
+  <div class="modal fade" tabindex="-1" data-bulk-capacity-update-target="modal" style="background-color: rgba(0,0,0,0.5);">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Update Existing Timeslots?</h5>
+          <button type="button" class="btn-close" data-action="bulk-capacity-update#hideModal"></button>
+        </div>
+        <div class="modal-body">
+          <p class="text-muted">
+            The following open conferences use this program. Would you like to update their existing timeslot capacities to match the new default?
+          </p>
+          <div class="mb-3">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="selectAll"
+                     data-bulk-capacity-update-target="selectAll"
+                     data-action="bulk-capacity-update#toggleSelectAll">
+              <label class="form-check-label fw-bold" for="selectAll">Select All</label>
+            </div>
+          </div>
+          <div data-bulk-capacity-update-target="conferenceList">
+            <!-- Conference checkboxes will be dynamically inserted here -->
+          </div>
+          <div class="alert alert-info mt-3">
+            <small>
+              <strong>Note:</strong> Timeslots with existing signups that exceed the new capacity will not be reduced.
+              Conferences with a capacity override set will be unchecked by default.
+            </small>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <span class="spinner-border spinner-border-sm me-2 d-none" data-bulk-capacity-update-target="loading"></span>
+          <button type="button" class="btn btn-secondary" data-action="bulk-capacity-update#skipUpdate">
+            Skip - Don't Update Existing
+          </button>
+          <button type="button" class="btn btn-primary" data-bulk-capacity-update-target="submitBtn"
+                  data-action="bulk-capacity-update#submitBulkUpdate">
+            Update Selected
+          </button>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,15 +50,18 @@ Rails.application.routes.draw do
   end
 
   # Program management
-  resources :programs
+  resources :programs do
+    member do
+      get :affected_conferences
+      post :bulk_update_capacity
+    end
+    resources :program_qualifications, only: [ :create, :destroy ]
+  end
 
   # Qualification management
   resources :qualifications
   resources :managed_users, controller: "users", path: "manage/users" do
     resources :user_qualifications, only: [ :create, :destroy ]
-  end
-  resources :programs do
-    resources :program_qualifications, only: [ :create, :destroy ]
   end
 
   # Leaderboard

--- a/test/jobs/update_timeslot_capacity_job_test.rb
+++ b/test/jobs/update_timeslot_capacity_job_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+class UpdateTimeslotCapacityJobTest < ActiveJob::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      village: @village,
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 12:00")
+    )
+    @program = Program.create!(
+      name: "Test Program",
+      village: @village,
+      max_volunteers: 2
+    )
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+  end
+
+  test "updates all timeslot max_volunteers for a conference_program" do
+    # All timeslots should have initial max_volunteers of 2 (from program default)
+    assert @conference_program.timeslots.all? { |ts| ts.max_volunteers == 2 }
+
+    # Run job to update to new capacity
+    UpdateTimeslotCapacityJob.perform_now(@conference_program.id, 5)
+
+    # Verify all timeslots updated
+    @conference_program.timeslots.reload.each do |timeslot|
+      assert_equal 5, timeslot.max_volunteers
+    end
+  end
+
+  test "does not reduce capacity below current signups" do
+    timeslot = @conference_program.timeslots.first
+    user1 = User.create!(email: "user1@example.com", password: "password123", password_confirmation: "password123")
+    user2 = User.create!(email: "user2@example.com", password: "password123", password_confirmation: "password123")
+    VolunteerSignup.create!(timeslot: timeslot, user: user1)
+    VolunteerSignup.create!(timeslot: timeslot, user: user2)
+    timeslot.update!(current_volunteers_count: 2)
+
+    # Try to reduce capacity to 1 (below current signups of 2)
+    UpdateTimeslotCapacityJob.perform_now(@conference_program.id, 1)
+
+    # Timeslot should keep capacity at 2 (current signups), not reduce to 1
+    timeslot.reload
+    assert_equal 2, timeslot.max_volunteers
+  end
+
+  test "handles missing conference_program gracefully" do
+    # Should not raise an error for non-existent conference_program
+    assert_nothing_raised do
+      UpdateTimeslotCapacityJob.perform_now(999999, 5)
+    end
+  end
+
+  test "job is idempotent" do
+    # Running the job twice with same value should produce same result
+    UpdateTimeslotCapacityJob.perform_now(@conference_program.id, 5)
+    UpdateTimeslotCapacityJob.perform_now(@conference_program.id, 5)
+
+    @conference_program.timeslots.reload.each do |timeslot|
+      assert_equal 5, timeslot.max_volunteers
+    end
+  end
+
+  test "returns count of updated and skipped timeslots" do
+    timeslot = @conference_program.timeslots.first
+    user1 = User.create!(email: "user1@example.com", password: "password123", password_confirmation: "password123")
+    user2 = User.create!(email: "user2@example.com", password: "password123", password_confirmation: "password123")
+    VolunteerSignup.create!(timeslot: timeslot, user: user1)
+    VolunteerSignup.create!(timeslot: timeslot, user: user2)
+    timeslot.update!(current_volunteers_count: 2)
+
+    # Reduce to 1 - the timeslot with 2 signups should be skipped
+    result = UpdateTimeslotCapacityJob.perform_now(@conference_program.id, 1)
+
+    assert_kind_of Hash, result
+    assert result[:skipped] >= 1
+  end
+end


### PR DESCRIPTION
## Summary
- When editing a program's max_volunteers, show a modal to optionally update existing timeslots
- Uses background job (Active Job) for processing bulk updates
- Only affects open conferences (end_date >= today)

## Implementation Details
- **UpdateTimeslotCapacityJob**: Background job that updates timeslot capacities safely
- **Controller actions**: `affected_conferences` (JSON) and `bulk_update_capacity` (POST)
- **Stimulus controller**: Handles modal UI, conference selection, and AJAX submission
- **Modal UI**: Shows affected conferences with capacity changes, warnings, and checkboxes

## Safety Features
- Does not reduce timeslot capacity below current volunteer signups
- Conferences with capacity overrides are unchecked by default
- Shows warning badge for timeslots that would be over capacity
- Job handles missing records gracefully (idempotent)

## Test plan
- [x] All 399 tests pass (0 failures, 0 errors)
- [x] Rubocop shows no offenses
- [ ] Edit program, change max_volunteers - modal should appear if open conferences exist
- [ ] Verify only open conferences are shown (not past conferences)
- [ ] Select conferences and click "Update Selected" - timeslots should update
- [ ] Click "Skip" - program saves without updating existing timeslots
- [ ] Verify timeslots with more signups than new capacity are not reduced

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)