### PR TITLE
Add Mailgun configuration to setup wizard

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -35,7 +35,7 @@ class SetupController < ApplicationController
   end
 
   def village_params
-    params.require(:village).permit(:name)
+    params.require(:village).permit(:name, :email_enabled, :mailgun_api_key, :mailgun_domain, :mailgun_region)
   end
 
   def user_params

--- a/app/javascript/controllers/email_config_controller.js
+++ b/app/javascript/controllers/email_config_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="email-config"
+export default class extends Controller {
+  toggle(event) {
+    const mailgunSettings = document.getElementById("mailgunSettings")
+    const emailDisabledWarning = document.getElementById("emailDisabledWarning")
+
+    if (event.target.checked) {
+      mailgunSettings.classList.remove("d-none")
+      emailDisabledWarning.classList.add("d-none")
+    } else {
+      mailgunSettings.classList.add("d-none")
+      emailDisabledWarning.classList.remove("d-none")
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import BulkCapacityUpdateController from "./bulk_capacity_update_controller"
 application.register("bulk-capacity-update", BulkCapacityUpdateController)
 
+import EmailConfigController from "./email_config_controller"
+application.register("email-config", EmailConfigController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,6 +5,20 @@ class ApplicationMailer < ActionMailer::Base
 
   private
 
+  # Helper to check if email should be sent
+  def email_enabled?
+    Village.email_enabled?
+  end
+
+  # Use this in mailer actions to skip sending when email is disabled
+  def skip_if_email_disabled
+    unless email_enabled?
+      mail.perform_deliveries = false
+      return true
+    end
+    false
+  end
+
   def default_from_address
     ENV.fetch("MAILER_FROM_ADDRESS", "notifications@example.com")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,13 @@ class User < ApplicationRecord
   # Devise handles email validation, but we keep format validation
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
+  # Skip email confirmation when email is disabled
+  before_create :auto_confirm_if_email_disabled
+
+  private def auto_confirm_if_email_disabled
+    skip_confirmation! unless Village.email_enabled?
+  end
+
   # Role associations
   has_many :user_roles, dependent: :destroy
   has_many :roles, through: :user_roles

--- a/app/models/village.rb
+++ b/app/models/village.rb
@@ -3,8 +3,33 @@ class Village < ApplicationRecord
   has_many :qualifications, dependent: :destroy
 
   validates :name, presence: true
+  validates :mailgun_api_key, presence: true, if: :email_enabled?
+  validates :mailgun_domain, presence: true, if: :email_enabled?
+  validates :mailgun_region, inclusion: { in: %w[us eu] }, allow_blank: true
 
   def self.setup_complete?
     exists? && first.setup_complete?
+  end
+
+  # Email configuration class methods
+  def self.email_enabled?
+    return false unless exists?
+
+    setup_complete? && first&.email_enabled?
+  end
+
+  def self.mailgun_settings
+    return {} unless setup_complete?
+
+    village = first
+    {
+      api_key: village.mailgun_api_key,
+      domain: village.mailgun_domain,
+      region: village.mailgun_region || "us"
+    }
+  end
+
+  def self.current
+    first
   end
 end

--- a/app/views/setup/show.html.erb
+++ b/app/views/setup/show.html.erb
@@ -49,6 +49,45 @@
               <%= form.password_field "user[password_confirmation]", class: "form-control", required: true %>
             </div>
 
+            <hr class="my-4">
+
+            <h5 class="mb-3">Email Configuration</h5>
+
+            <div class="mb-3">
+              <div class="form-check form-switch">
+                <%= form.check_box "village[email_enabled]", { class: "form-check-input", role: "switch", id: "emailEnabled", checked: @village.email_enabled?, data: { action: "change->email-config#toggle" } } %>
+                <%= form.label "village[email_enabled]", "Enable email notifications", class: "form-check-label", for: "emailEnabled" %>
+              </div>
+              <div class="form-text">When enabled, users must verify their email address to sign up, and the system can send notification emails.</div>
+            </div>
+
+            <div id="mailgunSettings" class="<%= 'd-none' unless @village.email_enabled? %>">
+              <div class="alert alert-info">
+                <small>
+                  <strong>Mailgun Setup:</strong> Create a free account at <a href="https://www.mailgun.com" target="_blank">mailgun.com</a> to get your API key and domain.
+                </small>
+              </div>
+
+              <div class="mb-3">
+                <%= form.label "village[mailgun_api_key]", "Mailgun API Key", class: "form-label" %>
+                <%= form.text_field "village[mailgun_api_key]", value: @village.mailgun_api_key, class: "form-control", placeholder: "key-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" %>
+              </div>
+
+              <div class="mb-3">
+                <%= form.label "village[mailgun_domain]", "Mailgun Domain", class: "form-label" %>
+                <%= form.text_field "village[mailgun_domain]", value: @village.mailgun_domain, class: "form-control", placeholder: "mg.yourdomain.com" %>
+              </div>
+
+              <div class="mb-3">
+                <%= form.label "village[mailgun_region]", "Mailgun Region", class: "form-label" %>
+                <%= form.select "village[mailgun_region]", [["US", "us"], ["EU", "eu"]], { selected: @village.mailgun_region || "us" }, { class: "form-select" } %>
+              </div>
+            </div>
+
+            <div id="emailDisabledWarning" class="alert alert-warning <%= 'd-none' if @village.email_enabled? %>">
+              <strong>Email disabled:</strong> Users will not need to verify their email address, and no notification emails will be sent. Password reset will not work without email.
+            </div>
+
             <div class="d-grid">
               <%= form.submit "Complete Setup", class: "btn btn-primary btn-lg" %>
             </div>

--- a/config/initializers/mailgun.rb
+++ b/config/initializers/mailgun.rb
@@ -18,9 +18,11 @@ class MailgunDeliveryMethod
   end
 
   def deliver!(mail)
-    api_key = settings[:api_key] || ENV.fetch("MAILGUN_API_KEY", nil)
-    domain = settings[:domain] || ENV.fetch("MAILGUN_DOMAIN", nil)
-    region = settings[:region] || ENV.fetch("MAILGUN_REGION", "us")
+    # Try Village settings first, then fall back to environment variables
+    village_settings = village_mailgun_settings
+    api_key = village_settings[:api_key] || settings[:api_key] || ENV.fetch("MAILGUN_API_KEY", nil)
+    domain = village_settings[:domain] || settings[:domain] || ENV.fetch("MAILGUN_DOMAIN", nil)
+    region = village_settings[:region] || settings[:region] || ENV.fetch("MAILGUN_REGION", "us")
 
     raise ArgumentError, "Mailgun API key is required" if api_key.blank?
     raise ArgumentError, "Mailgun domain is required" if domain.blank?
@@ -56,6 +58,17 @@ class MailgunDeliveryMethod
 
     # Send the message
     mg_client.send_message(domain, message_builder)
+  end
+
+  private
+
+  def village_mailgun_settings
+    return {} unless defined?(Village) && Village.table_exists?
+
+    Village.mailgun_settings
+  rescue ActiveRecord::StatementInvalid
+    # Handle case where database isn't ready yet
+    {}
   end
 end
 

--- a/db/migrate/20251218024149_add_email_settings_to_villages.rb
+++ b/db/migrate/20251218024149_add_email_settings_to_villages.rb
@@ -1,0 +1,8 @@
+class AddEmailSettingsToVillages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :villages, :email_enabled, :boolean, default: false, null: false
+    add_column :villages, :mailgun_api_key, :string
+    add_column :villages, :mailgun_domain, :string
+    add_column :villages, :mailgun_region, :string, default: "us"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_15_035321) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_18_024149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -194,6 +194,10 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_15_035321) do
 
   create_table "villages", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.boolean "email_enabled", default: false, null: false
+    t.string "mailgun_api_key"
+    t.string "mailgun_domain"
+    t.string "mailgun_region", default: "us"
     t.string "name", null: false
     t.boolean "setup_complete", default: false, null: false
     t.datetime "updated_at", null: false

--- a/test/controllers/setup_controller_test.rb
+++ b/test/controllers/setup_controller_test.rb
@@ -86,4 +86,81 @@ class SetupControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to root_url
   end
+
+  test "should create village with email disabled" do
+    post setup_url, params: {
+      village: {
+        name: "Ham Radio Village",
+        email_enabled: "0"
+      },
+      user: {
+        email: "admin@example.com",
+        password: "password123",
+        password_confirmation: "password123"
+      }
+    }
+
+    village = Village.last
+    assert_not village.email_enabled?
+    assert_nil village.mailgun_api_key
+  end
+
+  test "should create village with email enabled and mailgun settings" do
+    post setup_url, params: {
+      village: {
+        name: "Ham Radio Village",
+        email_enabled: "1",
+        mailgun_api_key: "key-123456",
+        mailgun_domain: "mg.example.com",
+        mailgun_region: "us"
+      },
+      user: {
+        email: "admin@example.com",
+        password: "password123",
+        password_confirmation: "password123"
+      }
+    }
+
+    village = Village.last
+    assert village.email_enabled?
+    assert_equal "key-123456", village.mailgun_api_key
+    assert_equal "mg.example.com", village.mailgun_domain
+    assert_equal "us", village.mailgun_region
+  end
+
+  test "should fail if email enabled but mailgun settings missing" do
+    assert_no_difference [ "Village.count", "User.count" ] do
+      post setup_url, params: {
+        village: {
+          name: "Ham Radio Village",
+          email_enabled: "1"
+          # Missing mailgun_api_key and mailgun_domain
+        },
+        user: {
+          email: "admin@example.com",
+          password: "password123",
+          password_confirmation: "password123"
+        }
+      }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "user is auto-confirmed when email is disabled" do
+    post setup_url, params: {
+      village: {
+        name: "Ham Radio Village",
+        email_enabled: "0"
+      },
+      user: {
+        email: "admin@example.com",
+        password: "password123",
+        password_confirmation: "password123"
+      }
+    }
+
+    user = User.find_by(email: "admin@example.com")
+    assert user.confirmed?, "User should be auto-confirmed when email is disabled"
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -2,6 +2,16 @@ require "test_helper"
 
 class NotificationMailerTest < ActionMailer::TestCase
   setup do
+    # Create a village with email enabled for mailer tests
+    Village.destroy_all
+    @village = Village.create!(
+      name: "Test Village",
+      setup_complete: true,
+      email_enabled: true,
+      mailgun_api_key: "test-key",
+      mailgun_domain: "test.mailgun.org"
+    )
+
     @user = User.create!(
       email: "user@example.com",
       password: "password123",

--- a/test/models/village_test.rb
+++ b/test/models/village_test.rb
@@ -33,4 +33,89 @@ class VillageTest < ActiveSupport::TestCase
     qualification = Qualification.create!(name: "Test Qual", description: "Test description", village: village)
     assert_includes village.qualifications, qualification
   end
+
+  # Email configuration tests
+  test "email_enabled defaults to false" do
+    village = Village.new(name: "Test Village")
+    assert_not village.email_enabled?
+  end
+
+  test "mailgun_api_key required when email enabled" do
+    village = Village.new(name: "Test Village", email_enabled: true, mailgun_domain: "mg.example.com")
+    assert_not village.valid?
+    assert_includes village.errors[:mailgun_api_key], "can't be blank"
+  end
+
+  test "mailgun_domain required when email enabled" do
+    village = Village.new(name: "Test Village", email_enabled: true, mailgun_api_key: "key-123")
+    assert_not village.valid?
+    assert_includes village.errors[:mailgun_domain], "can't be blank"
+  end
+
+  test "mailgun settings not required when email disabled" do
+    village = Village.new(name: "Test Village", email_enabled: false)
+    assert village.valid?
+  end
+
+  test "valid with complete mailgun settings when email enabled" do
+    village = Village.new(
+      name: "Test Village",
+      email_enabled: true,
+      mailgun_api_key: "key-123",
+      mailgun_domain: "mg.example.com",
+      mailgun_region: "us"
+    )
+    assert village.valid?
+  end
+
+  test "mailgun_region must be us or eu" do
+    village = Village.new(name: "Test", mailgun_region: "invalid")
+    assert_not village.valid?
+    assert_includes village.errors[:mailgun_region], "is not included in the list"
+  end
+
+  test "email_enabled? class method returns false when no village" do
+    Village.destroy_all
+    assert_not Village.email_enabled?
+  end
+
+  test "email_enabled? class method returns false when setup incomplete" do
+    Village.destroy_all
+    Village.create!(name: "Test", setup_complete: false)
+    assert_not Village.email_enabled?
+  end
+
+  test "email_enabled? class method returns village setting" do
+    Village.destroy_all
+    Village.create!(
+      name: "Test",
+      setup_complete: true,
+      email_enabled: true,
+      mailgun_api_key: "key-123",
+      mailgun_domain: "mg.example.com"
+    )
+    assert Village.email_enabled?
+  end
+
+  test "mailgun_settings returns empty hash when no village" do
+    Village.destroy_all
+    assert_equal({}, Village.mailgun_settings)
+  end
+
+  test "mailgun_settings returns settings hash" do
+    Village.destroy_all
+    Village.create!(
+      name: "Test",
+      setup_complete: true,
+      email_enabled: true,
+      mailgun_api_key: "key-123",
+      mailgun_domain: "mg.example.com",
+      mailgun_region: "eu"
+    )
+
+    settings = Village.mailgun_settings
+    assert_equal "key-123", settings[:api_key]
+    assert_equal "mg.example.com", settings[:domain]
+    assert_equal "eu", settings[:region]
+  end
 end


### PR DESCRIPTION
## Summary
- Setup wizard now includes email configuration section
- Admin can enable email (with Mailgun settings) or disable it entirely
- When email disabled: users are auto-confirmed, no verification required
- Mailgun settings stored in Village model instead of only environment variables

## Changes
- Added `email_enabled`, `mailgun_api_key`, `mailgun_domain`, `mailgun_region` to Village model
- Setup view has toggle for enabling/disabling email with Mailgun config fields
- User model auto-confirms new users when email is disabled
- Mailgun initializer pulls settings from Village model
- Stimulus controller for toggle UI

## Test plan
- [ ] Run setup wizard with email disabled - verify user is auto-confirmed
- [ ] Run setup wizard with email enabled - verify Mailgun fields are required
- [ ] Verify validation fails if email enabled but Mailgun settings missing
- [ ] After setup, verify `Village.email_enabled?` returns correct value

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)