### PR TITLE
Add shift signup confirmation emails

### DIFF
--- a/app/controllers/volunteer_signups_controller.rb
+++ b/app/controllers/volunteer_signups_controller.rb
@@ -18,6 +18,7 @@ class VolunteerSignupsController < ApplicationController
     @volunteer_signup = VolunteerSignup.new(user: current_user, timeslot: @timeslot)
 
     if @volunteer_signup.save
+      NotificationService.notify_shift_signups(user: current_user, signups: [ @volunteer_signup ])
       redirect_to conference_volunteer_signups_path(@timeslot.conference), notice: "Successfully signed up for this shift."
     else
       redirect_to conference_volunteer_signups_path(@timeslot.conference), alert: @volunteer_signup.errors.full_messages.join(", ")
@@ -58,18 +59,22 @@ class VolunteerSignupsController < ApplicationController
     end
 
     # Create signups in a transaction
-    created_count = 0
+    created_signups = []
     ActiveRecord::Base.transaction do
       timeslots_to_signup.each do |timeslot|
         signup = VolunteerSignup.new(user: current_user, timeslot: timeslot)
         if signup.save
-          created_count += 1
+          created_signups << signup
         else
           raise ActiveRecord::Rollback, signup.errors.full_messages.join(", ")
         end
       end
     end
 
+    # Send single consolidated notification for all signups
+    NotificationService.notify_shift_signups(user: current_user, signups: created_signups) if created_signups.any?
+
+    created_count = created_signups.size
     total_minutes = created_count * 15
     hours = total_minutes / 60
     minutes = total_minutes % 60

--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -1,0 +1,45 @@
+class VolunteerMailer < ApplicationMailer
+  def shift_signup_confirmation(user:, signups:, conference:)
+    @user = user
+    @signups = signups
+    @conference = conference
+    @village_name = Village.first&.name || "Villagers"
+
+    # Group signups by program for easier display
+    @grouped_signups = group_signups_by_program(signups)
+
+    # Calculate total duration
+    @total_minutes = signups.size * 15
+    @duration_display = format_duration(@total_minutes)
+
+    mail(
+      to: @user.email,
+      subject: "[#{@village_name}] Shift Signup Confirmation - #{@conference.name}"
+    )
+  end
+
+  private
+
+  def group_signups_by_program(signups)
+    signups.group_by { |s| s.timeslot.conference_program.program.name }.map do |program_name, program_signups|
+      sorted = program_signups.sort_by { |s| s.timeslot.start_time }
+      {
+        program_name: program_name,
+        start_time: sorted.first.timeslot.start_time,
+        end_time: sorted.last.timeslot.start_time + 15.minutes,
+        date: sorted.first.timeslot.start_time.to_date,
+        slot_count: sorted.size
+      }
+    end
+  end
+
+  def format_duration(minutes)
+    hours = minutes / 60
+    mins = minutes % 60
+
+    parts = []
+    parts << "#{hours} hour#{'s' if hours != 1}" if hours > 0
+    parts << "#{mins} minute#{'s' if mins != 1}" if mins > 0
+    parts.join(" ")
+  end
+end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,16 +1,45 @@
 class NotificationService
   class << self
     def notify_shift_signup(user:, timeslot:)
-      program_name = timeslot.conference_program.program.name
-      conference_name = timeslot.conference_program.conference.name
-      start_time = timeslot.start_time.strftime("%B %d, %Y at %l:%M %p")
+      notify_shift_signups(user: user, signups: [ timeslot.volunteer_signups.find_by(user: user) ].compact)
+    end
 
-      send_notification(
-        user: user,
-        title: "Shift Signup Confirmed",
-        body: "You've signed up for a #{program_name} shift at #{conference_name} on #{start_time}.",
-        notification_type: Notification::SHIFT_SIGNUP
-      )
+    def notify_shift_signups(user:, signups:)
+      return if signups.empty?
+
+      first_signup = signups.first
+      conference = first_signup.timeslot.conference_program.conference
+      program_name = first_signup.timeslot.conference_program.program.name
+
+      if signups.size == 1
+        start_time = first_signup.timeslot.start_time.strftime("%B %d, %Y at %l:%M %p")
+        body = "You've signed up for a #{program_name} shift at #{conference.name} on #{start_time}."
+      else
+        total_minutes = signups.size * 15
+        hours = total_minutes / 60
+        mins = total_minutes % 60
+        duration = hours > 0 ? "#{hours} hour#{'s' if hours != 1}" : ""
+        duration += " #{mins} minute#{'s' if mins != 1}" if mins > 0
+        body = "You've signed up for #{signups.size} shifts (#{duration.strip}) at #{conference.name}."
+      end
+
+      # Create in-app notification
+      if user.should_notify_in_app?
+        user.notifications.create!(
+          title: "Shift Signup Confirmed",
+          body: body,
+          notification_type: Notification::SHIFT_SIGNUP
+        )
+      end
+
+      # Send detailed email confirmation
+      if user.should_notify_by_email?
+        VolunteerMailer.shift_signup_confirmation(
+          user: user,
+          signups: signups,
+          conference: conference
+        ).deliver_later
+      end
     end
 
     def notify_shift_cancelled(user:, timeslot:)

--- a/app/views/volunteer_mailer/shift_signup_confirmation.html.erb
+++ b/app/views/volunteer_mailer/shift_signup_confirmation.html.erb
@@ -1,0 +1,49 @@
+<h1>Shift Signup Confirmed!</h1>
+
+<p>Hello <%= @user.name.presence || @user.email %>,</p>
+
+<p>Thank you for signing up to volunteer at <strong><%= @conference.name %></strong>!</p>
+
+<h2>Your Shift Details</h2>
+
+<table style="border-collapse: collapse; width: 100%; max-width: 600px;">
+  <thead>
+    <tr style="background-color: #f8f9fa;">
+      <th style="padding: 10px; text-align: left; border: 1px solid #dee2e6;">Program</th>
+      <th style="padding: 10px; text-align: left; border: 1px solid #dee2e6;">Date</th>
+      <th style="padding: 10px; text-align: left; border: 1px solid #dee2e6;">Time</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @grouped_signups.each do |shift| %>
+      <tr>
+        <td style="padding: 10px; border: 1px solid #dee2e6;"><%= shift[:program_name] %></td>
+        <td style="padding: 10px; border: 1px solid #dee2e6;"><%= shift[:date].strftime("%A, %B %d, %Y") %></td>
+        <td style="padding: 10px; border: 1px solid #dee2e6;"><%= shift[:start_time].strftime("%l:%M %p").strip %> - <%= shift[:end_time].strftime("%l:%M %p").strip %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<p style="margin-top: 15px;">
+  <strong>Total commitment:</strong> <%= @duration_display %>
+</p>
+
+<h2>What's Next?</h2>
+
+<p>
+  You can view or manage your shifts anytime by visiting your My Shifts page:
+</p>
+
+<p>
+  <%= link_to "View My Shifts", conference_volunteer_signups_url(@conference) %>
+</p>
+
+<p>
+  If you need to cancel your shift, you can do so from the My Shifts page up until the shift starts.
+</p>
+
+<p>
+  Thank you for volunteering!<br>
+  The <%= @village_name %> Team
+</p>

--- a/app/views/volunteer_mailer/shift_signup_confirmation.text.erb
+++ b/app/views/volunteer_mailer/shift_signup_confirmation.text.erb
@@ -1,0 +1,26 @@
+Shift Signup Confirmed!
+
+Hello <%= @user.name.presence || @user.email %>,
+
+Thank you for signing up to volunteer at <%= @conference.name %>!
+
+YOUR SHIFT DETAILS
+==================
+<% @grouped_signups.each do |shift| %>
+Program: <%= shift[:program_name] %>
+Date: <%= shift[:date].strftime("%A, %B %d, %Y") %>
+Time: <%= shift[:start_time].strftime("%l:%M %p").strip %> - <%= shift[:end_time].strftime("%l:%M %p").strip %>
+<% end %>
+
+Total commitment: <%= @duration_display %>
+
+WHAT'S NEXT?
+============
+
+You can view or manage your shifts anytime by visiting your My Shifts page:
+<%= conference_volunteer_signups_url(@conference) %>
+
+If you need to cancel your shift, you can do so from the My Shifts page up until the shift starts.
+
+Thank you for volunteering!
+The <%= @village_name %> Team

--- a/test/mailers/volunteer_mailer_test.rb
+++ b/test/mailers/volunteer_mailer_test.rb
@@ -1,0 +1,152 @@
+require "test_helper"
+
+class VolunteerMailerTest < ActionMailer::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true, email_enabled: true, mailgun_api_key: "test-key", mailgun_domain: "test.mailgun.org")
+    @user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Test Volunteer"
+    )
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 2.days,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+    @program = Program.create!(name: "Test Program", village: @village)
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program
+    )
+    @timeslot = Timeslot.create!(
+      conference_program: @conference_program,
+      start_time: Date.tomorrow.to_datetime + 9.hours,
+      max_volunteers: 5
+    )
+    @signup = VolunteerSignup.create!(user: @user, timeslot: @timeslot)
+  end
+
+  test "shift_signup_confirmation sends to correct recipient" do
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup ],
+      conference: @conference
+    )
+
+    assert_equal [ @user.email ], email.to
+  end
+
+  test "shift_signup_confirmation has correct subject" do
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup ],
+      conference: @conference
+    )
+
+    assert_equal "[#{@village.name}] Shift Signup Confirmation - #{@conference.name}", email.subject
+  end
+
+  test "shift_signup_confirmation includes program name" do
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup ],
+      conference: @conference
+    )
+
+    assert_match @program.name, email.html_part.body.to_s
+    assert_match @program.name, email.text_part.body.to_s
+  end
+
+  test "shift_signup_confirmation includes conference name" do
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup ],
+      conference: @conference
+    )
+
+    assert_match @conference.name, email.html_part.body.to_s
+    assert_match @conference.name, email.text_part.body.to_s
+  end
+
+  test "shift_signup_confirmation includes shift time" do
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup ],
+      conference: @conference
+    )
+
+    # Should include the start time
+    assert_match "9:00 AM", email.html_part.body.to_s
+    assert_match "9:00 AM", email.text_part.body.to_s
+  end
+
+  test "shift_signup_confirmation includes link to My Shifts" do
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup ],
+      conference: @conference
+    )
+
+    # Check that the email contains a link to My Shifts
+    assert_match %r{/conferences/\d+/volunteer_signups}, email.html_part.body.to_s
+    assert_match %r{/conferences/\d+/volunteer_signups}, email.text_part.body.to_s
+  end
+
+  test "shift_signup_confirmation handles multiple signups" do
+    timeslot2 = Timeslot.create!(
+      conference_program: @conference_program,
+      start_time: Date.tomorrow.to_datetime + 9.hours + 15.minutes,
+      max_volunteers: 5
+    )
+    signup2 = VolunteerSignup.create!(user: @user, timeslot: timeslot2)
+
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup, signup2 ],
+      conference: @conference
+    )
+
+    # Should show duration covering both timeslots (30 minutes)
+    assert_match "30 minutes", email.html_part.body.to_s
+    assert_match "30 minutes", email.text_part.body.to_s
+  end
+
+  test "shift_signup_confirmation shows total duration" do
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup ],
+      conference: @conference
+    )
+
+    # Single 15-minute slot
+    assert_match "15 minute", email.html_part.body.to_s
+    assert_match "15 minute", email.text_part.body.to_s
+  end
+
+  test "shift_signup_confirmation uses user name when available" do
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup ],
+      conference: @conference
+    )
+
+    assert_match @user.name, email.html_part.body.to_s
+    assert_match @user.name, email.text_part.body.to_s
+  end
+
+  test "shift_signup_confirmation uses email when name not available" do
+    @user.update!(name: nil)
+    email = VolunteerMailer.shift_signup_confirmation(
+      user: @user,
+      signups: [ @signup ],
+      conference: @conference
+    )
+
+    assert_match @user.email, email.html_part.body.to_s
+    assert_match @user.email, email.text_part.body.to_s
+  end
+end

--- a/test/services/notification_service_test.rb
+++ b/test/services/notification_service_test.rb
@@ -42,11 +42,12 @@ class NotificationServiceTest < ActiveSupport::TestCase
     )
   end
 
-  test "notify_shift_signup creates in-app notification when enabled" do
+  test "notify_shift_signups creates in-app notification when enabled" do
     @user.update!(notify_in_app: true, notify_by_email: false)
+    signup = VolunteerSignup.create!(user: @user, timeslot: @timeslot)
 
     assert_difference("Notification.count", 1) do
-      NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+      NotificationService.notify_shift_signups(user: @user, signups: [ signup ])
     end
 
     notification = @user.notifications.last
@@ -56,32 +57,65 @@ class NotificationServiceTest < ActiveSupport::TestCase
     assert_equal Notification::SHIFT_SIGNUP, notification.notification_type
   end
 
-  test "notify_shift_signup sends email when enabled and email configured" do
+  test "notify_shift_signups sends email when enabled and email configured" do
     @village.update!(email_enabled: true, mailgun_api_key: "test-key", mailgun_domain: "test.mailgun.org")
     @user.update!(notify_in_app: false, notify_by_email: true)
+    signup = VolunteerSignup.create!(user: @user, timeslot: @timeslot)
 
     assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
-      NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+      NotificationService.notify_shift_signups(user: @user, signups: [ signup ])
     end
   end
 
-  test "notify_shift_signup does not send email when email disabled globally" do
+  test "notify_shift_signups does not send email when email disabled globally" do
     @village.update!(email_enabled: false)
     @user.update!(notify_in_app: false, notify_by_email: true)
+    signup = VolunteerSignup.create!(user: @user, timeslot: @timeslot)
 
     assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
-      NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+      NotificationService.notify_shift_signups(user: @user, signups: [ signup ])
     end
   end
 
-  test "notify_shift_signup creates both in-app and email when both enabled" do
+  test "notify_shift_signups creates both in-app and email when both enabled" do
     @village.update!(email_enabled: true, mailgun_api_key: "test-key", mailgun_domain: "test.mailgun.org")
     @user.update!(notify_in_app: true, notify_by_email: true)
+    signup = VolunteerSignup.create!(user: @user, timeslot: @timeslot)
 
     assert_difference("Notification.count", 1) do
       assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
-        NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+        NotificationService.notify_shift_signups(user: @user, signups: [ signup ])
       end
+    end
+  end
+
+  test "notify_shift_signups with multiple signups creates single notification" do
+    @user.update!(notify_in_app: true, notify_by_email: false)
+
+    timeslot2 = Timeslot.create!(
+      conference_program: @conference_program,
+      start_time: Date.tomorrow.to_datetime + 9.hours + 15.minutes,
+      max_volunteers: 2
+    )
+
+    signup1 = VolunteerSignup.create!(user: @user, timeslot: @timeslot)
+    signup2 = VolunteerSignup.create!(user: @user, timeslot: timeslot2)
+
+    assert_difference("Notification.count", 1) do
+      NotificationService.notify_shift_signups(user: @user, signups: [ signup1, signup2 ])
+    end
+
+    notification = @user.notifications.last
+    assert_equal "Shift Signup Confirmed", notification.title
+    assert_includes notification.body, "2 shifts"
+    assert_includes notification.body, "30 minutes"
+  end
+
+  test "notify_shift_signups with empty signups does nothing" do
+    @user.update!(notify_in_app: true, notify_by_email: true)
+
+    assert_no_difference("Notification.count") do
+      NotificationService.notify_shift_signups(user: @user, signups: [])
     end
   end
 
@@ -142,9 +176,10 @@ class NotificationServiceTest < ActiveSupport::TestCase
 
   test "does not create in-app notification when disabled" do
     @user.update!(notify_in_app: false, notify_by_email: false)
+    signup = VolunteerSignup.create!(user: @user, timeslot: @timeslot)
 
     assert_no_difference("Notification.count") do
-      NotificationService.notify_shift_signup(user: @user, timeslot: @timeslot)
+      NotificationService.notify_shift_signups(user: @user, signups: [ signup ])
     end
   end
 end


### PR DESCRIPTION
## Summary
- Create VolunteerMailer with shift_signup_confirmation email template
- Email includes all relevant details:
  - Conference name
  - Program name
  - Date and time of shift
  - Duration
  - Link to My Shifts page for viewing/canceling
- For bulk signups (using duration picker), sends single consolidated email
- Integrates with existing notification preferences - only sends if user has email enabled
- Both HTML and plain text email versions included

## Test plan
- [ ] Sign up for a single 15-minute shift, verify email received with correct details
- [ ] Sign up for a multi-hour shift using duration picker, verify single consolidated email
- [ ] Verify email contains link to My Shifts page
- [ ] Disable email notifications in profile, verify no email sent
- [ ] Verify HTML and plain text versions both render correctly

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)