### PR TITLE
Add email verification for new user signups

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :confirmable
 
   # Devise handles email validation, but we keep format validation
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -147,7 +147,8 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  # Allow 2-day grace period for users to confirm their email
+  config.allow_unconfirmed_access_for = 2.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm
@@ -155,7 +156,8 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  # Confirmation tokens expire after 3 days
+  config.confirm_within = 3.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/db/migrate/20251215035321_add_confirmable_to_users.rb
+++ b/db/migrate/20251215035321_add_confirmable_to_users.rb
@@ -1,0 +1,21 @@
+class AddConfirmableToUsers < ActiveRecord::Migration[8.1]
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+
+    add_index :users, :confirmation_token, unique: true
+
+    # Confirm all existing users so they don't get locked out
+    User.update_all(confirmed_at: Time.current)
+  end
+
+  def down
+    remove_index :users, :confirmation_token
+    remove_column :users, :confirmation_token
+    remove_column :users, :confirmed_at
+    remove_column :users, :confirmation_sent_at
+    remove_column :users, :unconfirmed_email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_13_034924) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_15_035321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -170,6 +170,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_13_034924) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.datetime "confirmation_sent_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
     t.datetime "created_at", null: false
     t.string "discord"
     t.string "email", null: false
@@ -182,7 +185,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_13_034924) do
     t.string "reset_password_token"
     t.string "signal"
     t.string "twitter"
+    t.string "unconfirmed_email"
     t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,17 @@ module ActiveSupport
   end
 end
 
+# Auto-confirm users created in tests (for Devise confirmable)
+class User
+  before_create :auto_confirm_in_test
+
+  private
+
+  def auto_confirm_in_test
+    self.confirmed_at ||= Time.current if Rails.env.test?
+  end
+end
+
 # Include Devise test helpers
 class ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers


### PR DESCRIPTION
## Summary
Uses Devise's built-in `:confirmable` module for email verification - no custom code needed.

- Add migration for confirmable columns with unique index on confirmation_token
- Enable `:confirmable` in User model
- Configure Devise confirmable settings:
  - 2-day grace period for unconfirmed access
  - 3-day token expiration
  - Reconfirmation required for email changes
- Auto-confirm existing users in migration to prevent lockout
- Add test helper to auto-confirm users in test environment

## User Flow
1. User signs up → account created, confirmation email sent
2. User has 2 days to access site without confirming (grace period)
3. User clicks confirmation link → account fully confirmed
4. Email changes require re-confirmation

## Test plan
- [x] All tests pass
- [x] Rubocop passes
- [ ] Sign up as new user and verify confirmation email is sent
- [ ] Verify unconfirmed user can access site for 2 days
- [ ] Click confirmation link and verify account is confirmed
- [ ] Change email and verify reconfirmation email is sent

**Depends on:** #100 (Mailgun) - merged ✓

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)