### PR TITLE
Style confirmation email with HTML template and button

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,72 @@
-<p>Welcome <%= @email %>!</p>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Confirm your email</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f4f4f5;">
+  <table role="presentation" style="width: 100%; border-collapse: collapse;">
+    <tr>
+      <td style="padding: 40px 20px;">
+        <table role="presentation" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);">
+          <!-- Header -->
+          <tr>
+            <td style="padding: 40px 40px 20px; text-align: center; border-bottom: 1px solid #e5e5e5;">
+              <h1 style="margin: 0; font-size: 28px; font-weight: 600; color: #1a1a1a;">Villagers</h1>
+              <p style="margin: 8px 0 0; font-size: 14px; color: #6b7280;">Volunteer Management</p>
+            </td>
+          </tr>
 
-<p>You can confirm your account email through the link below:</p>
+          <!-- Content -->
+          <tr>
+            <td style="padding: 40px;">
+              <h2 style="margin: 0 0 16px; font-size: 22px; font-weight: 600; color: #1a1a1a;">Confirm your email address</h2>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+              <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #4b5563;">
+                Welcome to Villagers! Please confirm your email address by clicking the button below. This helps us ensure your account is secure.
+              </p>
+
+              <!-- Button -->
+              <table role="presentation" style="width: 100%; border-collapse: collapse;">
+                <tr>
+                  <td style="padding: 16px 0 24px; text-align: center;">
+                    <a href="<%= confirmation_url(@resource, confirmation_token: @token) %>"
+                       style="display: inline-block; padding: 14px 32px; font-size: 16px; font-weight: 600; color: #ffffff; background-color: #2563eb; text-decoration: none; border-radius: 6px; box-shadow: 0 2px 4px rgba(37, 99, 235, 0.3);">
+                      Confirm Email Address
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.6; color: #6b7280;">
+                If the button doesn't work, copy and paste this link into your browser:
+              </p>
+
+              <p style="margin: 0 0 24px; font-size: 14px; line-height: 1.6; word-break: break-all;">
+                <a href="<%= confirmation_url(@resource, confirmation_token: @token) %>"
+                   style="color: #2563eb; text-decoration: underline;">
+                  <%= confirmation_url(@resource, confirmation_token: @token) %>
+                </a>
+              </p>
+
+              <p style="margin: 0; font-size: 14px; line-height: 1.6; color: #6b7280;">
+                This link will expire in <%= distance_of_time_in_words(Devise.confirm_within) %>.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding: 24px 40px; background-color: #f9fafb; border-top: 1px solid #e5e5e5; border-radius: 0 0 8px 8px;">
+              <p style="margin: 0; font-size: 13px; line-height: 1.5; color: #9ca3af; text-align: center;">
+                If you didn't create an account with Villagers, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -1,0 +1,12 @@
+Villagers - Confirm your email address
+======================================
+
+Welcome to Villagers!
+
+Please confirm your email address by visiting the link below:
+
+<%= confirmation_url(@resource, confirmation_token: @token) %>
+
+This link will expire in <%= distance_of_time_in_words(Devise.confirm_within) %>.
+
+If you didn't create an account with Villagers, you can safely ignore this email.


### PR DESCRIPTION
## Summary
- Add styled HTML email template with inline CSS for email client compatibility
- Include prominent blue call-to-action button for confirmation link
- Add plain text fallback version for email clients that don't support HTML
- Show dynamic expiration time from Devise configuration

## Test plan
- [ ] Register a new user and verify confirmation email is styled
- [ ] Verify button links to correct confirmation URL
- [ ] Test in multiple email clients (Gmail, Outlook, Apple Mail)
- [ ] Verify plain text version renders correctly

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)