### PR TITLE
Add program leads (activity leads) feature

### DIFF
--- a/app/controllers/program_roles_controller.rb
+++ b/app/controllers/program_roles_controller.rb
@@ -1,0 +1,32 @@
+class ProgramRolesController < ApplicationController
+  before_action :set_program
+
+  def create
+    @user = User.find(params[:user_id])
+    authorize @program, :update?
+
+    @program_role = ProgramRole.find_or_create_by!(
+      user: @user,
+      program: @program,
+      role_name: ProgramRole::PROGRAM_LEAD
+    )
+
+    redirect_to @program, notice: "Program lead assigned successfully."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to @program, alert: "Could not assign program lead: #{e.message}"
+  end
+
+  def destroy
+    @program_role = ProgramRole.find(params[:id])
+    authorize @program, :update?
+
+    @program_role.destroy
+    redirect_to @program, notice: "Program lead removed successfully."
+  end
+
+  private
+
+  def set_program
+    @program = Program.find(params[:program_id])
+  end
+end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -6,6 +6,9 @@ class Program < ApplicationRecord
   has_many :timeslots, through: :conference_programs
   has_many :program_qualifications, dependent: :destroy
   has_many :qualifications, through: :program_qualifications
+  has_many :program_roles, dependent: :destroy
+  has_many :program_leads, -> { where(program_roles: { role_name: ProgramRole::PROGRAM_LEAD }) },
+           through: :program_roles, source: :user
 
   validates :name, presence: true
   validates :name, uniqueness: { scope: [ :village_id, :conference_id ], message: "must be unique within the village" }

--- a/app/models/program_role.rb
+++ b/app/models/program_role.rb
@@ -1,0 +1,10 @@
+class ProgramRole < ApplicationRecord
+  belongs_to :user
+  belongs_to :program
+
+  validates :user_id, uniqueness: { scope: [ :program_id, :role_name ] }
+  validates :role_name, inclusion: { in: %w[program_lead] }
+
+  # Role names
+  PROGRAM_LEAD = "program_lead"
+end

--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -23,6 +23,7 @@ class ProgramPolicy < ApplicationPolicy
 
   def update?
     return true if user&.village_admin?
+    return true if user&.program_lead?(record)
 
     # Conference leads/admins can update conference-specific programs for their conference
     if record.conference_specific?

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -29,6 +29,44 @@
 
           <hr>
 
+          <div class="card bg-light mb-3">
+            <div class="card-body">
+              <h5 class="card-title">Program Leads</h5>
+              <% if @program.program_leads.any? %>
+                <ul class="list-group list-group-flush mb-3">
+                  <% @program.program_roles.where(role_name: ProgramRole::PROGRAM_LEAD).includes(:user).each do |role| %>
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                      <%= role.user.email %>
+                      <% if policy(@program).update? %>
+                        <%= link_to "Remove", program_program_role_path(@program, role),
+                            data: { turbo_method: :delete, turbo_confirm: "Remove this program lead?" },
+                            class: "btn btn-sm btn-danger" %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="text-muted">No program leads assigned.</p>
+              <% end %>
+
+              <% if policy(@program).update? %>
+                <% existing_lead_ids = @program.program_leads.pluck(:id) %>
+                <% available_users = User.where.not(id: existing_lead_ids).order(:email) %>
+                <% if available_users.any? %>
+                  <%= form_with url: program_program_roles_path(@program), method: :post, local: true, class: "d-flex gap-2" do |f| %>
+                    <select name="user_id" class="form-select form-select-sm" required>
+                      <option value="">Select user...</option>
+                      <% available_users.each do |user| %>
+                        <option value="<%= user.id %>"><%= user.email %></option>
+                      <% end %>
+                    </select>
+                    <%= f.submit "Add Lead", class: "btn btn-sm btn-primary" %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+
           <div class="card bg-light">
             <div class="card-body">
               <h5 class="card-title">Required Qualifications</h5>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
       post :bulk_update_capacity
     end
     resources :program_qualifications, only: [ :create, :destroy ]
+    resources :program_roles, only: [ :create, :destroy ]
   end
 
   # Qualification management

--- a/db/migrate/20251213034924_create_program_roles.rb
+++ b/db/migrate/20251213034924_create_program_roles.rb
@@ -1,0 +1,13 @@
+class CreateProgramRoles < ActiveRecord::Migration[8.1]
+  def change
+    create_table :program_roles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :program, null: false, foreign_key: true
+      t.string :role_name, null: false
+
+      t.timestamps
+    end
+
+    add_index :program_roles, [ :user_id, :program_id, :role_name ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_11_180603) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_13_034924) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -81,6 +81,17 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_11_180603) do
     t.datetime "updated_at", null: false
     t.index ["program_id"], name: "index_program_qualifications_on_program_id"
     t.index ["qualification_id"], name: "index_program_qualifications_on_qualification_id"
+  end
+
+  create_table "program_roles", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "program_id", null: false
+    t.string "role_name", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["program_id"], name: "index_program_roles_on_program_id"
+    t.index ["user_id", "program_id", "role_name"], name: "index_program_roles_on_user_id_and_program_id_and_role_name", unique: true
+    t.index ["user_id"], name: "index_program_roles_on_user_id"
   end
 
   create_table "programs", force: :cascade do |t|
@@ -203,6 +214,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_11_180603) do
   add_foreign_key "conferences", "villages"
   add_foreign_key "program_qualifications", "programs"
   add_foreign_key "program_qualifications", "qualifications"
+  add_foreign_key "program_roles", "programs"
+  add_foreign_key "program_roles", "users"
   add_foreign_key "programs", "conferences"
   add_foreign_key "programs", "villages"
   add_foreign_key "qualification_removals", "conferences"

--- a/test/controllers/program_roles_controller_test.rb
+++ b/test/controllers/program_roles_controller_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+class ProgramRolesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @program = Program.create!(name: "Test Program", description: "Test", village: @village)
+
+    @village_admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.create!(user: @village_admin, role: village_admin_role)
+
+    @program_lead = User.create!(
+      email: "lead@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @new_lead = User.create!(
+      email: "newlead@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  test "village admin can add program lead" do
+    sign_in @village_admin
+    assert_difference "ProgramRole.count", 1 do
+      post program_program_roles_path(@program), params: { user_id: @new_lead.id }
+    end
+    assert_redirected_to @program
+    assert @new_lead.program_lead?(@program)
+  end
+
+  test "village admin can remove program lead" do
+    ProgramRole.create!(user: @program_lead, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    sign_in @village_admin
+
+    assert_difference "ProgramRole.count", -1 do
+      delete program_program_role_path(@program, @program.program_roles.first)
+    end
+    assert_redirected_to @program
+  end
+
+  test "program lead can add another program lead" do
+    ProgramRole.create!(user: @program_lead, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    sign_in @program_lead
+
+    assert_difference "ProgramRole.count", 1 do
+      post program_program_roles_path(@program), params: { user_id: @new_lead.id }
+    end
+    assert_redirected_to @program
+  end
+
+  test "program lead can remove another program lead" do
+    role1 = ProgramRole.create!(user: @program_lead, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    role2 = ProgramRole.create!(user: @new_lead, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    sign_in @program_lead
+
+    assert_difference "ProgramRole.count", -1 do
+      delete program_program_role_path(@program, role2)
+    end
+    assert_redirected_to @program
+  end
+
+  test "volunteer cannot add program lead" do
+    sign_in @volunteer
+    assert_no_difference "ProgramRole.count" do
+      post program_program_roles_path(@program), params: { user_id: @new_lead.id }
+    end
+    assert_redirected_to root_path
+  end
+
+  test "volunteer cannot remove program lead" do
+    role = ProgramRole.create!(user: @program_lead, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    sign_in @volunteer
+
+    assert_no_difference "ProgramRole.count" do
+      delete program_program_role_path(@program, role)
+    end
+    assert_redirected_to root_path
+  end
+
+  test "adding duplicate program lead does not create new record" do
+    ProgramRole.create!(user: @new_lead, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    sign_in @village_admin
+
+    assert_no_difference "ProgramRole.count" do
+      post program_program_roles_path(@program), params: { user_id: @new_lead.id }
+    end
+    assert_redirected_to @program
+  end
+end

--- a/test/models/program_role_test.rb
+++ b/test/models/program_role_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class ProgramRoleTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @program = Program.create!(name: "Test Program", description: "Test", village: @village)
+    @user = User.create!(email: "test@example.com", password: "password123", password_confirmation: "password123")
+  end
+
+  test "valid program role" do
+    role = ProgramRole.new(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    assert role.valid?
+  end
+
+  test "requires user" do
+    role = ProgramRole.new(program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    assert_not role.valid?
+    assert_includes role.errors[:user], "must exist"
+  end
+
+  test "requires program" do
+    role = ProgramRole.new(user: @user, role_name: ProgramRole::PROGRAM_LEAD)
+    assert_not role.valid?
+    assert_includes role.errors[:program], "must exist"
+  end
+
+  test "requires valid role_name" do
+    role = ProgramRole.new(user: @user, program: @program, role_name: "invalid_role")
+    assert_not role.valid?
+    assert_includes role.errors[:role_name], "is not included in the list"
+  end
+
+  test "allows program_lead role_name" do
+    role = ProgramRole.new(user: @user, program: @program, role_name: "program_lead")
+    assert role.valid?
+  end
+
+  test "prevents duplicate user-program-role combinations" do
+    ProgramRole.create!(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    duplicate = ProgramRole.new(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:user_id], "has already been taken"
+  end
+
+  test "allows same user to lead different programs" do
+    program2 = Program.create!(name: "Another Program", description: "Test", village: @village)
+    ProgramRole.create!(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    role2 = ProgramRole.new(user: @user, program: program2, role_name: ProgramRole::PROGRAM_LEAD)
+    assert role2.valid?
+  end
+
+  test "allows different users to lead same program" do
+    user2 = User.create!(email: "other@example.com", password: "password123", password_confirmation: "password123")
+    ProgramRole.create!(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    role2 = ProgramRole.new(user: user2, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    assert role2.valid?
+  end
+
+  test "PROGRAM_LEAD constant is defined" do
+    assert_equal "program_lead", ProgramRole::PROGRAM_LEAD
+  end
+end

--- a/test/models/program_test.rb
+++ b/test/models/program_test.rb
@@ -164,4 +164,36 @@ class ProgramTest < ActiveSupport::TestCase
     )
     assert conference_program.valid?
   end
+
+  # Program lead tests
+  test "program can have program roles" do
+    program = Program.create!(name: "Test Program", village: @village)
+    user = User.create!(email: "lead@example.com", password: "password123", password_confirmation: "password123")
+    role = ProgramRole.create!(user: user, program: program, role_name: ProgramRole::PROGRAM_LEAD)
+
+    assert_includes program.program_roles, role
+  end
+
+  test "program can have multiple leads" do
+    program = Program.create!(name: "Test Program", village: @village)
+    user1 = User.create!(email: "lead1@example.com", password: "password123", password_confirmation: "password123")
+    user2 = User.create!(email: "lead2@example.com", password: "password123", password_confirmation: "password123")
+
+    ProgramRole.create!(user: user1, program: program, role_name: ProgramRole::PROGRAM_LEAD)
+    ProgramRole.create!(user: user2, program: program, role_name: ProgramRole::PROGRAM_LEAD)
+
+    assert_equal 2, program.program_leads.count
+    assert_includes program.program_leads, user1
+    assert_includes program.program_leads, user2
+  end
+
+  test "deleting program deletes associated program roles" do
+    program = Program.create!(name: "Test Program", village: @village)
+    user = User.create!(email: "lead@example.com", password: "password123", password_confirmation: "password123")
+    ProgramRole.create!(user: user, program: program, role_name: ProgramRole::PROGRAM_LEAD)
+
+    assert_difference "ProgramRole.count", -1 do
+      program.destroy
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,71 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @user = User.create!(email: "test@example.com", password: "password123", password_confirmation: "password123")
+    @program = Program.create!(name: "Test Program", description: "Test", village: @village)
+  end
+
+  # Program lead tests
+  test "user can have program roles" do
+    role = ProgramRole.create!(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    assert_includes @user.program_roles, role
+  end
+
+  test "program_lead? returns true when user is a program lead" do
+    ProgramRole.create!(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    assert @user.program_lead?(@program)
+  end
+
+  test "program_lead? returns false when user is not a program lead" do
+    assert_not @user.program_lead?(@program)
+  end
+
+  test "can_manage_program? returns true for village admin" do
+    admin_role = Role.create!(name: Role::VILLAGE_ADMIN)
+    UserRole.create!(user: @user, role: admin_role)
+    assert @user.can_manage_program?(@program)
+  end
+
+  test "can_manage_program? returns true for program lead" do
+    ProgramRole.create!(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+    assert @user.can_manage_program?(@program)
+  end
+
+  test "can_manage_program? returns true for conference lead of conference-specific program" do
+    conference = Conference.create!(
+      name: "Test Conference",
+      village: @village,
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    conference_program = Program.create!(
+      name: "Conference Program",
+      village: @village,
+      conference: conference
+    )
+    ConferenceRole.create!(user: @user, conference: conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+    assert @user.can_manage_program?(conference_program)
+  end
+
+  test "can_manage_program? returns false for regular user" do
+    assert_not @user.can_manage_program?(@program)
+  end
+
+  test "led_programs returns programs where user is a lead" do
+    program2 = Program.create!(name: "Another Program", description: "Test", village: @village)
+    ProgramRole.create!(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+
+    assert_includes @user.led_programs, @program
+    assert_not_includes @user.led_programs, program2
+  end
+
+  test "deleting user deletes associated program roles" do
+    ProgramRole.create!(user: @user, program: @program, role_name: ProgramRole::PROGRAM_LEAD)
+
+    assert_difference "ProgramRole.count", -1 do
+      @user.destroy
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Implements program leads (activity leads) feature similar to conference leads
- Creates ProgramRole model with PROGRAM_LEAD role type
- Adds authorization for program leads to manage their assigned programs
- Adds UI for viewing and managing program leads on the program show page

## Changes

- **ProgramRole model**: New model for assigning users as program leads
- **Program model**: Added `program_roles` and `program_leads` associations
- **User model**: Added `program_lead?`, `can_manage_program?`, and `led_programs` methods
- **ProgramPolicy**: Updated to allow program leads to update their programs
- **ProgramRolesController**: New controller for adding/removing program leads
- **Program show view**: Added UI section for managing program leads

## Authorization

Program leads can:
- Update their assigned programs (name, description, etc.)
- Add/remove other program leads for their programs
- Cannot delete programs (only village admins can)

## Test plan

- [x] ProgramRole model tests pass
- [x] User model program lead tests pass
- [x] ProgramPolicy tests for program lead authorization pass
- [x] ProgramRolesController tests pass
- [x] System tests pass

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)