### PR TITLE
Configure Mailgun for outgoing emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Mailgun Configuration
+# Required for sending emails in production
+MAILGUN_API_KEY=your-mailgun-api-key
+MAILGUN_DOMAIN=your-mailgun-domain.mailgun.org
+
+# Optional: Set to "eu" if using Mailgun EU region
+# MAILGUN_REGION=us
+
+# Application host for URL generation in emails
+APP_HOST=your-app-domain.com
+
+# Optional: Override the default sender email address
+# Defaults to noreply@MAILGUN_DOMAIN if not set
+# MAILER_FROM=noreply@your-domain.com

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@
 /.bundle
 /vendor/bundle
 
-# Ignore all environment files.
+# Ignore all environment files except the example.
 /.env*
+!/.env.example
 .env
 .env*.local
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem "csv"
 # Calendar export (iCal/ICS)
 gem "icalendar"
 
+# Email delivery via Mailgun API
+gem "mailgun-ruby", "~> 1.2"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,14 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -194,6 +202,10 @@ GEM
       net-imap
       net-pop
       net-smtp
+    mailgun-ruby (1.4.0)
+      faraday (~> 2.1)
+      faraday-multipart (~> 1.1.0)
+      mini_mime
     marcel (1.1.0)
     matrix (0.4.3)
     mini_magick (5.3.1)
@@ -201,6 +213,9 @@ GEM
     mini_mime (1.1.5)
     minitest (5.26.2)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
+    net-http (0.8.0)
+      uri (>= 0.11.1)
     net-imap (0.5.12)
       date
       net-protocol
@@ -439,6 +454,7 @@ DEPENDENCIES
   jsbundling-rails
   kamal
   letter_opener
+  mailgun-ruby (~> 1.2)
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,21 +57,21 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   # Set host to be used by links generated in mailer templates.
-  # Configure via MAILER_HOST environment variable.
-  config.action_mailer.default_url_options = { host: ENV.fetch("MAILER_HOST", "example.com") }
+  # Configure via APP_HOST environment variable.
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "example.com") }
 
-  # Email delivery configuration via SMTP.
-  # Configure via environment variables or Rails credentials.
-  config.action_mailer.delivery_method = :smtp
+  # Email delivery configuration via Mailgun API.
+  # Required environment variables:
+  #   MAILGUN_API_KEY - Your Mailgun API key
+  #   MAILGUN_DOMAIN  - Your Mailgun sending domain
+  # Optional:
+  #   MAILGUN_REGION  - "us" (default) or "eu"
+  config.action_mailer.delivery_method = :mailgun
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.smtp_settings = {
-    address: ENV.fetch("SMTP_ADDRESS", Rails.application.credentials.dig(:smtp, :address)),
-    port: ENV.fetch("SMTP_PORT", Rails.application.credentials.dig(:smtp, :port) || 587).to_i,
-    domain: ENV.fetch("SMTP_DOMAIN", Rails.application.credentials.dig(:smtp, :domain)),
-    user_name: ENV.fetch("SMTP_USERNAME", Rails.application.credentials.dig(:smtp, :user_name)),
-    password: ENV.fetch("SMTP_PASSWORD", Rails.application.credentials.dig(:smtp, :password)),
-    authentication: ENV.fetch("SMTP_AUTHENTICATION", Rails.application.credentials.dig(:smtp, :authentication) || "plain"),
-    enable_starttls_auto: true
+  config.action_mailer.mailgun_settings = {
+    api_key: ENV.fetch("MAILGUN_API_KEY", nil),
+    domain: ENV.fetch("MAILGUN_DOMAIN", nil),
+    region: ENV.fetch("MAILGUN_REGION", "us")
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,11 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  # Uses MAILER_FROM environment variable, falling back to noreply@MAILGUN_DOMAIN
+  config.mailer_sender = ENV.fetch("MAILER_FROM") {
+    domain = ENV.fetch("MAILGUN_DOMAIN", "example.com")
+    "noreply@#{domain}"
+  }
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/mailgun.rb
+++ b/config/initializers/mailgun.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Mailgun API delivery method for Action Mailer
+# This allows sending emails via Mailgun's REST API instead of SMTP
+#
+# Required environment variables:
+#   MAILGUN_API_KEY - Your Mailgun API key
+#   MAILGUN_DOMAIN  - Your Mailgun sending domain (e.g., sandbox123.mailgun.org)
+#
+# Optional environment variables:
+#   MAILGUN_REGION  - "us" (default) or "eu" for EU region
+
+class MailgunDeliveryMethod
+  attr_reader :settings
+
+  def initialize(settings)
+    @settings = settings
+  end
+
+  def deliver!(mail)
+    api_key = settings[:api_key] || ENV.fetch("MAILGUN_API_KEY", nil)
+    domain = settings[:domain] || ENV.fetch("MAILGUN_DOMAIN", nil)
+    region = settings[:region] || ENV.fetch("MAILGUN_REGION", "us")
+
+    raise ArgumentError, "Mailgun API key is required" if api_key.blank?
+    raise ArgumentError, "Mailgun domain is required" if domain.blank?
+
+    # Configure Mailgun client based on region
+    api_host = region == "eu" ? "api.eu.mailgun.net" : "api.mailgun.net"
+
+    mg_client = Mailgun::Client.new(api_key, api_host)
+    message_builder = Mailgun::MessageBuilder.new
+
+    # Build the message
+    message_builder.from(mail.from.first)
+    mail.to.each { |recipient| message_builder.add_recipient(:to, recipient) }
+    mail.cc&.each { |recipient| message_builder.add_recipient(:cc, recipient) }
+    mail.bcc&.each { |recipient| message_builder.add_recipient(:bcc, recipient) }
+
+    message_builder.subject(mail.subject)
+
+    # Handle multipart emails
+    if mail.multipart?
+      mail.parts.each do |part|
+        if part.content_type.start_with?("text/plain")
+          message_builder.body_text(part.body.decoded)
+        elsif part.content_type.start_with?("text/html")
+          message_builder.body_html(part.body.decoded)
+        end
+      end
+    elsif mail.content_type&.start_with?("text/html")
+      message_builder.body_html(mail.body.decoded)
+    else
+      message_builder.body_text(mail.body.decoded)
+    end
+
+    # Send the message
+    mg_client.send_message(domain, message_builder)
+  end
+end
+
+# Register the delivery method with Action Mailer
+ActionMailer::Base.add_delivery_method :mailgun, MailgunDeliveryMethod


### PR DESCRIPTION
## Summary
- Add mailgun-ruby gem for API-based email delivery
- Create custom Mailgun delivery method for Action Mailer
- Update production environment to use Mailgun API
- Configure Devise mailer sender from environment variables
- Add .env.example documenting required environment variables
- Development continues to use letter_opener for local testing

## Environment Variables

**Required for production:**
- `MAILGUN_API_KEY` - Mailgun API key
- `MAILGUN_DOMAIN` - Mailgun sending domain
- `APP_HOST` - Application hostname for email URL generation

**Optional:**
- `MAILGUN_REGION` - "us" (default) or "eu" for EU region
- `MAILER_FROM` - Override default noreply@ sender address

## Test plan
- [x] Tests pass (no regressions)
- [x] Rubocop passes
- [ ] Test email sending in production with Mailgun sandbox domain
- [ ] Verify emails appear in Mailgun dashboard logs

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)