### PR TITLE
Show demo credentials on home page when demo mode enabled

### DIFF
--- a/app/views/root/show.html.erb
+++ b/app/views/root/show.html.erb
@@ -5,6 +5,7 @@
     <div class="alert alert-info">
       <p class="mb-0"><%= link_to "Sign in", new_user_session_path %> or <%= link_to "create an account", new_user_registration_path %> to view your dashboard and sign up for volunteer shifts.</p>
     </div>
+    <%= render "shared/demo_credentials" %>
   <% end %>
 
   <% if user_signed_in? %>

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -362,4 +362,28 @@ class RootControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".card-header", text: /Open Opportunities/
   end
+
+  # Demo Mode Tests
+  test "unauthenticated user sees demo credentials when demo mode enabled" do
+    ENV["DEMO_MODE"] = "true"
+
+    get root_url
+
+    assert_response :success
+    assert_select ".demo-credentials"
+    assert_select ".demo-credentials", text: /admin@example.com/
+  ensure
+    ENV["DEMO_MODE"] = nil
+  end
+
+  test "unauthenticated user does not see demo credentials when demo mode disabled" do
+    ENV["DEMO_MODE"] = "false"
+
+    get root_url
+
+    assert_response :success
+    assert_select ".demo-credentials", count: 0
+  ensure
+    ENV["DEMO_MODE"] = nil
+  end
 end


### PR DESCRIPTION
## Summary
- Renders the demo credentials partial on the root/home page for unauthenticated users when `DEMO_MODE=true`
- Makes it easier for visitors to find login credentials without navigating to the sign in page first

## Test plan
- [x] All 762 tests pass
- [x] Rubocop passes
- [ ] Verify demo credentials table appears on home page when `DEMO_MODE=true`
- [ ] Verify demo credentials table does NOT appear when `DEMO_MODE=false`

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)