### PR TITLE
Fix schedule page UI alignment between program columns

### DIFF
--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -71,8 +71,9 @@
                     <td class="<%= cell_class %>">
                       <% if slot_data %>
                         <% is_user_signed_up = @user_signups.include?(slot_data[:timeslot].id) %>
-                        <div class="schedule-slot">
-                          <div class="d-flex align-items-center justify-content-between flex-wrap gap-1">
+                        <div class="schedule-slot d-flex flex-column h-100">
+                          <%# Status bar - always at top %>
+                          <div class="slot-status d-flex align-items-center justify-content-between flex-wrap gap-1">
                             <div class="d-flex align-items-center flex-wrap gap-1">
                               <% if is_user_signed_up %>
                                 <span class="badge bg-primary">You're signed up</span>
@@ -109,7 +110,8 @@
                           </div>
 
                           <% if @can_see_all_volunteers %>
-                            <div class="volunteer-list mt-1">
+                            <%# Volunteer list - fills available space %>
+                            <div class="volunteer-list flex-grow-1 mt-1">
                               <% slot_data[:volunteers].each do |volunteer| %>
                                 <div class="d-flex justify-content-between align-items-center mb-2">
                                   <small class="text-truncate" title="<%= volunteer.email %>">
@@ -123,7 +125,8 @@
                               <% end %>
                             </div>
 
-                            <div class="admin-controls mt-2 pt-2 border-top">
+                            <%# Admin controls - always at bottom %>
+                            <div class="admin-controls mt-auto pt-2 border-top">
                               <% unless slot_data[:full] %>
                                 <%= form_with url: add_volunteer_conference_timeslot_path(@conference, slot_data[:timeslot]), method: :post, local: true, class: "d-flex gap-1 mb-2" do |form| %>
                                   <% available_users = @users - slot_data[:volunteers] %>
@@ -243,9 +246,10 @@
   }
 
   .schedule-cell {
-    vertical-align: middle;
+    vertical-align: top;
     padding: 0.5rem !important;
     border: 4px solid #fff !important;
+    height: 1px; /* Trick to make td respect height for flexbox children */
   }
 
   .schedule-cell.user-signed-up {
@@ -275,6 +279,7 @@
 
   .schedule-slot {
     padding: 0;
+    min-height: 100%;
   }
 
   .volunteer-list {


### PR DESCRIPTION
## Summary
- Use flexbox layout on schedule slot content to ensure consistent positioning
- Admin controls (Add volunteer dropdown, Edit Capacity button) now anchor at the bottom of each cell
- Volunteer list fills available vertical space between status badges and controls
- All cells in a row now have consistent control positioning regardless of content

## Test plan
- [ ] View schedule page with 2 programs where one has volunteers and one doesn't
- [ ] Verify "Add volunteer..." dropdown and "Edit Capacity" button align horizontally across columns
- [ ] Verify alignment works with varying numbers of volunteers in different columns
- [ ] Verify alignment works on conferences with 3+ programs

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)