### PR TITLE
Add admin notifications for new volunteer signups

### DIFF
--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -41,6 +41,23 @@ class VolunteerMailer < ApplicationMailer
     )
   end
 
+  def admin_signup_notification(admin:, volunteer:, signup:, conference:)
+    @admin = admin
+    @volunteer = volunteer
+    @signup = signup
+    @conference = conference
+    @village_name = Village.first&.name || "Villagers"
+
+    @timeslot = signup.timeslot
+    @program = @timeslot.conference_program.program
+    @fill_status = "#{@timeslot.current_volunteers_count}/#{@timeslot.max_volunteers}"
+
+    mail(
+      to: @admin.email,
+      subject: "[#{@village_name}] New Volunteer Signup - #{@conference.name}"
+    )
+  end
+
   private
 
   def group_signups_by_program(signups)

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -87,6 +87,17 @@ class Conference < ApplicationRecord
          .where(conference_roles: { role_name: ConferenceRole::CONFERENCE_LEAD })
   end
 
+  def conference_admins
+    users.joins(:conference_roles)
+         .where(conference_roles: { role_name: ConferenceRole::CONFERENCE_ADMIN })
+  end
+
+  def conference_managers
+    users.joins(:conference_roles)
+         .where(conference_roles: { role_name: [ ConferenceRole::CONFERENCE_LEAD, ConferenceRole::CONFERENCE_ADMIN ] })
+         .distinct
+  end
+
   def primary_lead
     conference_roles.find_by(role_name: ConferenceRole::CONFERENCE_LEAD)&.user
   end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -40,6 +40,28 @@ class NotificationService
           conference: conference
         ).deliver_later
       end
+
+      # Notify conference managers about the new signup(s)
+      notify_admins_of_signups(user: user, signups: signups, conference: conference)
+    end
+
+    def notify_admins_of_signups(user:, signups:, conference:)
+      return unless Village.email_enabled?
+
+      conference.conference_managers.find_each do |admin|
+        next if admin == user # Don't notify the volunteer themselves
+        next unless admin.should_notify_by_email?
+
+        # Send one notification per signup (real-time notifications)
+        signups.each do |signup|
+          VolunteerMailer.admin_signup_notification(
+            admin: admin,
+            volunteer: user,
+            signup: signup,
+            conference: conference
+          ).deliver_later
+        end
+      end
     end
 
     def notify_shift_cancelled(user:, timeslot:)

--- a/app/views/volunteer_mailer/admin_signup_notification.html.erb
+++ b/app/views/volunteer_mailer/admin_signup_notification.html.erb
@@ -1,0 +1,48 @@
+<h1>New Volunteer Signup</h1>
+
+<p>Hello <%= @admin.name.presence || @admin.email %>,</p>
+
+<p>A volunteer has signed up for a shift at <strong><%= @conference.name %></strong>.</p>
+
+<h2>Signup Details</h2>
+
+<table style="border-collapse: collapse; width: 100%; max-width: 600px;">
+  <tbody>
+    <tr>
+      <td style="padding: 10px; border: 1px solid #dee2e6; background-color: #f8f9fa; font-weight: bold;">Volunteer</td>
+      <td style="padding: 10px; border: 1px solid #dee2e6;"><%= @volunteer.name.presence || @volunteer.email %></td>
+    </tr>
+    <tr>
+      <td style="padding: 10px; border: 1px solid #dee2e6; background-color: #f8f9fa; font-weight: bold;">Email</td>
+      <td style="padding: 10px; border: 1px solid #dee2e6;"><%= @volunteer.email %></td>
+    </tr>
+    <tr>
+      <td style="padding: 10px; border: 1px solid #dee2e6; background-color: #f8f9fa; font-weight: bold;">Program</td>
+      <td style="padding: 10px; border: 1px solid #dee2e6;"><%= @program.name %></td>
+    </tr>
+    <tr>
+      <td style="padding: 10px; border: 1px solid #dee2e6; background-color: #f8f9fa; font-weight: bold;">Date</td>
+      <td style="padding: 10px; border: 1px solid #dee2e6;"><%= @timeslot.start_time.strftime("%A, %B %d, %Y") %></td>
+    </tr>
+    <tr>
+      <td style="padding: 10px; border: 1px solid #dee2e6; background-color: #f8f9fa; font-weight: bold;">Time</td>
+      <td style="padding: 10px; border: 1px solid #dee2e6;"><%= @timeslot.start_time.strftime("%l:%M %p").strip %> - <%= @timeslot.end_time.strftime("%l:%M %p").strip %></td>
+    </tr>
+    <tr>
+      <td style="padding: 10px; border: 1px solid #dee2e6; background-color: #f8f9fa; font-weight: bold;">Timeslot Fill Status</td>
+      <td style="padding: 10px; border: 1px solid #dee2e6;"><%= @fill_status %> volunteers</td>
+    </tr>
+  </tbody>
+</table>
+
+<p style="margin-top: 20px;">
+  You can view the full schedule and all signups on the conference dashboard:
+</p>
+
+<p>
+  <%= link_to "View Dashboard", conference_dashboard_url(@conference) %>
+</p>
+
+<p>
+  The <%= @village_name %> Team
+</p>

--- a/app/views/volunteer_mailer/admin_signup_notification.text.erb
+++ b/app/views/volunteer_mailer/admin_signup_notification.text.erb
@@ -1,0 +1,19 @@
+New Volunteer Signup
+
+Hello <%= @admin.name.presence || @admin.email %>,
+
+A volunteer has signed up for a shift at <%= @conference.name %>.
+
+SIGNUP DETAILS
+==============
+Volunteer: <%= @volunteer.name.presence || @volunteer.email %>
+Email: <%= @volunteer.email %>
+Program: <%= @program.name %>
+Date: <%= @timeslot.start_time.strftime("%A, %B %d, %Y") %>
+Time: <%= @timeslot.start_time.strftime("%l:%M %p").strip %> - <%= @timeslot.end_time.strftime("%l:%M %p").strip %>
+Timeslot Fill Status: <%= @fill_status %> volunteers
+
+You can view the full schedule and all signups on the conference dashboard:
+<%= conference_dashboard_url(@conference) %>
+
+The <%= @village_name %> Team

--- a/test/mailers/previews/volunteer_mailer_preview.rb
+++ b/test/mailers/previews/volunteer_mailer_preview.rb
@@ -19,6 +19,34 @@ class VolunteerMailerPreview < ActionMailer::Preview
     )
   end
 
+  # Preview: http://localhost:3000/rails/mailers/volunteer_mailer/admin_signup_notification
+  def admin_signup_notification
+    admin = User.first || User.new(email: "admin@example.com", name: "Conference Admin")
+    volunteer = User.second || User.new(email: "volunteer@example.com", name: "New Volunteer")
+    conference = Conference.first || Conference.new(
+      name: "Preview Conference",
+      city: "Las Vegas",
+      state: "NV",
+      country: "US"
+    )
+    program = Program.first || Program.new(name: "Preview Program")
+    conference_program = ConferenceProgram.new(conference: conference, program: program)
+    timeslot = Timeslot.new(
+      conference_program: conference_program,
+      start_time: Time.current.beginning_of_day + 10.hours,
+      max_volunteers: 5,
+      current_volunteers_count: 2
+    )
+    signup = VolunteerSignup.new(user: volunteer, timeslot: timeslot)
+
+    VolunteerMailer.admin_signup_notification(
+      admin: admin,
+      volunteer: volunteer,
+      signup: signup,
+      conference: conference
+    )
+  end
+
   private
 
   def build_preview_data

--- a/test/mailers/volunteer_mailer_test.rb
+++ b/test/mailers/volunteer_mailer_test.rb
@@ -215,4 +215,113 @@ class VolunteerMailerTest < ActionMailer::TestCase
     assert_match "Las Vegas, NV", email.html_part.body.to_s
     assert_match "Las Vegas, NV", email.text_part.body.to_s
   end
+
+  # Admin signup notification tests
+  test "admin_signup_notification sends to correct recipient" do
+    admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Admin User"
+    )
+
+    email = VolunteerMailer.admin_signup_notification(
+      admin: admin,
+      volunteer: @user,
+      signup: @signup,
+      conference: @conference
+    )
+
+    assert_equal [ admin.email ], email.to
+  end
+
+  test "admin_signup_notification has correct subject" do
+    admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    email = VolunteerMailer.admin_signup_notification(
+      admin: admin,
+      volunteer: @user,
+      signup: @signup,
+      conference: @conference
+    )
+
+    assert_equal "[#{@village.name}] New Volunteer Signup - #{@conference.name}", email.subject
+  end
+
+  test "admin_signup_notification includes volunteer info" do
+    admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    email = VolunteerMailer.admin_signup_notification(
+      admin: admin,
+      volunteer: @user,
+      signup: @signup,
+      conference: @conference
+    )
+
+    assert_match @user.email, email.html_part.body.to_s
+    assert_match @user.email, email.text_part.body.to_s
+  end
+
+  test "admin_signup_notification includes program name" do
+    admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    email = VolunteerMailer.admin_signup_notification(
+      admin: admin,
+      volunteer: @user,
+      signup: @signup,
+      conference: @conference
+    )
+
+    assert_match @program.name, email.html_part.body.to_s
+    assert_match @program.name, email.text_part.body.to_s
+  end
+
+  test "admin_signup_notification includes fill status" do
+    admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    email = VolunteerMailer.admin_signup_notification(
+      admin: admin,
+      volunteer: @user,
+      signup: @signup,
+      conference: @conference
+    )
+
+    # Should show current fill status (1/5 since we have one signup)
+    assert_match "1/5", email.html_part.body.to_s
+    assert_match "1/5", email.text_part.body.to_s
+  end
+
+  test "admin_signup_notification includes shift time" do
+    admin = User.create!(
+      email: "admin@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    email = VolunteerMailer.admin_signup_notification(
+      admin: admin,
+      volunteer: @user,
+      signup: @signup,
+      conference: @conference
+    )
+
+    assert_match "9:00 AM", email.html_part.body.to_s
+    assert_match "9:00 AM", email.text_part.body.to_s
+  end
 end


### PR DESCRIPTION
## Summary
- Adds email notifications to conference leads and admins when volunteers sign up for shifts
- Emails include volunteer info, program, timeslot, and current fill status
- Notifications are sent via `NotificationService.notify_admins_of_signups`

Closes #122

## Changes
- Added `admin_signup_notification` method to `VolunteerMailer`
- Added `conference_admins` and `conference_managers` methods to `Conference` model
- Updated `NotificationService` to notify admins when volunteers sign up
- Created HTML and text email templates
- Added mailer preview and comprehensive tests

## Test plan
- [x] All 724 tests pass
- [ ] Verify admin receives email when volunteer signs up for a shift
- [ ] Verify email shows correct volunteer info, program, and fill status
- [ ] Verify conference leads and admins both receive notifications
- [ ] Preview email at http://localhost:3000/rails/mailers/volunteer_mailer/admin_signup_notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)