### PR TITLE
Allow village admins to edit any user's profile

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: [ :show ]
+  before_action :set_user, only: [ :show, :edit, :update ]
   before_action :set_village
 
   def index
@@ -12,6 +12,20 @@ class UsersController < ApplicationController
     @qualifications = Qualification.where(village: @village).order(:name)
   end
 
+  def edit
+    authorize @user, :edit?, policy_class: UserPolicy
+  end
+
+  def update
+    authorize @user, :update?, policy_class: UserPolicy
+
+    if @user.update(user_params)
+      redirect_to managed_user_path(@user), notice: "User was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_user
@@ -21,5 +35,10 @@ class UsersController < ApplicationController
   def set_village
     @village = Village.first
     redirect_to setup_path if @village.nil?
+  end
+
+  def user_params
+    # Only allow profile fields - no email or password changes
+    params.require(:user).permit(:name, :handle, :phone, :twitter, :signal, :discord)
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -7,6 +7,14 @@ class UserPolicy < ApplicationPolicy
     user&.village_admin?
   end
 
+  def edit?
+    user&.village_admin?
+  end
+
+  def update?
+    user&.village_admin?
+  end
+
   def grant_qualification?
     user&.village_admin?
   end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,66 @@
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-md-8">
+      <div class="card">
+        <div class="card-header">
+          <h2>Edit User: <%= @user.email %></h2>
+        </div>
+        <div class="card-body">
+          <%= form_with(model: @user, url: managed_user_path(@user), method: :patch, local: true) do |f| %>
+            <% if @user.errors.any? %>
+              <div class="alert alert-danger">
+                <h5><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h5>
+                <ul class="mb-0">
+                  <% @user.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+
+            <div class="mb-3">
+              <label class="form-label">Email</label>
+              <input type="text" class="form-control" value="<%= @user.email %>" disabled>
+              <div class="form-text">Email cannot be changed by administrators.</div>
+            </div>
+
+            <div class="mb-3">
+              <%= f.label :name, class: "form-label" %>
+              <%= f.text_field :name, class: "form-control", placeholder: "Full name" %>
+            </div>
+
+            <div class="mb-3">
+              <%= f.label :handle, class: "form-label" %>
+              <%= f.text_field :handle, class: "form-control", placeholder: "Handle / nickname" %>
+            </div>
+
+            <div class="mb-3">
+              <%= f.label :phone, class: "form-label" %>
+              <%= f.text_field :phone, class: "form-control", placeholder: "Phone number" %>
+            </div>
+
+            <div class="mb-3">
+              <%= f.label :twitter, class: "form-label" %>
+              <%= f.text_field :twitter, class: "form-control", placeholder: "@username" %>
+            </div>
+
+            <div class="mb-3">
+              <%= f.label :signal, class: "form-label" %>
+              <%= f.text_field :signal, class: "form-control", placeholder: "Signal username" %>
+            </div>
+
+            <div class="mb-3">
+              <%= f.label :discord, class: "form-label" %>
+              <%= f.text_field :discord, class: "form-control", placeholder: "username#1234" %>
+            </div>
+
+            <div class="d-flex gap-2">
+              <%= f.submit "Update User", class: "btn btn-primary" %>
+              <%= link_to "Cancel", managed_user_path(@user), class: "btn btn-outline-secondary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -89,8 +89,9 @@
             </div>
           </div>
         </div>
-        <div class="card-footer">
+        <div class="card-footer d-flex justify-content-between">
           <%= link_to "← Back to Users", managed_users_path, class: "btn btn-link" %>
+          <%= link_to "Edit", edit_managed_user_path(@user), class: "btn btn-outline-primary" %>
         </div>
       </div>
     </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -77,4 +77,106 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_match @volunteer.email, response.body
     assert_match @village_admin.email, response.body
   end
+
+  # Edit action tests
+  test "should get edit as village admin" do
+    sign_in_user(@village_admin)
+    get edit_managed_user_url(@volunteer)
+    assert_response :success
+  end
+
+  test "should not get edit as volunteer" do
+    sign_in_user(@volunteer)
+    get edit_managed_user_url(@village_admin)
+    assert_redirected_to root_path
+  end
+
+  test "edit page should display user profile fields" do
+    sign_in_user(@village_admin)
+    get edit_managed_user_url(@volunteer)
+    assert_response :success
+    assert_select "input[name='user[name]']"
+    assert_select "input[name='user[handle]']"
+    assert_select "input[name='user[phone]']"
+    assert_select "input[name='user[twitter]']"
+    assert_select "input[name='user[signal]']"
+    assert_select "input[name='user[discord]']"
+  end
+
+  test "edit page should not have password fields" do
+    sign_in_user(@village_admin)
+    get edit_managed_user_url(@volunteer)
+    assert_response :success
+    assert_select "input[name='user[password]']", count: 0
+    assert_select "input[name='user[password_confirmation]']", count: 0
+  end
+
+  # Update action tests
+  test "should update user as village admin" do
+    sign_in_user(@village_admin)
+    patch managed_user_url(@volunteer), params: {
+      user: {
+        name: "Updated Name",
+        handle: "newhandle",
+        phone: "555-1234",
+        twitter: "@newtwitter",
+        signal: "newsignal",
+        discord: "newdiscord#1234"
+      }
+    }
+    assert_redirected_to managed_user_path(@volunteer)
+
+    @volunteer.reload
+    assert_equal "Updated Name", @volunteer.name
+    assert_equal "newhandle", @volunteer.handle
+    assert_equal "555-1234", @volunteer.phone
+    assert_equal "@newtwitter", @volunteer.twitter
+    assert_equal "newsignal", @volunteer.signal
+    assert_equal "newdiscord#1234", @volunteer.discord
+  end
+
+  test "should not update user as volunteer" do
+    sign_in_user(@volunteer)
+    original_name = @village_admin.name
+    patch managed_user_url(@village_admin), params: {
+      user: { name: "Hacked Name" }
+    }
+    assert_redirected_to root_path
+
+    @village_admin.reload
+    assert_equal original_name, @village_admin.name
+  end
+
+  test "update should not change user email" do
+    sign_in_user(@village_admin)
+    original_email = @volunteer.email
+    patch managed_user_url(@volunteer), params: {
+      user: { email: "hacked@example.com", name: "New Name" }
+    }
+    assert_redirected_to managed_user_path(@volunteer)
+
+    @volunteer.reload
+    assert_equal original_email, @volunteer.email
+    assert_equal "New Name", @volunteer.name
+  end
+
+  test "update should not change user password" do
+    sign_in_user(@village_admin)
+    original_password = @volunteer.encrypted_password
+    patch managed_user_url(@volunteer), params: {
+      user: { password: "newpassword123", password_confirmation: "newpassword123", name: "New Name" }
+    }
+    assert_redirected_to managed_user_path(@volunteer)
+
+    @volunteer.reload
+    assert_equal original_password, @volunteer.encrypted_password
+    assert_equal "New Name", @volunteer.name
+  end
+
+  test "show page should have edit link for village admin" do
+    sign_in_user(@village_admin)
+    get managed_user_url(@volunteer)
+    assert_response :success
+    assert_select "a[href=?]", edit_managed_user_path(@volunteer)
+  end
 end


### PR DESCRIPTION
## Summary
- Add edit/update actions to UsersController for village admins
- Add edit/update policies to UserPolicy
- Create edit view for user profiles with profile fields only (name, handle, phone, twitter, signal, discord)
- Add edit link to user show page
- Password and email fields are intentionally excluded for security

## Test plan
- [ ] Sign in as village admin
- [ ] Navigate to Manage > Users
- [ ] Click on a user to view their profile
- [ ] Click Edit button
- [ ] Verify email field is displayed but disabled
- [ ] Update profile fields and save
- [ ] Verify changes are persisted
- [ ] Sign in as regular volunteer and verify they cannot access edit page for other users

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)