### PR TITLE
Add in-app notification system with inbox

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :handle, :phone, :twitter, :signal, :discord ])
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :handle, :phone, :twitter, :signal, :discord ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :handle, :phone, :twitter, :signal, :discord, :notify_by_email, :notify_in_app ])
   end
 
   private

--- a/app/controllers/notification_preferences_controller.rb
+++ b/app/controllers/notification_preferences_controller.rb
@@ -1,0 +1,17 @@
+class NotificationPreferencesController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    if current_user.update(notification_preferences_params)
+      redirect_to edit_user_registration_path, notice: "Notification preferences updated."
+    else
+      redirect_to edit_user_registration_path, alert: "Failed to update notification preferences."
+    end
+  end
+
+  private
+
+  def notification_preferences_params
+    params.require(:user).permit(:notify_by_email, :notify_in_app)
+  end
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,35 @@
+class NotificationsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_notification, only: [ :show, :destroy ]
+
+  def index
+    @notifications = current_user.notifications.recent.limit(100)
+    @unread_count = current_user.unread_notifications_count
+  end
+
+  def show
+    @notification.mark_as_read!
+  end
+
+  def mark_all_read
+    current_user.notifications.unread.update_all(read_at: Time.current)
+    redirect_to notifications_path, notice: "All notifications marked as read."
+  end
+
+  def destroy
+    @notification.destroy
+    redirect_to notifications_path, notice: "Notification deleted."
+  end
+
+  def bulk_destroy
+    notification_ids = params[:notification_ids] || []
+    current_user.notifications.where(id: notification_ids).destroy_all
+    redirect_to notifications_path, notice: "Selected notifications deleted."
+  end
+
+  private
+
+  def set_notification
+    @notification = current_user.notifications.find(params[:id])
+  end
+end

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -55,7 +55,7 @@ class ProgramsController < ApplicationController
 
     conferences_data = @program.conference_programs
       .joins(:conference)
-      .where("conferences.end_date >= ?", Date.today)
+      .where("conferences.end_date >= ?", Date.current)
       .includes(:conference, :timeslots)
       .map do |cp|
         timeslots_count = cp.timeslots.count

--- a/app/jobs/cleanup_old_notifications_job.rb
+++ b/app/jobs/cleanup_old_notifications_job.rb
@@ -1,0 +1,9 @@
+class CleanupOldNotificationsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    # Delete notifications that have been read more than 30 days ago
+    deleted_count = Notification.old_read.delete_all
+    Rails.logger.info "CleanupOldNotificationsJob: Deleted #{deleted_count} old notifications"
+  end
+end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -6,4 +6,17 @@ class NotificationMailer < ApplicationMailer
       subject: "Villagers Email Test"
     )
   end
+
+  def notification_email(user:, title:, body:, notification_type:)
+    @user = user
+    @title = title
+    @body = body
+    @notification_type = notification_type
+    @village_name = Village.first&.name || "Villagers"
+
+    mail(
+      to: @user.email,
+      subject: "[#{@village_name}] #{@title}"
+    )
+  end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -18,7 +18,7 @@ class Conference < ApplicationRecord
   # Archive scopes
   scope :active, -> { where(archived_at: nil) }
   scope :archived, -> { where.not(archived_at: nil) }
-  scope :past_unarchived, -> { where("end_date < ?", Date.today).where(archived_at: nil) }
+  scope :past_unarchived, -> { where("end_date < ?", Date.current).where(archived_at: nil) }
 
   # Archive methods
   def archived?
@@ -26,7 +26,7 @@ class Conference < ApplicationRecord
   end
 
   def archivable?
-    end_date < Date.today
+    end_date < Date.current
   end
 
   def archive!

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,42 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+
+  validates :title, presence: true
+  validates :body, presence: true
+  validates :notification_type, presence: true
+
+  # Notification types
+  SHIFT_SIGNUP = "shift_signup"
+  SHIFT_REMINDER = "shift_reminder"
+  SHIFT_CANCELLED = "shift_cancelled"
+  ADMIN_ALERT = "admin_alert"
+  SYSTEM = "system"
+
+  TYPES = [
+    SHIFT_SIGNUP,
+    SHIFT_REMINDER,
+    SHIFT_CANCELLED,
+    ADMIN_ALERT,
+    SYSTEM
+  ].freeze
+
+  validates :notification_type, inclusion: { in: TYPES }
+
+  # Scopes
+  scope :unread, -> { where(read_at: nil) }
+  scope :read, -> { where.not(read_at: nil) }
+  scope :recent, -> { order(created_at: :desc) }
+  scope :old_read, -> { read.where("read_at < ?", 30.days.ago) }
+
+  def read?
+    read_at.present?
+  end
+
+  def unread?
+    !read?
+  end
+
+  def mark_as_read!
+    update!(read_at: Time.current) if unread?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,8 @@ class User < ApplicationRecord
   # Volunteer signup associations
   has_many :volunteer_signups, dependent: :destroy
   has_many :timeslots, through: :volunteer_signups
+  # Notification associations
+  has_many :notifications, dependent: :destroy
 
   # Role checking methods
   def village_admin?
@@ -162,5 +164,22 @@ class User < ApplicationRecord
       .group("users.id")
       .order("shifts_count DESC")
       .limit(limit)
+  end
+
+  # Notification methods
+  def unread_notifications_count
+    notifications.unread.count
+  end
+
+  def has_unread_notifications?
+    unread_notifications_count > 0
+  end
+
+  def should_notify_by_email?
+    notify_by_email? && Village.email_enabled?
+  end
+
+  def should_notify_in_app?
+    notify_in_app?
   end
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,0 +1,86 @@
+class NotificationService
+  class << self
+    def notify_shift_signup(user:, timeslot:)
+      program_name = timeslot.conference_program.program.name
+      conference_name = timeslot.conference_program.conference.name
+      start_time = timeslot.start_time.strftime("%B %d, %Y at %l:%M %p")
+
+      send_notification(
+        user: user,
+        title: "Shift Signup Confirmed",
+        body: "You've signed up for a #{program_name} shift at #{conference_name} on #{start_time}.",
+        notification_type: Notification::SHIFT_SIGNUP
+      )
+    end
+
+    def notify_shift_cancelled(user:, timeslot:)
+      program_name = timeslot.conference_program.program.name
+      conference_name = timeslot.conference_program.conference.name
+      start_time = timeslot.start_time.strftime("%B %d, %Y at %l:%M %p")
+
+      send_notification(
+        user: user,
+        title: "Shift Cancelled",
+        body: "Your #{program_name} shift at #{conference_name} on #{start_time} has been cancelled.",
+        notification_type: Notification::SHIFT_CANCELLED
+      )
+    end
+
+    def notify_shift_reminder(user:, timeslot:, minutes_before: 60)
+      program_name = timeslot.conference_program.program.name
+      conference_name = timeslot.conference_program.conference.name
+      start_time = timeslot.start_time.strftime("%l:%M %p")
+
+      send_notification(
+        user: user,
+        title: "Shift Reminder",
+        body: "Your #{program_name} shift at #{conference_name} starts in #{minutes_before} minutes (#{start_time}).",
+        notification_type: Notification::SHIFT_REMINDER
+      )
+    end
+
+    def notify_admin_new_signup(admin:, volunteer:, timeslot:)
+      program_name = timeslot.conference_program.program.name
+      start_time = timeslot.start_time.strftime("%B %d at %l:%M %p")
+
+      send_notification(
+        user: admin,
+        title: "New Volunteer Signup",
+        body: "#{volunteer.email} signed up for #{program_name} on #{start_time}.",
+        notification_type: Notification::ADMIN_ALERT
+      )
+    end
+
+    def send_system_notification(user:, title:, body:)
+      send_notification(
+        user: user,
+        title: title,
+        body: body,
+        notification_type: Notification::SYSTEM
+      )
+    end
+
+    private
+
+    def send_notification(user:, title:, body:, notification_type:)
+      # Create in-app notification if user has it enabled
+      if user.should_notify_in_app?
+        user.notifications.create!(
+          title: title,
+          body: body,
+          notification_type: notification_type
+        )
+      end
+
+      # Send email notification if user has it enabled and email is configured
+      if user.should_notify_by_email?
+        NotificationMailer.notification_email(
+          user: user,
+          title: title,
+          body: body,
+          notification_type: notification_type
+        ).deliver_later
+      end
+    end
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -130,6 +130,29 @@
 
           <hr class="my-4">
 
+          <h5 class="mb-3">Notification Preferences</h5>
+          <div class="card border-info mb-4">
+            <div class="card-body">
+              <%= form_with url: notification_preferences_path, method: :patch, local: true do |f| %>
+                <div class="form-check mb-2">
+                  <%= hidden_field_tag "user[notify_in_app]", "0" %>
+                  <%= check_box_tag "user[notify_in_app]", "1", resource.notify_in_app?, class: "form-check-input", id: "notify_in_app" %>
+                  <%= label_tag :notify_in_app, "In-app notifications", class: "form-check-label" %>
+                  <div class="form-text">Receive notifications in your inbox within the app</div>
+                </div>
+                <div class="form-check mb-3">
+                  <%= hidden_field_tag "user[notify_by_email]", "0" %>
+                  <%= check_box_tag "user[notify_by_email]", "1", resource.notify_by_email?, class: "form-check-input", id: "notify_by_email" %>
+                  <%= label_tag :notify_by_email, "Email notifications", class: "form-check-label" %>
+                  <div class="form-text">Receive notifications via email<%= " (email is currently disabled)" unless Village.email_enabled? %></div>
+                </div>
+                <%= f.submit "Save Notification Preferences", class: "btn btn-outline-primary btn-sm" %>
+              <% end %>
+            </div>
+          </div>
+
+          <hr class="my-4">
+
           <h5 class="mb-3 text-danger">Danger Zone</h5>
           <div class="card border-danger">
             <div class="card-body">

--- a/app/views/notification_mailer/notification_email.html.erb
+++ b/app/views/notification_mailer/notification_email.html.erb
@@ -1,0 +1,10 @@
+<h1><%= @title %></h1>
+
+<p>Hello <%= @user.name.presence || @user.email %>,</p>
+
+<p><%= @body %></p>
+
+<p>
+  Best regards,<br>
+  The <%= @village_name %> Team
+</p>

--- a/app/views/notification_mailer/notification_email.text.erb
+++ b/app/views/notification_mailer/notification_email.text.erb
@@ -1,0 +1,8 @@
+<%= @title %>
+
+Hello <%= @user.name.presence || @user.email %>,
+
+<%= @body %>
+
+Best regards,
+The <%= @village_name %> Team

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,56 @@
+<div class="container mt-4">
+  <div class="row mb-4">
+    <div class="col-12">
+      <div class="d-flex justify-content-between align-items-center">
+        <h1 class="mb-0">
+          Inbox
+          <% if @unread_count > 0 %>
+            <span class="badge bg-danger"><%= @unread_count %> unread</span>
+          <% end %>
+        </h1>
+        <div>
+          <% if @notifications.any? { |n| n.unread? } %>
+            <%= link_to "Mark All Read", mark_all_read_notifications_path,
+                data: { turbo_method: :post },
+                class: "btn btn-outline-primary" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <% if @notifications.any? %>
+    <div class="card">
+      <div class="list-group list-group-flush">
+        <% @notifications.each do |notification| %>
+          <%= link_to notification_path(notification),
+              class: "list-group-item list-group-item-action #{'bg-light' if notification.unread?}" do %>
+            <div class="d-flex w-100 justify-content-between align-items-start">
+              <div>
+                <div class="d-flex align-items-center">
+                  <% if notification.unread? %>
+                    <span class="badge bg-primary me-2">New</span>
+                  <% end %>
+                  <h6 class="mb-1 <%= 'fw-bold' if notification.unread? %>">
+                    <%= notification.title %>
+                  </h6>
+                </div>
+                <p class="mb-1 text-muted small">
+                  <%= truncate(notification.body, length: 100) %>
+                </p>
+              </div>
+              <small class="text-muted text-nowrap ms-3">
+                <%= time_ago_in_words(notification.created_at) %> ago
+              </small>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      <h5>No Notifications</h5>
+      <p class="mb-0">You don't have any notifications yet.</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -1,0 +1,35 @@
+<div class="container mt-4">
+  <div class="row mb-4">
+    <div class="col-12">
+      <div class="d-flex align-items-center">
+        <%= link_to notifications_path, class: "btn btn-secondary btn-sm me-3" do %>
+          <span aria-hidden="true">&larr;</span> Back to Inbox
+        <% end %>
+        <h1 class="mb-0"><%= @notification.title %></h1>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-8">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <div>
+            <span class="badge bg-secondary"><%= @notification.notification_type.humanize %></span>
+            <small class="text-muted ms-2">
+              <%= @notification.created_at.strftime("%B %d, %Y at %l:%M %p") %>
+            </small>
+          </div>
+          <%= link_to "Delete", notification_path(@notification),
+              data: { turbo_method: :delete, turbo_confirm: "Delete this notification?" },
+              class: "btn btn-sm btn-outline-danger" %>
+        </div>
+        <div class="card-body">
+          <div class="notification-body">
+            <%= simple_format(@notification.body) %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -85,6 +85,14 @@
             </li>
           <% end %>
           <li class="nav-item">
+            <%= link_to notifications_path, class: "nav-link" do %>
+              Inbox
+              <% if current_user.has_unread_notifications? %>
+                <span class="badge bg-danger"><%= current_user.unread_notifications_count %></span>
+              <% end %>
+            <% end %>
+          </li>
+          <li class="nav-item">
             <%= link_to "Profile", edit_user_registration_path, class: "nav-link" %>
           </li>
           <li class="nav-item">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,17 @@ Rails.application.routes.draw do
   # Volunteer history
   resources :volunteer_history, only: [ :index, :show ]
 
+  # Notifications / Inbox
+  resources :notifications, only: [ :index, :show, :destroy ] do
+    collection do
+      post :mark_all_read
+      delete :bulk_destroy
+    end
+  end
+
+  # Notification preferences (doesn't require password like Devise profile updates)
+  resource :notification_preferences, only: [ :update ]
+
   # Defines the root path route ("/")
   root "root#show"
 end

--- a/db/migrate/20251218030649_create_notifications.rb
+++ b/db/migrate/20251218030649_create_notifications.rb
@@ -1,0 +1,18 @@
+class CreateNotifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :body, null: false
+      t.string :notification_type, null: false
+      t.datetime :read_at
+
+      t.timestamps
+    end
+
+    # Index for fetching user's notifications ordered by date
+    add_index :notifications, [ :user_id, :created_at ], order: { created_at: :desc }
+    # Index for cleanup job (find read notifications older than 30 days)
+    add_index :notifications, :read_at
+  end
+end

--- a/db/migrate/20251218030709_add_notification_preferences_to_users.rb
+++ b/db/migrate/20251218030709_add_notification_preferences_to_users.rb
@@ -1,0 +1,6 @@
+class AddNotificationPreferencesToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :notify_by_email, :boolean, default: true, null: false
+    add_column :users, :notify_in_app, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_18_024149) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_18_030709) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -72,6 +72,19 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_18_024149) do
     t.datetime "updated_at", null: false
     t.bigint "village_id", null: false
     t.index ["village_id"], name: "index_conferences_on_village_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.string "notification_type", null: false
+    t.datetime "read_at"
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["read_at"], name: "index_notifications_on_read_at"
+    t.index ["user_id", "created_at"], name: "index_notifications_on_user_id_and_created_at", order: { created_at: :desc }
+    t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 
   create_table "program_qualifications", force: :cascade do |t|
@@ -179,6 +192,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_18_024149) do
     t.string "encrypted_password", default: "", null: false
     t.string "handle"
     t.string "name"
+    t.boolean "notify_by_email", default: true, null: false
+    t.boolean "notify_in_app", default: true, null: false
     t.string "phone"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
@@ -221,6 +236,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_18_024149) do
   add_foreign_key "conference_user_qualifications", "conference_qualifications"
   add_foreign_key "conference_user_qualifications", "users"
   add_foreign_key "conferences", "villages"
+  add_foreign_key "notifications", "users"
   add_foreign_key "program_qualifications", "programs"
   add_foreign_key "program_qualifications", "qualifications"
   add_foreign_key "program_roles", "programs"

--- a/test/controllers/notification_preferences_controller_test.rb
+++ b/test/controllers/notification_preferences_controller_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class NotificationPreferencesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @user = User.create!(
+      email: "test@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    sign_in @user
+  end
+
+  test "should update notification preferences to enable both" do
+    @user.update!(notify_by_email: false, notify_in_app: false)
+
+    patch notification_preferences_path, params: {
+      user: { notify_by_email: "1", notify_in_app: "1" }
+    }
+
+    assert_redirected_to edit_user_registration_path
+    assert_equal "Notification preferences updated.", flash[:notice]
+
+    @user.reload
+    assert @user.notify_by_email?
+    assert @user.notify_in_app?
+  end
+
+  test "should update notification preferences to disable both" do
+    @user.update!(notify_by_email: true, notify_in_app: true)
+
+    patch notification_preferences_path, params: {
+      user: { notify_by_email: "0", notify_in_app: "0" }
+    }
+
+    assert_redirected_to edit_user_registration_path
+    assert_equal "Notification preferences updated.", flash[:notice]
+
+    @user.reload
+    assert_not @user.notify_by_email?
+    assert_not @user.notify_in_app?
+  end
+
+  test "should update notification preferences to enable only in-app" do
+    patch notification_preferences_path, params: {
+      user: { notify_by_email: "0", notify_in_app: "1" }
+    }
+
+    assert_redirected_to edit_user_registration_path
+
+    @user.reload
+    assert_not @user.notify_by_email?
+    assert @user.notify_in_app?
+  end
+
+  test "should update notification preferences to enable only email" do
+    patch notification_preferences_path, params: {
+      user: { notify_by_email: "1", notify_in_app: "0" }
+    }
+
+    assert_redirected_to edit_user_registration_path
+
+    @user.reload
+    assert @user.notify_by_email?
+    assert_not @user.notify_in_app?
+  end
+
+  test "requires authentication" do
+    sign_out @user
+    patch notification_preferences_path, params: {
+      user: { notify_by_email: "1", notify_in_app: "1" }
+    }
+    assert_redirected_to new_user_session_path
+  end
+end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,0 +1,139 @@
+require "test_helper"
+
+class NotificationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @user = User.create!(
+      email: "test@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    @other_user = User.create!(
+      email: "other@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    @notification = @user.notifications.create!(
+      title: "Test Notification",
+      body: "Test notification body",
+      notification_type: Notification::SYSTEM
+    )
+    sign_in @user
+  end
+
+  test "should get index" do
+    get notifications_path
+    assert_response :success
+    assert_select "h1", /Inbox/
+  end
+
+  test "index shows unread count badge" do
+    @user.notifications.create!(
+      title: "Unread Notification",
+      body: "Unread body",
+      notification_type: Notification::SYSTEM
+    )
+    get notifications_path
+    assert_response :success
+    # Should show badge with count
+    assert_select ".badge.bg-danger"
+  end
+
+  test "index does not show unread badge when all read" do
+    @user.notifications.update_all(read_at: Time.current)
+    get notifications_path
+    assert_response :success
+    # Should not show the unread badge in the title area
+    assert_select "h1 .badge.bg-danger", count: 0
+  end
+
+  test "should get show and mark notification as read" do
+    assert_nil @notification.read_at
+    get notification_path(@notification)
+    assert_response :success
+    @notification.reload
+    assert_not_nil @notification.read_at
+  end
+
+  test "show displays notification details" do
+    get notification_path(@notification)
+    assert_response :success
+    assert_select "h1", @notification.title
+    assert_select ".notification-body", /#{@notification.body}/
+  end
+
+  test "should mark all notifications as read" do
+    unread1 = @user.notifications.create!(title: "Unread 1", body: "Body", notification_type: Notification::SYSTEM)
+    unread2 = @user.notifications.create!(title: "Unread 2", body: "Body", notification_type: Notification::SYSTEM)
+
+    assert_nil unread1.read_at
+    assert_nil unread2.read_at
+
+    post mark_all_read_notifications_path
+    assert_redirected_to notifications_path
+    assert_equal "All notifications marked as read.", flash[:notice]
+
+    unread1.reload
+    unread2.reload
+    assert_not_nil unread1.read_at
+    assert_not_nil unread2.read_at
+  end
+
+  test "should destroy notification" do
+    assert_difference("Notification.count", -1) do
+      delete notification_path(@notification)
+    end
+    assert_redirected_to notifications_path
+    assert_equal "Notification deleted.", flash[:notice]
+  end
+
+  test "should bulk destroy notifications" do
+    notification2 = @user.notifications.create!(
+      title: "Another Notification",
+      body: "Another body",
+      notification_type: Notification::SYSTEM
+    )
+
+    assert_difference("Notification.count", -2) do
+      delete bulk_destroy_notifications_path, params: { notification_ids: [ @notification.id, notification2.id ] }
+    end
+    assert_redirected_to notifications_path
+    assert_equal "Selected notifications deleted.", flash[:notice]
+  end
+
+  test "cannot access other user notifications" do
+    other_notification = @other_user.notifications.create!(
+      title: "Other User Notification",
+      body: "Body",
+      notification_type: Notification::SYSTEM
+    )
+
+    get notification_path(other_notification)
+    assert_response :not_found
+  end
+
+  test "cannot destroy other user notifications" do
+    other_notification = @other_user.notifications.create!(
+      title: "Other User Notification",
+      body: "Body",
+      notification_type: Notification::SYSTEM
+    )
+
+    assert_no_difference("Notification.count") do
+      delete notification_path(other_notification)
+    end
+    assert_response :not_found
+  end
+
+  test "requires authentication for index" do
+    sign_out @user
+    get notifications_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "requires authentication for show" do
+    sign_out @user
+    get notification_path(@notification)
+    assert_redirected_to new_user_session_path
+  end
+end

--- a/test/controllers/programs_controller_test.rb
+++ b/test/controllers/programs_controller_test.rb
@@ -190,8 +190,8 @@ class ProgramsControllerTest < ActionDispatch::IntegrationTest
     past_conference = Conference.create!(
       name: "Past Conference",
       village: @village,
-      start_date: Date.yesterday - 5.days,
-      end_date: Date.yesterday,
+      start_date: 6.days.ago.to_date,
+      end_date: 1.day.ago.to_date,
       conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
       conference_hours_end: Time.zone.parse("2000-01-01 12:00")
     )

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,2 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# Notifications are created dynamically in tests

--- a/test/jobs/cleanup_old_notifications_job_test.rb
+++ b/test/jobs/cleanup_old_notifications_job_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class CleanupOldNotificationsJobTest < ActiveJob::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @user = User.create!(
+      email: "test@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  test "deletes read notifications older than 30 days" do
+    old_read = @user.notifications.create!(
+      title: "Old Read",
+      body: "Old read notification",
+      notification_type: Notification::SYSTEM,
+      read_at: 31.days.ago
+    )
+
+    assert_difference("Notification.count", -1) do
+      CleanupOldNotificationsJob.perform_now
+    end
+
+    assert_not Notification.exists?(old_read.id)
+  end
+
+  test "does not delete read notifications less than 30 days old" do
+    new_read = @user.notifications.create!(
+      title: "New Read",
+      body: "New read notification",
+      notification_type: Notification::SYSTEM,
+      read_at: 29.days.ago
+    )
+
+    assert_no_difference("Notification.count") do
+      CleanupOldNotificationsJob.perform_now
+    end
+
+    assert Notification.exists?(new_read.id)
+  end
+
+  test "does not delete unread notifications" do
+    unread = @user.notifications.create!(
+      title: "Unread",
+      body: "Unread notification",
+      notification_type: Notification::SYSTEM
+    )
+
+    assert_no_difference("Notification.count") do
+      CleanupOldNotificationsJob.perform_now
+    end
+
+    assert Notification.exists?(unread.id)
+  end
+
+  test "deletes multiple old notifications" do
+    3.times do |i|
+      @user.notifications.create!(
+        title: "Old Read #{i}",
+        body: "Old read notification",
+        notification_type: Notification::SYSTEM,
+        read_at: (31 + i).days.ago
+      )
+    end
+
+    assert_difference("Notification.count", -3) do
+      CleanupOldNotificationsJob.perform_now
+    end
+  end
+end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -63,4 +63,65 @@ class NotificationMailerTest < ActionMailer::TestCase
       NotificationMailer.test_email(@user).deliver_now
     end
   end
+
+  test "notification_email sends to correct recipient" do
+    email = NotificationMailer.notification_email(
+      user: @user,
+      title: "Test Title",
+      body: "Test body",
+      notification_type: Notification::SYSTEM
+    )
+
+    assert_equal [ @user.email ], email.to
+  end
+
+  test "notification_email has correct subject with village name" do
+    email = NotificationMailer.notification_email(
+      user: @user,
+      title: "Test Title",
+      body: "Test body",
+      notification_type: Notification::SYSTEM
+    )
+
+    assert_equal "[#{@village.name}] Test Title", email.subject
+  end
+
+  test "notification_email body contains title and body" do
+    email = NotificationMailer.notification_email(
+      user: @user,
+      title: "Test Title",
+      body: "Test notification body content",
+      notification_type: Notification::SYSTEM
+    )
+
+    assert_match "Test Title", email.html_part.body.to_s
+    assert_match "Test notification body content", email.html_part.body.to_s
+    assert_match "Test Title", email.text_part.body.to_s
+    assert_match "Test notification body content", email.text_part.body.to_s
+  end
+
+  test "notification_email body contains user greeting" do
+    email = NotificationMailer.notification_email(
+      user: @user,
+      title: "Test Title",
+      body: "Test body",
+      notification_type: Notification::SYSTEM
+    )
+
+    assert_match @user.name, email.html_part.body.to_s
+    assert_match @user.name, email.text_part.body.to_s
+  end
+
+  test "notification_email uses email when user has no name" do
+    @user.update!(name: nil)
+    email = NotificationMailer.notification_email(
+      user: @user,
+      title: "Test Title",
+      body: "Test body",
+      notification_type: Notification::SYSTEM
+    )
+
+    assert_match @user.email, email.html_part.body.to_s
+    assert_match @user.email, email.text_part.body.to_s
+  end
 end

--- a/test/models/conference_test.rb
+++ b/test/models/conference_test.rb
@@ -200,8 +200,8 @@ class ConferenceTest < ActiveSupport::TestCase
     past_conference = Conference.create!(
       village: @village,
       name: "Past Conference",
-      start_date: Date.yesterday - 5.days,
-      end_date: Date.yesterday
+      start_date: 6.days.ago.to_date,
+      end_date: 1.day.ago.to_date
     )
     assert past_conference.archivable?
   end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,153 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @user = User.create!(
+      email: "test@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  test "valid notification with required attributes" do
+    notification = Notification.new(
+      user: @user,
+      title: "Test Notification",
+      body: "This is a test notification body",
+      notification_type: Notification::SHIFT_SIGNUP
+    )
+    assert notification.valid?
+  end
+
+  test "invalid without user" do
+    notification = Notification.new(
+      title: "Test",
+      body: "Test body",
+      notification_type: Notification::SHIFT_SIGNUP
+    )
+    assert_not notification.valid?
+    assert_includes notification.errors[:user], "must exist"
+  end
+
+  test "invalid without title" do
+    notification = Notification.new(
+      user: @user,
+      body: "Test body",
+      notification_type: Notification::SHIFT_SIGNUP
+    )
+    assert_not notification.valid?
+    assert_includes notification.errors[:title], "can't be blank"
+  end
+
+  test "invalid without body" do
+    notification = Notification.new(
+      user: @user,
+      title: "Test",
+      notification_type: Notification::SHIFT_SIGNUP
+    )
+    assert_not notification.valid?
+    assert_includes notification.errors[:body], "can't be blank"
+  end
+
+  test "invalid without notification_type" do
+    notification = Notification.new(
+      user: @user,
+      title: "Test",
+      body: "Test body"
+    )
+    assert_not notification.valid?
+    assert_includes notification.errors[:notification_type], "can't be blank"
+  end
+
+  test "invalid with unknown notification_type" do
+    notification = Notification.new(
+      user: @user,
+      title: "Test",
+      body: "Test body",
+      notification_type: "invalid_type"
+    )
+    assert_not notification.valid?
+    assert_includes notification.errors[:notification_type], "is not included in the list"
+  end
+
+  test "unread scope returns notifications without read_at" do
+    @user.notifications.create!(title: "Read", body: "Read notification", notification_type: Notification::SYSTEM, read_at: Time.current)
+    unread = @user.notifications.create!(title: "Unread", body: "Unread notification", notification_type: Notification::SYSTEM)
+
+    assert_includes Notification.unread, unread
+    assert_not_includes Notification.unread, @user.notifications.where(title: "Read").first
+  end
+
+  test "read scope returns notifications with read_at" do
+    read = @user.notifications.create!(title: "Read", body: "Read notification", notification_type: Notification::SYSTEM, read_at: Time.current)
+    @user.notifications.create!(title: "Unread", body: "Unread notification", notification_type: Notification::SYSTEM)
+
+    assert_includes Notification.read, read
+  end
+
+  test "recent scope orders by created_at desc" do
+    older = @user.notifications.create!(title: "Older", body: "Older notification", notification_type: Notification::SYSTEM, created_at: 1.day.ago)
+    newer = @user.notifications.create!(title: "Newer", body: "Newer notification", notification_type: Notification::SYSTEM, created_at: Time.current)
+
+    notifications = @user.notifications.recent
+    assert_equal newer, notifications.first
+    assert_equal older, notifications.second
+  end
+
+  test "old_read scope returns read notifications older than 30 days" do
+    old_read = @user.notifications.create!(title: "Old Read", body: "Old read notification", notification_type: Notification::SYSTEM, read_at: 31.days.ago)
+    new_read = @user.notifications.create!(title: "New Read", body: "New read notification", notification_type: Notification::SYSTEM, read_at: 1.day.ago)
+    unread = @user.notifications.create!(title: "Unread", body: "Unread notification", notification_type: Notification::SYSTEM)
+
+    old_read_notifications = Notification.old_read
+    assert_includes old_read_notifications, old_read
+    assert_not_includes old_read_notifications, new_read
+    assert_not_includes old_read_notifications, unread
+  end
+
+  test "read? returns true when read_at is present" do
+    notification = @user.notifications.create!(title: "Read", body: "Read notification", notification_type: Notification::SYSTEM, read_at: Time.current)
+    assert notification.read?
+  end
+
+  test "read? returns false when read_at is nil" do
+    notification = @user.notifications.create!(title: "Unread", body: "Unread notification", notification_type: Notification::SYSTEM)
+    assert_not notification.read?
+  end
+
+  test "unread? returns true when read_at is nil" do
+    notification = @user.notifications.create!(title: "Unread", body: "Unread notification", notification_type: Notification::SYSTEM)
+    assert notification.unread?
+  end
+
+  test "unread? returns false when read_at is present" do
+    notification = @user.notifications.create!(title: "Read", body: "Read notification", notification_type: Notification::SYSTEM, read_at: Time.current)
+    assert_not notification.unread?
+  end
+
+  test "mark_as_read! sets read_at when unread" do
+    notification = @user.notifications.create!(title: "Unread", body: "Unread notification", notification_type: Notification::SYSTEM)
+    assert_nil notification.read_at
+
+    notification.mark_as_read!
+    notification.reload
+
+    assert_not_nil notification.read_at
+    assert notification.read?
+  end
+
+  test "mark_as_read! does not update read_at when already read" do
+    original_read_at = 1.day.ago
+    notification = @user.notifications.create!(title: "Read", body: "Read notification", notification_type: Notification::SYSTEM, read_at: original_read_at)
+
+    notification.mark_as_read!
+    notification.reload
+
+    assert_in_delta original_read_at.to_i, notification.read_at.to_i, 1
+  end
+
+  test "all notification types are defined" do
+    assert_equal [ "shift_signup", "shift_reminder", "shift_cancelled", "admin_alert", "system" ], Notification::TYPES
+  end
+end

--- a/test/services/notification_service_test.rb
+++ b/test/services/notification_service_test.rb
@@ -1,0 +1,150 @@
+require "test_helper"
+
+class NotificationServiceTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @user = User.create!(
+      email: "test@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    @admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 2.days,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+
+    @program = Program.create!(
+      name: "Test Program",
+      village: @village
+    )
+
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program
+    )
+
+    @timeslot = Timeslot.create!(
+      conference_program: @conference_program,
+      start_time: Date.tomorrow.to_datetime + 9.hours,
+      max_volunteers: 2
+    )
+  end
+
+  test "notify_shift_signup creates in-app notification when enabled" do
+    @user.update!(notify_in_app: true, notify_by_email: false)
+
+    assert_difference("Notification.count", 1) do
+      NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+    end
+
+    notification = @user.notifications.last
+    assert_equal "Shift Signup Confirmed", notification.title
+    assert_includes notification.body, @program.name
+    assert_includes notification.body, @conference.name
+    assert_equal Notification::SHIFT_SIGNUP, notification.notification_type
+  end
+
+  test "notify_shift_signup sends email when enabled and email configured" do
+    @village.update!(email_enabled: true, mailgun_api_key: "test-key", mailgun_domain: "test.mailgun.org")
+    @user.update!(notify_in_app: false, notify_by_email: true)
+
+    assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+      NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+    end
+  end
+
+  test "notify_shift_signup does not send email when email disabled globally" do
+    @village.update!(email_enabled: false)
+    @user.update!(notify_in_app: false, notify_by_email: true)
+
+    assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+    end
+  end
+
+  test "notify_shift_signup creates both in-app and email when both enabled" do
+    @village.update!(email_enabled: true, mailgun_api_key: "test-key", mailgun_domain: "test.mailgun.org")
+    @user.update!(notify_in_app: true, notify_by_email: true)
+
+    assert_difference("Notification.count", 1) do
+      assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+        NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+      end
+    end
+  end
+
+  test "notify_shift_cancelled creates notification" do
+    @user.update!(notify_in_app: true, notify_by_email: false)
+
+    assert_difference("Notification.count", 1) do
+      NotificationService.notify_shift_cancelled(user: @user, timeslot: @timeslot)
+    end
+
+    notification = @user.notifications.last
+    assert_equal "Shift Cancelled", notification.title
+    assert_equal Notification::SHIFT_CANCELLED, notification.notification_type
+  end
+
+  test "notify_shift_reminder creates notification" do
+    @user.update!(notify_in_app: true, notify_by_email: false)
+
+    assert_difference("Notification.count", 1) do
+      NotificationService.notify_shift_reminder(user: @user, timeslot: @timeslot, minutes_before: 30)
+    end
+
+    notification = @user.notifications.last
+    assert_equal "Shift Reminder", notification.title
+    assert_includes notification.body, "30 minutes"
+    assert_equal Notification::SHIFT_REMINDER, notification.notification_type
+  end
+
+  test "notify_admin_new_signup creates notification for admin" do
+    @admin.update!(notify_in_app: true, notify_by_email: false)
+
+    assert_difference("Notification.count", 1) do
+      NotificationService.notify_admin_new_signup(admin: @admin, volunteer: @user, timeslot: @timeslot)
+    end
+
+    notification = @admin.notifications.last
+    assert_equal "New Volunteer Signup", notification.title
+    assert_includes notification.body, @user.email
+    assert_equal Notification::ADMIN_ALERT, notification.notification_type
+  end
+
+  test "send_system_notification creates notification" do
+    @user.update!(notify_in_app: true, notify_by_email: false)
+
+    assert_difference("Notification.count", 1) do
+      NotificationService.send_system_notification(
+        user: @user,
+        title: "System Alert",
+        body: "Important system message"
+      )
+    end
+
+    notification = @user.notifications.last
+    assert_equal "System Alert", notification.title
+    assert_equal "Important system message", notification.body
+    assert_equal Notification::SYSTEM, notification.notification_type
+  end
+
+  test "does not create in-app notification when disabled" do
+    @user.update!(notify_in_app: false, notify_by_email: false)
+
+    assert_no_difference("Notification.count") do
+      NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,9 +5,9 @@ require "rails/test_help"
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers
-    # Disabled (threshold: 500) due to Devise mapping race conditions with parallel processes
-    # TODO: Re-enable when Devise fixes parallel test support or we have 500+ tests
-    parallelize(workers: :number_of_processors, threshold: 500)
+    # Disabled (threshold: 1000) due to Devise mapping race conditions with parallel processes
+    # TODO: Re-enable when Devise fixes parallel test support or we have 1000+ tests
+    parallelize(workers: :number_of_processors, threshold: 1000)
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all


### PR DESCRIPTION
## Summary
- Create Notification model with types: shift_signup, shift_reminder, shift_cancelled, admin_alert, system
- Add notification preferences (notify_by_email, notify_in_app) to User model
- Create NotificationsController with inbox, show, mark_all_read, destroy, bulk_destroy actions
- Add inbox link with unread badge to navbar
- Add notification preferences section to profile page
- Create NotificationService for sending notifications (in-app and email)
- Create CleanupOldNotificationsJob to delete read notifications after 30 days
- Add NotificationMailer for email notifications
- Fix Date.today vs Date.current timezone issues in Conference model
- Increase test parallelization threshold to avoid Devise race conditions

## Test plan
- [ ] Verify inbox link appears in navbar with unread count badge
- [ ] Create a notification and verify it appears in inbox
- [ ] Click notification to view details and verify it's marked as read
- [ ] Test "Mark All Read" functionality
- [ ] Test delete notification functionality
- [ ] Verify notification preferences appear on profile page
- [ ] Toggle notification preferences and verify they save correctly
- [ ] Verify NotificationService creates in-app notifications when enabled
- [ ] Verify email is sent when email notifications enabled and email configured

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)