### PR TITLE
Add demo mode for public demonstration instances

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ Ruby on Rails app for hacker conference village organizers to manage volunteer s
 
 ## Technology Stack
 
-- **Framework**: Ruby on Rails 7
+- **Framework**: Ruby on Rails 8
 - **Database**: PostgreSQL
 - **Frontend**: Bootstrap
 - **Authentication**: Devise

--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,14 @@ APP_HOST=your-app-domain.com
 # Optional: Override the default sender email address
 # Defaults to noreply@MAILGUN_DOMAIN if not set
 # MAILER_FROM=noreply@your-domain.com
+
+# Demo Mode Configuration
+# Set to "true" to enable demo mode for public demonstration instances
+# See docs/demo_mode.md for full documentation
+# DEMO_MODE=false
+
+# Optional: Hour (UTC) for daily database reset (default: 4)
+# DEMO_RESET_HOUR=4
+
+# Optional: Custom banner text displayed at the top of all pages
+# DEMO_BANNER_TEXT=Demo Mode - Data resets daily

--- a/Gemfile
+++ b/Gemfile
@@ -84,4 +84,6 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  # Pin minitest to avoid compatibility issues with Rails 8
+  gem "minitest", "~> 5.25"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,8 +211,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.0)
-      prism (~> 1.5)
+    minitest (5.27.0)
     msgpack (1.8.0)
     multipart-post (2.4.1)
     net-http (0.8.0)
@@ -456,6 +455,7 @@ DEPENDENCIES
   kamal
   letter_opener
   mailgun-ruby (~> 1.2)
+  minitest (~> 5.25)
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class HealthController < ApplicationController
+  skip_before_action :load_past_unarchived_conferences
+
+  def show
+    health_status = {
+      status: "ok",
+      database: database_connected?,
+      demo_mode: DemoMode.enabled?
+    }
+
+    if DemoMode.enabled?
+      health_status[:next_reset] = DemoMode.next_reset_time.iso8601
+      health_status[:time_until_reset] = DemoMode.formatted_time_until_reset
+    end
+
+    render json: health_status
+  end
+
+  private
+
+  def database_connected?
+    ActiveRecord::Base.connection.active?
+  rescue StandardError
+    false
+  end
+end

--- a/app/models/demo_mode.rb
+++ b/app/models/demo_mode.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# DemoMode provides configuration and utilities for running Villagers
+# as a publicly accessible demonstration instance.
+#
+# When enabled via DEMO_MODE=true:
+# - Email sending is disabled
+# - User accounts are auto-confirmed
+# - A demo banner is displayed
+# - Demo credentials are shown on login
+# - Seed demo accounts are protected from deletion
+#
+# Configuration via environment variables:
+#   DEMO_MODE=true                    # Enable demo mode
+#   DEMO_RESET_HOUR=4                 # Hour (UTC) to reset database
+#   DEMO_BANNER_TEXT="Custom Text"    # Custom banner text
+module DemoMode
+  PROTECTED_EMAILS = %w[
+    admin@example.com
+    coordinator@example.com
+    admin1@example.com
+    admin2@example.com
+    volunteer1@example.com
+    volunteer2@example.com
+    volunteer3@example.com
+    volunteer4@example.com
+    volunteer5@example.com
+  ].freeze
+
+  class << self
+    def enabled?
+      ActiveModel::Type::Boolean.new.cast(ENV.fetch("DEMO_MODE", false))
+    end
+
+    def disabled?
+      !enabled?
+    end
+
+    def protected_email?(email)
+      PROTECTED_EMAILS.include?(email.to_s.downcase)
+    end
+
+    def demo_credentials
+      [
+        { email: "admin@example.com", password: "password", role: "Village Admin" },
+        { email: "coordinator@example.com", password: "password", role: "Conference Lead" },
+        { email: "volunteer1@example.com", password: "password", role: "Volunteer" }
+      ]
+    end
+
+    def reset_hour
+      ENV.fetch("DEMO_RESET_HOUR", 4).to_i
+    end
+
+    def banner_text
+      ENV.fetch("DEMO_BANNER_TEXT") { "Demo Mode - Data resets daily at #{reset_hour}:00 AM UTC" }
+    end
+
+    def next_reset_time
+      now = Time.current.utc
+      reset_time = now.change(hour: reset_hour, min: 0, sec: 0)
+      reset_time += 1.day if now >= reset_time
+      reset_time
+    end
+
+    def time_until_reset
+      next_reset_time - Time.current.utc
+    end
+
+    def formatted_time_until_reset
+      seconds = time_until_reset.to_i
+      hours = seconds / 3600
+      minutes = (seconds % 3600) / 60
+
+      if hours > 0
+        "#{hours}h #{minutes}m"
+      else
+        "#{minutes}m"
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,22 @@ class User < ApplicationRecord
   # Skip email confirmation when email is disabled
   before_create :auto_confirm_if_email_disabled
 
+  # Protect demo accounts from deletion
+  before_destroy :prevent_demo_account_deletion
+
+  def demo_protected?
+    DemoMode.enabled? && DemoMode.protected_email?(email)
+  end
+
   private def auto_confirm_if_email_disabled
     skip_confirmation! unless Village.email_enabled?
+  end
+
+  private def prevent_demo_account_deletion
+    if demo_protected?
+      errors.add(:base, "Cannot delete protected demo accounts in demo mode")
+      throw(:abort)
+    end
   end
 
   # Role associations

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -36,6 +36,7 @@
           <%= render "devise/shared/links" %>
         </div>
       </div>
+      <%= render "shared/demo_credentials" %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
   </head>
 
   <body>
+    <%= render "shared/demo_banner" %>
     <%= render "shared/navbar" %>
     <div class="container-fluid">
       <% if notice %>

--- a/app/views/shared/_demo_banner.html.erb
+++ b/app/views/shared/_demo_banner.html.erb
@@ -1,0 +1,6 @@
+<% if DemoMode.enabled? %>
+  <div class="demo-banner alert alert-warning text-center mb-0 rounded-0 py-2" role="alert">
+    <strong><%= DemoMode.banner_text %></strong>
+    <span class="ms-2 text-muted small">(Resets in <%= DemoMode.formatted_time_until_reset %>)</span>
+  </div>
+<% end %>

--- a/app/views/shared/_demo_credentials.html.erb
+++ b/app/views/shared/_demo_credentials.html.erb
@@ -1,0 +1,21 @@
+<% if DemoMode.enabled? %>
+  <div class="demo-credentials card bg-light mt-4">
+    <div class="card-header bg-warning text-dark">
+      <strong>Demo Credentials</strong>
+    </div>
+    <div class="card-body">
+      <p class="card-text small mb-2">Use any of these accounts to explore:</p>
+      <table class="table table-sm table-borderless mb-0">
+        <tbody>
+          <% DemoMode.demo_credentials.each do |cred| %>
+            <tr>
+              <td class="text-muted"><%= cred[:role] %>:</td>
+              <td><code><%= cred[:email] %></code></td>
+              <td><code><%= cred[:password] %></code></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
+  # Detailed health check with demo mode status
+  get "health" => "health#show", as: :health
+
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,3 +94,11 @@ puts "Conference Lead: #{conference_lead.email}"
 puts "Conference Admins: #{conference_admin1.email}, #{conference_admin2.email}"
 puts "Volunteers: volunteer1@example.com through volunteer5@example.com"
 puts "\nAll users have password: password"
+
+# Load enhanced demo seeds if DEMO_MODE is enabled
+if ENV["DEMO_MODE"] == "true"
+  puts "\n" + "=" * 50
+  puts "DEMO_MODE detected - loading enhanced demo data..."
+  puts "=" * 50 + "\n"
+  load Rails.root.join("db/seeds/demo_seeds.rb")
+end

--- a/db/seeds/demo_seeds.rb
+++ b/db/seeds/demo_seeds.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+# Demo Seeds - Enhanced seed data for demo mode
+# This file creates a more comprehensive dataset for demonstration purposes
+
+puts "Creating demo seed data..."
+
+# Create village with email disabled for demo
+village = Village.find_or_create_by!(name: "Ham Radio Village") do |v|
+  v.setup_complete = true
+  v.email_enabled = false
+end
+
+# Update existing village to have email disabled
+village.update!(email_enabled: false) if village.email_enabled?
+
+puts "  Village: #{village.name} (email disabled for demo)"
+
+# Create village admin role
+village_admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+
+# Create village admin
+village_admin = User.find_or_create_by!(email: "admin@example.com") do |u|
+  u.password = "password"
+  u.password_confirmation = "password"
+  u.name = "Village Administrator"
+  u.handle = "VillageAdmin"
+end
+UserRole.find_or_create_by!(user: village_admin, role: village_admin_role)
+puts "  Village Admin: #{village_admin.email}"
+
+# Create multiple conferences (past, current, future)
+conferences = []
+
+# Past conference
+past_conference = Conference.find_or_create_by!(name: "DEF CON 31", village: village) do |c|
+  c.country = "US"
+  c.state = "NV"
+  c.city = "Las Vegas"
+  c.start_date = Date.new(2023, 8, 10)
+  c.end_date = Date.new(2023, 8, 13)
+  c.conference_hours_start = Time.parse("10:00")
+  c.conference_hours_end = Time.parse("18:00")
+  c.archived = true
+end
+conferences << past_conference
+puts "  Past Conference: #{past_conference.name}"
+
+# Current/Recent conference
+current_conference = Conference.find_or_create_by!(name: "DEF CON 32", village: village) do |c|
+  c.country = "US"
+  c.state = "NV"
+  c.city = "Las Vegas"
+  c.start_date = Date.new(2024, 8, 8)
+  c.end_date = Date.new(2024, 8, 11)
+  c.conference_hours_start = Time.parse("09:00")
+  c.conference_hours_end = Time.parse("18:00")
+end
+conferences << current_conference
+puts "  Current Conference: #{current_conference.name}"
+
+# Future conference
+future_conference = Conference.find_or_create_by!(name: "DEF CON 33", village: village) do |c|
+  c.country = "US"
+  c.state = "NV"
+  c.city = "Las Vegas"
+  c.start_date = Date.new(2025, 8, 7)
+  c.end_date = Date.new(2025, 8, 10)
+  c.conference_hours_start = Time.parse("10:00")
+  c.conference_hours_end = Time.parse("19:00")
+end
+conferences << future_conference
+puts "  Future Conference: #{future_conference.name}"
+
+# Create conference lead
+conference_lead = User.find_or_create_by!(email: "coordinator@example.com") do |u|
+  u.password = "password"
+  u.password_confirmation = "password"
+  u.name = "Conference Coordinator"
+  u.handle = "CoordLead"
+end
+conferences.each do |conf|
+  ConferenceRole.find_or_create_by!(
+    user: conference_lead,
+    conference: conf,
+    role_name: ConferenceRole::CONFERENCE_LEAD
+  )
+end
+puts "  Conference Lead: #{conference_lead.email}"
+
+# Create conference admins
+admin_users = []
+2.times do |i|
+  admin = User.find_or_create_by!(email: "admin#{i + 1}@example.com") do |u|
+    u.password = "password"
+    u.password_confirmation = "password"
+    u.name = "Conference Admin #{i + 1}"
+    u.handle = "Admin#{i + 1}"
+  end
+  admin_users << admin
+
+  # Assign to current and future conferences
+  [ current_conference, future_conference ].each do |conf|
+    ConferenceRole.find_or_create_by!(
+      user: admin,
+      conference: conf,
+      role_name: ConferenceRole::CONFERENCE_ADMIN
+    )
+  end
+end
+puts "  Conference Admins: #{admin_users.map(&:email).join(', ')}"
+
+# Create volunteers
+volunteer_users = []
+5.times do |i|
+  volunteer = User.find_or_create_by!(email: "volunteer#{i + 1}@example.com") do |u|
+    u.password = "password"
+    u.password_confirmation = "password"
+    u.name = "Demo Volunteer #{i + 1}"
+    u.handle = "Vol#{i + 1}"
+  end
+  volunteer_users << volunteer
+end
+puts "  Volunteers: volunteer1@example.com through volunteer5@example.com"
+
+# Create programs
+programs = []
+
+program_data = [
+  { name: "Fox Hunting", description: "Radio direction finding competitions and training" },
+  { name: "Kit Building", description: "Hands-on electronics kit assembly workshops" },
+  { name: "Antenna Building", description: "Learn to build various amateur radio antennas" },
+  { name: "License Exams", description: "Amateur radio license examination sessions" },
+  { name: "On-Air Operations", description: "Live amateur radio operations and demonstrations" }
+]
+
+program_data.each do |data|
+  program = Program.find_or_create_by!(name: data[:name], village: village) do |p|
+    p.description = data[:description]
+  end
+  programs << program
+end
+puts "  Programs: #{programs.map(&:name).join(', ')}"
+
+# Create conference programs for current and future conferences
+[ current_conference, future_conference ].each do |conf|
+  programs.each_with_index do |program, idx|
+    cp = ConferenceProgram.find_or_create_by!(conference: conf, program: program) do |c|
+      c.public_description = "#{program.name} at #{conf.name}"
+      c.max_volunteers = [ 2, 3, 4 ].sample
+    end
+
+    # Create day schedules with timeslots for the first 3 programs
+    if idx < 3 && cp.timeslots.empty?
+      conf.conference_days.each do |day|
+        # Morning session
+        start_time = conf.conference_hours_start
+        4.times do |slot|
+          Timeslot.find_or_create_by!(
+            conference_program: cp,
+            date: day,
+            start_time: start_time + (slot * 15).minutes
+          ) do |t|
+            t.max_volunteers = cp.max_volunteers
+          end
+        end
+
+        # Afternoon session
+        start_time = conf.conference_hours_start + 4.hours
+        4.times do |slot|
+          Timeslot.find_or_create_by!(
+            conference_program: cp,
+            date: day,
+            start_time: start_time + (slot * 15).minutes
+          ) do |t|
+            t.max_volunteers = cp.max_volunteers
+          end
+        end
+      end
+    end
+  end
+end
+puts "  Conference programs and timeslots created"
+
+# Create some sample volunteer signups for the current conference
+current_conference.conference_programs.each do |cp|
+  cp.timeslots.limit(3).each_with_index do |timeslot, idx|
+    volunteer = volunteer_users[idx % volunteer_users.size]
+    VolunteerSignup.find_or_create_by!(user: volunteer, timeslot: timeslot)
+  end
+end
+puts "  Sample volunteer signups created"
+
+# Create qualifications
+qualifications = []
+qual_data = [
+  { name: "Licensed Ham", description: "Must hold a valid amateur radio license" },
+  { name: "Soldering Certified", description: "Completed soldering safety training" },
+  { name: "VE Certified", description: "Certified Volunteer Examiner" }
+]
+
+qual_data.each do |data|
+  qual = Qualification.find_or_create_by!(name: data[:name], village: village) do |q|
+    q.description = data[:description]
+  end
+  qualifications << qual
+end
+puts "  Qualifications: #{qualifications.map(&:name).join(', ')}"
+
+# Assign qualifications to some volunteers
+volunteer_users.first(3).each do |volunteer|
+  qualifications.first(2).each do |qual|
+    UserQualification.find_or_create_by!(user: volunteer, qualification: qual)
+  end
+end
+puts "  Qualifications assigned to volunteers"
+
+puts "\nDemo seed data created successfully!"
+puts "\nDemo Accounts:"
+puts "  Village Admin:     admin@example.com / password"
+puts "  Conference Lead:   coordinator@example.com / password"
+puts "  Conference Admin:  admin1@example.com / password"
+puts "  Volunteer:         volunteer1@example.com / password"
+puts "\nAll accounts use password: password"

--- a/docs/demo_mode.md
+++ b/docs/demo_mode.md
@@ -1,0 +1,205 @@
+# Demo Mode
+
+Demo mode allows running Villagers as a publicly accessible demonstration instance. When enabled, the application provides a safe, self-resetting environment where potential users can explore all features.
+
+## Features
+
+When demo mode is enabled:
+
+- **Email disabled**: All email sending is disabled
+- **Auto-confirmation**: New user accounts don't require email verification
+- **Demo banner**: A persistent banner displays at the top of all pages
+- **Login credentials**: Demo account credentials are shown on the login page
+- **Protected accounts**: Seed demo accounts cannot be deleted
+- **Health endpoint**: `/health` endpoint includes demo mode status
+
+## Configuration
+
+### Environment Variables
+
+Add these to your `.env` file:
+
+```bash
+# Required: Enable demo mode
+DEMO_MODE=true
+
+# Optional: Hour (UTC) for daily database reset (default: 4)
+DEMO_RESET_HOUR=4
+
+# Optional: Custom banner text
+DEMO_BANNER_TEXT="Demo Instance - Data resets daily"
+```
+
+### Quick Start
+
+1. Copy the environment example:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Enable demo mode in `.env`:
+   ```bash
+   DEMO_MODE=true
+   ```
+
+3. Set up the database with demo data:
+   ```bash
+   bin/rails db:setup
+   ```
+
+4. Start the server:
+   ```bash
+   bin/rails server
+   ```
+
+## Demo Accounts
+
+The following accounts are created when demo mode is enabled:
+
+| Role | Email | Password |
+|------|-------|----------|
+| Village Admin | admin@example.com | password |
+| Conference Lead | coordinator@example.com | password |
+| Conference Admin | admin1@example.com | password |
+| Conference Admin | admin2@example.com | password |
+| Volunteer | volunteer1@example.com | password |
+| Volunteer | volunteer2@example.com | password |
+| Volunteer | volunteer3@example.com | password |
+| Volunteer | volunteer4@example.com | password |
+| Volunteer | volunteer5@example.com | password |
+
+## Rake Tasks
+
+### Check Demo Status
+
+```bash
+bin/rails demo:status
+```
+
+Shows current demo mode configuration and protected accounts.
+
+### Reset Demo Database
+
+```bash
+bin/rails demo:reset
+```
+
+Drops and recreates the database with fresh demo data. Only works when `DEMO_MODE=true`.
+
+### Seed Demo Data Only
+
+```bash
+bin/rails demo:seed
+```
+
+Loads enhanced demo data without resetting the database.
+
+## Automated Daily Reset
+
+### Setting Up Cron
+
+To automatically reset the demo database daily:
+
+1. Open crontab:
+   ```bash
+   crontab -e
+   ```
+
+2. Add the following line (resets at 4 AM UTC):
+   ```cron
+   0 4 * * * /path/to/villagers/scripts/reset_demo_database.sh >> /var/log/villagers/demo_reset.log 2>&1
+   ```
+
+3. Create the log directory:
+   ```bash
+   sudo mkdir -p /var/log/villagers
+   sudo chown $USER:$USER /var/log/villagers
+   ```
+
+### Script Options
+
+The reset script is located at `scripts/reset_demo_database.sh`. It:
+
+- Verifies `DEMO_MODE=true` is set
+- Drops and recreates the database
+- Runs all migrations
+- Seeds with demo data
+- Logs all output with timestamps
+
+### Troubleshooting Cron
+
+1. **Check if cron is running**:
+   ```bash
+   sudo systemctl status cron
+   ```
+
+2. **View cron logs**:
+   ```bash
+   grep CRON /var/log/syslog
+   ```
+
+3. **Test the script manually**:
+   ```bash
+   ./scripts/reset_demo_database.sh
+   ```
+
+4. **Common issues**:
+   - Ensure the script has execute permissions: `chmod +x scripts/reset_demo_database.sh`
+   - Ensure environment variables are set in the script or `.env` file
+   - Use absolute paths in crontab
+
+## Health Check Endpoint
+
+The `/health` endpoint returns JSON with application status:
+
+```bash
+curl http://localhost:3000/health
+```
+
+Response when demo mode is enabled:
+```json
+{
+  "status": "ok",
+  "database": true,
+  "demo_mode": true,
+  "next_reset": "2024-01-15T04:00:00Z",
+  "time_until_reset": "12h 30m"
+}
+```
+
+Response when demo mode is disabled:
+```json
+{
+  "status": "ok",
+  "database": true,
+  "demo_mode": false
+}
+```
+
+## Security Considerations
+
+Demo mode includes several safety features:
+
+1. **Protected accounts**: Seed demo accounts (admin@example.com, etc.) cannot be deleted
+2. **Email disabled**: No emails are sent, preventing spam
+3. **Auto-confirmation**: Simplifies account creation for demo purposes
+4. **Daily reset**: All user-created data is cleared daily
+
+### Recommendations for Production Demo Instances
+
+1. **Rate limiting**: Consider adding rate limiting to prevent abuse
+2. **Monitoring**: Set up alerts for the `/health` endpoint
+3. **Log rotation**: Configure log rotation for demo reset logs
+4. **Separate database**: Use a dedicated database for the demo instance
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `app/models/demo_mode.rb` | Core demo mode logic |
+| `app/views/shared/_demo_banner.html.erb` | Demo mode banner partial |
+| `app/views/shared/_demo_credentials.html.erb` | Login page credentials |
+| `app/controllers/health_controller.rb` | Health check endpoint |
+| `db/seeds/demo_seeds.rb` | Enhanced demo seed data |
+| `lib/tasks/demo.rake` | Demo rake tasks |
+| `scripts/reset_demo_database.sh` | Cron reset script |

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+namespace :demo do
+  desc "Reset the demo database - drops, recreates, migrates, and seeds"
+  task reset: :environment do
+    unless DemoMode.enabled?
+      puts "ERROR: DEMO_MODE is not enabled. Set DEMO_MODE=true to run this task."
+      exit 1
+    end
+
+    puts "=" * 60
+    puts "Demo Database Reset"
+    puts "Started at: #{Time.current}"
+    puts "=" * 60
+
+    # Clear all sessions
+    puts "\n[1/5] Clearing sessions..."
+    begin
+      ActiveRecord::SessionStore::Session.delete_all if defined?(ActiveRecord::SessionStore)
+      puts "      Sessions cleared"
+    rescue StandardError => e
+      puts "      No session store to clear (#{e.message})"
+    end
+
+    # Drop and recreate database
+    puts "\n[2/5] Dropping database..."
+    Rake::Task["db:drop"].invoke
+    puts "      Database dropped"
+
+    puts "\n[3/5] Creating database..."
+    Rake::Task["db:create"].invoke
+    puts "      Database created"
+
+    # Run migrations
+    puts "\n[4/5] Running migrations..."
+    Rake::Task["db:migrate"].invoke
+    puts "      Migrations complete"
+
+    # Seed database
+    puts "\n[5/5] Seeding database..."
+    Rake::Task["db:seed"].invoke
+    puts "      Seeding complete"
+
+    puts "\n" + "=" * 60
+    puts "Demo reset completed at: #{Time.current}"
+    puts "Next reset scheduled for: #{DemoMode.next_reset_time}"
+    puts "=" * 60
+  end
+
+  desc "Show demo mode status"
+  task status: :environment do
+    puts "Demo Mode Status"
+    puts "-" * 40
+    puts "Enabled:           #{DemoMode.enabled?}"
+    puts "Reset Hour (UTC):  #{DemoMode.reset_hour}:00"
+    puts "Banner Text:       #{DemoMode.banner_text}"
+
+    if DemoMode.enabled?
+      puts "Next Reset:        #{DemoMode.next_reset_time}"
+      puts "Time Until Reset:  #{DemoMode.formatted_time_until_reset}"
+    end
+
+    puts "-" * 40
+    puts "\nProtected Accounts:"
+    DemoMode::PROTECTED_EMAILS.each do |email|
+      puts "  - #{email}"
+    end
+  end
+
+  desc "Seed demo data only (without database reset)"
+  task seed: :environment do
+    puts "Loading demo seed data..."
+    load Rails.root.join("db/seeds/demo_seeds.rb")
+  end
+end

--- a/scripts/reset_demo_database.sh
+++ b/scripts/reset_demo_database.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Demo Database Reset Script
+# This script resets the demo database and is intended to be run via cron.
+#
+# Usage:
+#   ./scripts/reset_demo_database.sh
+#
+# Cron example (reset daily at 4 AM UTC):
+#   0 4 * * * /path/to/villagers/scripts/reset_demo_database.sh >> /var/log/villagers/demo_reset.log 2>&1
+#
+
+set -e
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(dirname "$SCRIPT_DIR")"
+LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+
+# Change to application directory
+cd "$APP_DIR"
+
+echo "$LOG_PREFIX Starting demo database reset..."
+
+# Source environment file if it exists
+if [ -f "$APP_DIR/.env" ]; then
+    export $(grep -v '^#' "$APP_DIR/.env" | xargs)
+fi
+
+# Verify DEMO_MODE is enabled
+if [ "$DEMO_MODE" != "true" ]; then
+    echo "$LOG_PREFIX ERROR: DEMO_MODE is not enabled. Aborting."
+    exit 1
+fi
+
+# Set Rails environment if not set
+export RAILS_ENV="${RAILS_ENV:-production}"
+
+echo "$LOG_PREFIX Environment: $RAILS_ENV"
+echo "$LOG_PREFIX Application directory: $APP_DIR"
+
+# Run the demo reset rake task
+echo "$LOG_PREFIX Running demo:reset task..."
+bundle exec rails demo:reset
+
+# Restart application server (adjust command based on your deployment)
+# Uncomment and modify as needed for your setup:
+#
+# For systemd:
+# echo "$LOG_PREFIX Restarting application..."
+# sudo systemctl restart villagers
+#
+# For Puma with pumactl:
+# echo "$LOG_PREFIX Restarting Puma..."
+# bundle exec pumactl -P tmp/pids/puma.pid restart
+#
+# For Docker:
+# echo "$LOG_PREFIX Restarting container..."
+# docker restart villagers
+
+echo "$LOG_PREFIX Demo database reset completed successfully."
+echo "$LOG_PREFIX Next scheduled reset: $(bundle exec rails runner 'puts DemoMode.next_reset_time')"

--- a/test/controllers/health_controller_test.rb
+++ b/test/controllers/health_controller_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class HealthControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_demo_mode = ENV["DEMO_MODE"]
+  end
+
+  teardown do
+    ENV["DEMO_MODE"] = @original_demo_mode
+  end
+
+  test "health check returns 200" do
+    get health_path
+
+    assert_response :success
+  end
+
+  test "health check returns JSON" do
+    get health_path, as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json.key?("status")
+    assert_equal "ok", json["status"]
+  end
+
+  test "health check includes demo mode status when enabled" do
+    ENV["DEMO_MODE"] = "true"
+
+    get health_path, as: :json
+
+    json = JSON.parse(response.body)
+    assert json["demo_mode"]
+    assert json.key?("next_reset")
+  end
+
+  test "health check shows demo mode false when disabled" do
+    ENV["DEMO_MODE"] = "false"
+
+    get health_path, as: :json
+
+    json = JSON.parse(response.body)
+    assert_not json["demo_mode"]
+    assert_nil json["next_reset"]
+  end
+
+  test "health check includes database connectivity" do
+    get health_path, as: :json
+
+    json = JSON.parse(response.body)
+    assert json.key?("database")
+  end
+end

--- a/test/models/demo_mode_test.rb
+++ b/test/models/demo_mode_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class DemoModeTest < ActiveSupport::TestCase
+  setup do
+    @original_demo_mode = ENV["DEMO_MODE"]
+    @original_reset_hour = ENV["DEMO_RESET_HOUR"]
+    @original_banner_text = ENV["DEMO_BANNER_TEXT"]
+  end
+
+  teardown do
+    ENV["DEMO_MODE"] = @original_demo_mode
+    ENV["DEMO_RESET_HOUR"] = @original_reset_hour
+    ENV["DEMO_BANNER_TEXT"] = @original_banner_text
+  end
+
+  test "enabled? returns false by default" do
+    ENV["DEMO_MODE"] = nil
+    refute DemoMode.enabled?
+  end
+
+  test "enabled? returns true when DEMO_MODE is true" do
+    ENV["DEMO_MODE"] = "true"
+    assert DemoMode.enabled?
+  end
+
+  test "enabled? returns false when DEMO_MODE is false" do
+    ENV["DEMO_MODE"] = "false"
+    refute DemoMode.enabled?
+  end
+
+  test "disabled? is inverse of enabled?" do
+    ENV["DEMO_MODE"] = "true"
+    refute DemoMode.disabled?
+
+    ENV["DEMO_MODE"] = "false"
+    assert DemoMode.disabled?
+  end
+
+  test "protected_email? returns true for seed demo emails" do
+    assert DemoMode.protected_email?("admin@example.com")
+    assert DemoMode.protected_email?("coordinator@example.com")
+    assert DemoMode.protected_email?("admin1@example.com")
+    assert DemoMode.protected_email?("admin2@example.com")
+    assert DemoMode.protected_email?("volunteer1@example.com")
+    assert DemoMode.protected_email?("volunteer5@example.com")
+  end
+
+  test "protected_email? returns false for non-demo emails" do
+    refute DemoMode.protected_email?("random@example.com")
+    refute DemoMode.protected_email?("test@test.com")
+  end
+
+  test "protected_email? is case insensitive" do
+    assert DemoMode.protected_email?("ADMIN@EXAMPLE.COM")
+    assert DemoMode.protected_email?("Admin@Example.Com")
+  end
+
+  test "demo_credentials returns list of demo accounts" do
+    credentials = DemoMode.demo_credentials
+
+    assert credentials.is_a?(Array)
+    assert credentials.any? { |c| c[:email] == "admin@example.com" }
+    assert credentials.any? { |c| c[:role] == "Village Admin" }
+    assert credentials.all? { |c| c[:password] == "password" }
+  end
+
+  test "reset_hour returns configured hour" do
+    ENV["DEMO_RESET_HOUR"] = "6"
+    assert_equal 6, DemoMode.reset_hour
+  end
+
+  test "reset_hour defaults to 4" do
+    ENV["DEMO_RESET_HOUR"] = nil
+    assert_equal 4, DemoMode.reset_hour
+  end
+
+  test "banner_text returns configured text" do
+    ENV["DEMO_BANNER_TEXT"] = "Custom Demo Text"
+    assert_equal "Custom Demo Text", DemoMode.banner_text
+  end
+
+  test "banner_text returns default when not configured" do
+    ENV["DEMO_BANNER_TEXT"] = nil
+    ENV["DEMO_RESET_HOUR"] = "4"
+    assert_match(/Demo Mode/, DemoMode.banner_text)
+    assert_match(/4:00 AM UTC/, DemoMode.banner_text)
+  end
+
+  test "next_reset_time returns future time" do
+    ENV["DEMO_RESET_HOUR"] = "4"
+    next_reset = DemoMode.next_reset_time
+    assert next_reset > Time.current
+  end
+
+  test "time_until_reset returns positive duration" do
+    ENV["DEMO_RESET_HOUR"] = "4"
+    assert DemoMode.time_until_reset > 0
+  end
+
+  test "formatted_time_until_reset returns readable string" do
+    ENV["DEMO_RESET_HOUR"] = "4"
+    formatted = DemoMode.formatted_time_until_reset
+    assert formatted.is_a?(String)
+    assert formatted.match?(/\d+[hm]/)
+  end
+end

--- a/test/models/user_demo_protection_test.rb
+++ b/test/models/user_demo_protection_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class UserDemoProtectionTest < ActiveSupport::TestCase
+  setup do
+    @original_demo_mode = ENV["DEMO_MODE"]
+  end
+
+  teardown do
+    ENV["DEMO_MODE"] = @original_demo_mode
+  end
+
+  test "protected demo account cannot be destroyed when demo mode enabled" do
+    ENV["DEMO_MODE"] = "true"
+
+    user = User.new(
+      email: "admin@example.com",
+      password: "password",
+      password_confirmation: "password"
+    )
+    user.skip_confirmation!
+    user.save!
+
+    assert_not user.destroy
+    assert user.errors[:base].any? { |e| e.include?("demo") }
+    assert User.exists?(user.id)
+  end
+
+  test "protected demo account can be destroyed when demo mode disabled" do
+    ENV["DEMO_MODE"] = "false"
+
+    user = User.new(
+      email: "admin@example.com",
+      password: "password",
+      password_confirmation: "password"
+    )
+    user.skip_confirmation!
+    user.save!
+
+    assert user.destroy
+    assert_not User.exists?(user.id)
+  end
+
+  test "non-demo account can be destroyed when demo mode enabled" do
+    ENV["DEMO_MODE"] = "true"
+
+    user = User.new(
+      email: "random@example.com",
+      password: "password",
+      password_confirmation: "password"
+    )
+    user.skip_confirmation!
+    user.save!
+
+    assert user.destroy
+    assert_not User.exists?(user.id)
+  end
+
+  test "demo_protected? returns true for protected emails in demo mode" do
+    ENV["DEMO_MODE"] = "true"
+
+    user = User.new(email: "admin@example.com")
+    assert user.demo_protected?
+  end
+
+  test "demo_protected? returns false for protected emails when demo disabled" do
+    ENV["DEMO_MODE"] = "false"
+
+    user = User.new(email: "admin@example.com")
+    assert_not user.demo_protected?
+  end
+
+  test "demo_protected? returns false for non-demo emails" do
+    ENV["DEMO_MODE"] = "true"
+
+    user = User.new(email: "random@example.com")
+    assert_not user.demo_protected?
+  end
+end

--- a/test/system/demo_mode_test.rb
+++ b/test/system/demo_mode_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class DemoModeSystemTest < ApplicationSystemTestCase
+  setup do
+    @original_demo_mode = ENV["DEMO_MODE"]
+  end
+
+  teardown do
+    ENV["DEMO_MODE"] = @original_demo_mode
+  end
+
+  test "demo banner is displayed when demo mode is enabled" do
+    ENV["DEMO_MODE"] = "true"
+
+    visit root_path
+
+    assert_selector ".demo-banner", text: /Demo Mode/
+  end
+
+  test "demo banner is not displayed when demo mode is disabled" do
+    ENV["DEMO_MODE"] = "false"
+
+    visit root_path
+
+    assert_no_selector ".demo-banner"
+  end
+
+  test "demo credentials are shown on login page when demo mode enabled" do
+    ENV["DEMO_MODE"] = "true"
+
+    visit new_user_session_path
+
+    assert_selector ".demo-credentials"
+    assert_text "admin@example.com"
+    assert_text "password"
+  end
+
+  test "demo credentials are not shown on login page when demo mode disabled" do
+    ENV["DEMO_MODE"] = "false"
+
+    visit new_user_session_path
+
+    assert_no_selector ".demo-credentials"
+  end
+end


### PR DESCRIPTION
## Summary

- Adds comprehensive demo mode functionality for running Villagers as a public demonstration instance
- Demo mode is enabled via `DEMO_MODE=true` environment variable
- When enabled: emails are disabled, accounts auto-confirm, demo banner shows, credentials displayed on login
- Protected demo accounts (seed users) cannot be deleted
- Includes automated database reset script for cron (daily resets)
- Adds `/health` endpoint with demo mode status for monitoring

## Features

- `DemoMode` module with configuration utilities
- Demo banner at top of all pages with reset countdown
- Demo credentials card on login page
- Protected demo accounts (admin@example.com, etc.)
- Health check endpoint (`/health`) returns JSON status
- Enhanced demo seed data (multiple conferences, programs, timeslots)
- Rake tasks: `demo:reset`, `demo:status`, `demo:seed`
- Cron script: `scripts/reset_demo_database.sh`
- Full documentation: `docs/demo_mode.md`

## Configuration

```bash
DEMO_MODE=true                    # Enable demo mode
DEMO_RESET_HOUR=4                 # Hour (UTC) for daily reset
DEMO_BANNER_TEXT="Custom text"    # Custom banner message
```

## Test plan

- [x] All 754 tests pass
- [x] Rubocop shows no offenses
- [ ] Manual test: Enable DEMO_MODE=true and verify banner appears
- [ ] Manual test: Verify demo credentials show on login page
- [ ] Manual test: Verify protected accounts cannot be deleted
- [ ] Manual test: Verify /health endpoint returns demo status

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)