### PR TITLE
Display conference lead name on conference cards

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -5,9 +5,9 @@ class ConferencesController < ApplicationController
   def index
     @show_archived = params[:show_archived] == "true"
     @conferences = if @show_archived
-                     Conference.order(start_date: :desc)
+                     Conference.includes(conference_roles: :user).order(start_date: :desc)
     else
-                     Conference.active.order(start_date: :desc)
+                     Conference.active.includes(conference_roles: :user).order(start_date: :desc)
     end
   end
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -81,6 +81,25 @@ class Conference < ApplicationRecord
                    .limit(limit)
   end
 
+  # Conference lead methods
+  def conference_leads
+    users.joins(:conference_roles)
+         .where(conference_roles: { role_name: ConferenceRole::CONFERENCE_LEAD })
+  end
+
+  def primary_lead
+    conference_roles.find_by(role_name: ConferenceRole::CONFERENCE_LEAD)&.user
+  end
+
+  def lead_display_name
+    lead = primary_lead
+    return "No lead assigned" unless lead
+
+    name = lead.name.presence || lead.email
+    additional_leads = conference_leads.count - 1
+    additional_leads > 0 ? "#{name} +#{additional_leads}" : name
+  end
+
   # Location display methods
   def display_location
     return "Not specified" if city.blank?

--- a/app/views/conferences/index.html.erb
+++ b/app/views/conferences/index.html.erb
@@ -31,6 +31,16 @@
                 <% end %>
               </h5>
               <p class="card-text text-muted">
+                <strong>Lead:</strong>
+                <% if (lead = conference.primary_lead) %>
+                  <%= link_to (lead.name.presence || lead.email), managed_user_path(lead), class: "text-decoration-none" %>
+                  <% if (additional = conference.conference_leads.count - 1) > 0 %>
+                    <span class="text-muted">+<%= additional %></span>
+                  <% end %>
+                <% else %>
+                  <span class="text-muted">No lead assigned</span>
+                <% end %>
+                <br>
                 <strong>Location:</strong> <%= conference.display_location %><br>
                 <strong>Dates:</strong> <%= conference.start_date.strftime("%B %d") %> - <%= conference.end_date.strftime("%B %d, %Y") %>
               </p>

--- a/test/models/conference_test.rb
+++ b/test/models/conference_test.rb
@@ -225,4 +225,98 @@ class ConferenceTest < ActiveSupport::TestCase
     )
     assert_not ongoing_conference.archivable?
   end
+
+  # Conference lead tests
+  test "primary_lead returns the first conference lead" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    user = User.create!(email: "lead@example.com", password: "password123", password_confirmation: "password123")
+    ConferenceRole.create!(user: user, conference: conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+
+    assert_equal user, conference.primary_lead
+  end
+
+  test "primary_lead returns nil when no lead assigned" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+
+    assert_nil conference.primary_lead
+  end
+
+  test "conference_leads returns all conference leads" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    lead1 = User.create!(email: "lead1@example.com", password: "password123", password_confirmation: "password123")
+    lead2 = User.create!(email: "lead2@example.com", password: "password123", password_confirmation: "password123")
+    ConferenceRole.create!(user: lead1, conference: conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+    ConferenceRole.create!(user: lead2, conference: conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+
+    assert_equal 2, conference.conference_leads.count
+    assert_includes conference.conference_leads, lead1
+    assert_includes conference.conference_leads, lead2
+  end
+
+  test "lead_display_name returns user name when available" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    user = User.create!(email: "lead@example.com", password: "password123", password_confirmation: "password123", name: "John Doe")
+    ConferenceRole.create!(user: user, conference: conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+
+    assert_equal "John Doe", conference.lead_display_name
+  end
+
+  test "lead_display_name returns email when name not available" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    user = User.create!(email: "lead@example.com", password: "password123", password_confirmation: "password123")
+    ConferenceRole.create!(user: user, conference: conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+
+    assert_equal "lead@example.com", conference.lead_display_name
+  end
+
+  test "lead_display_name shows count when multiple leads" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+    lead1 = User.create!(email: "lead1@example.com", password: "password123", password_confirmation: "password123", name: "Jane Doe")
+    lead2 = User.create!(email: "lead2@example.com", password: "password123", password_confirmation: "password123")
+    ConferenceRole.create!(user: lead1, conference: conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+    ConferenceRole.create!(user: lead2, conference: conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+
+    assert_equal "Jane Doe +1", conference.lead_display_name
+  end
+
+  test "lead_display_name returns message when no lead assigned" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+
+    assert_equal "No lead assigned", conference.lead_display_name
+  end
 end


### PR DESCRIPTION
## Summary

Adds conference lead information to conference cards on the index page, with the lead's name linked to their user profile.

## Changes

- Add `conference_leads` method to Conference model to get all leads
- Add `primary_lead` method to get the first assigned lead
- Add `lead_display_name` helper for simple string representation
- Update conferences index view to show lead name as a link to user profile
- Shows "+N" suffix when multiple leads are assigned
- Shows "No lead assigned" when no lead exists
- Eager load conference_roles in controller to avoid N+1 queries

## Screenshots

Conference cards now display:
- **Lead:** [Name or Email](link to user) +N (if multiple)
- Location
- Dates

## Test plan

- [x] Conference model tests for new methods pass
- [x] System tests pass
- [x] Lead name links to user profile page
- [x] Multiple leads show "+N" suffix
- [x] No lead shows "No lead assigned"

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)