### PR TITLE
Fix flaky My Shifts navigation system test

### DIFF
--- a/test/system/my_shifts_test.rb
+++ b/test/system/my_shifts_test.rb
@@ -75,10 +75,16 @@ class MyShiftsTest < ApplicationSystemTestCase
     login_as @user
     visit conference_path(@conference)
 
-    # Wait for the page to fully load before clicking
-    assert_text @conference.name
-    click_link "My Shifts"
+    # Wait for the conference show page to fully load by checking for the My Shifts button
+    assert_selector "a.btn", text: "My Shifts"
 
+    # Click the My Shifts button and wait for navigation
+    find("a.btn", text: "My Shifts", match: :first).click
+
+    # Wait for navigation to complete - the URL should change
+    assert_current_path conference_volunteer_signups_path(@conference)
+
+    # Verify we're on the My Shifts page
     assert_text "My Shifts - #{@conference.name}"
   end
 end


### PR DESCRIPTION
## Summary
- Fix flaky system test `MyShiftsTest#test_my_shifts_page_is_accessible_from_conference_show_page`
- Use `find().click` instead of `click_link` for more reliable element interaction
- Add `assert_current_path` to wait for navigation to complete before checking page content

## Root Cause
The test was failing intermittently because:
1. `click_link` wasn't reliably waiting for the element to be interactive
2. The assertion ran before navigation completed, so it was still on the conference page

## Test plan
- [x] Test passes locally (ran 3x consecutively)
- [ ] CI passes

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)