### PR TITLE
Support either PostgreSQL or MySQL/MariaDB via DATABASE_ADAPTER

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,15 @@
+# Database Configuration
+# Choose the database engine. Defaults to "postgresql" when unset.
+#   postgresql -> uses the "pg" gem (default port 5432, default user "postgres")
+#   mysql2     -> uses the "mysql2" gem for MySQL/MariaDB (default port 3306, user "root")
+# DATABASE_ADAPTER=postgresql
+# DATABASE_HOST=localhost
+# DATABASE_PORT=5432
+# DATABASE_USERNAME=postgres
+# DATABASE_PASSWORD=
+# Note: schema.rb is committed in PostgreSQL dialect. On MySQL/MariaDB, set up the
+# database with `bin/rails db:create db:migrate` (the migrations are portable).
+
 # Mailgun Configuration
 # Required for sending emails in production
 MAILGUN_API_KEY=your-mailgun-api-key

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,11 @@ source "https://rubygems.org"
 gem "rails", "~> 8.1.1"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
-# Use PostgreSQL as the database for Active Record
+# Database adapters for Active Record. The active one is selected at runtime via
+# the DATABASE_ADAPTER env var (see config/database.yml); both gems are bundled
+# so either PostgreSQL or MySQL/MariaDB can be used without changing the Gemfile.
 gem "pg", "~> 1.5"
+gem "mysql2", "~> 0.5"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,8 @@ GEM
     minitest (5.27.0)
     msgpack (1.8.0)
     multipart-post (2.4.1)
+    mysql2 (0.5.7)
+      bigdecimal
     net-http (0.8.0)
       uri (>= 0.11.1)
     net-imap (0.5.12)
@@ -254,12 +256,12 @@ GEM
     parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
-    pg (1.6.2)
-    pg (1.6.2-aarch64-linux)
-    pg (1.6.2-aarch64-linux-musl)
-    pg (1.6.2-arm64-darwin)
-    pg (1.6.2-x86_64-linux)
-    pg (1.6.2-x86_64-linux-musl)
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -460,6 +462,7 @@ DEPENDENCIES
   letter_opener
   mailgun-ruby (~> 1.2)
   minitest (~> 5.25)
+  mysql2 (~> 0.5)
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/app/models/conference_program.rb
+++ b/app/models/conference_program.rb
@@ -1,4 +1,12 @@
 class ConferenceProgram < ApplicationRecord
+  # Force JSON (de)serialization for day_schedules so it behaves identically on
+  # every supported adapter. PostgreSQL and MySQL expose a native `json` type, but
+  # MariaDB reports the column as `longtext`, where ActiveRecord would otherwise
+  # store a hash via #to_s (invalid JSON) and trip MariaDB's implicit json_valid()
+  # CHECK constraint. Declaring the type here is a no-op on Postgres/MySQL and the
+  # fix for MariaDB.
+  attribute :day_schedules, :json
+
   belongs_to :conference
   belongs_to :program
   has_many :timeslots, dependent: :destroy

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,33 +1,39 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On macOS with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem "pg"
-#
+<%#
+  Database configuration supporting either PostgreSQL (default) or MySQL/MariaDB.
+
+  Select the engine with the DATABASE_ADAPTER environment variable:
+    DATABASE_ADAPTER=postgresql   (default)  -> requires the "pg" gem
+    DATABASE_ADAPTER=mysql2                   -> requires the "mysql2" gem
+  Both gems are bundled, so no Gemfile change is needed to switch.
+
+  Client libraries:
+    PostgreSQL:     apt-get install libpq-dev          / brew install libpq
+    MySQL/MariaDB:  apt-get install libmariadb-dev      / brew install mariadb
+
+  Supported versions for the day_schedules JSON column:
+    PostgreSQL 9.3+   /   MySQL 5.7+   /   MariaDB 10.2+
+%>
+<%
+  db_adapter = ENV.fetch("DATABASE_ADAPTER", "postgresql")
+  mysql      = db_adapter == "mysql2"
+%>
 default: &default
-  adapter: postgresql
-  encoding: unicode
+  adapter: <%= db_adapter %>
+  encoding: <%= mysql ? "utf8mb4" : "unicode" %>
+<% if mysql %>
+  collation: utf8mb4_unicode_ci
+<% end %>
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: <%= ENV.fetch("DATABASE_USERNAME") { mysql ? "root" : "postgres" } %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
+  host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
+  port: <%= ENV.fetch("DATABASE_PORT") { mysql ? 3306 : 5432 } %>
 
 development:
   <<: *default
   database: villagers_development
-  username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>
-  password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
-  host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
-  port: <%= ENV.fetch("DATABASE_PORT") { 5432 } %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -35,10 +41,6 @@ development:
 test:
   <<: *default
   database: villagers_test
-  username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>
-  password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
-  host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
-  port: <%= ENV.fetch("DATABASE_PORT") { 5432 } %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -48,13 +50,14 @@ test:
 # variable when you boot the app. For example:
 #
 #   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
 #
 # If DATABASE_URL is provided, it will be used as configuration information;
 # this means you don't need to set any of these config values. If you want to
 # override any of these values, you can use the DATABASE_URL environment variable
 # with the following format:
 #
-#   postgres://[user[:password]@][host][:port][/database]
+#   <adapter>://[user[:password]@][host][:port][/database]
 #
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
@@ -63,31 +66,15 @@ production:
   primary:
     <<: *default
     database: <%= ENV.fetch("DATABASE_NAME") { "villagers_production" } %>
-    username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>
-    password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
-    host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
-    port: <%= ENV.fetch("DATABASE_PORT") { 5432 } %>
   cache:
     <<: *default
     database: <%= ENV.fetch("CACHE_DATABASE_NAME") { "villagers_production_cache" } %>
-    username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>
-    password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
-    host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
-    port: <%= ENV.fetch("DATABASE_PORT") { 5432 } %>
     migrations_paths: db/cache_migrate
   queue:
     <<: *default
     database: <%= ENV.fetch("QUEUE_DATABASE_NAME") { "villagers_production_queue" } %>
-    username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>
-    password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
-    host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
-    port: <%= ENV.fetch("DATABASE_PORT") { 5432 } %>
     migrations_paths: db/queue_migrate
   cable:
     <<: *default
     database: <%= ENV.fetch("CABLE_DATABASE_NAME") { "villagers_production_cable" } %>
-    username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>
-    password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
-    host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
-    port: <%= ENV.fetch("DATABASE_PORT") { 5432 } %>
     migrations_paths: db/cable_migrate

--- a/db/migrate/20251124024049_create_conference_programs.rb
+++ b/db/migrate/20251124024049_create_conference_programs.rb
@@ -4,7 +4,10 @@ class CreateConferencePrograms < ActiveRecord::Migration[8.1]
       t.references :conference, null: false, foreign_key: true
       t.references :program, null: false, foreign_key: true
       t.text :public_description
-      t.jsonb :day_schedules, default: {}
+      # `json` (not `jsonb`) for cross-database support; MySQL/MariaDB don't have
+      # jsonb. No column default: MySQL/MariaDB can't default JSON columns, so the
+      # default empty hash is provided by ConferenceProgram#day_schedules instead.
+      t.json :day_schedules
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_18_055559) do
   create_table "conference_programs", force: :cascade do |t|
     t.bigint "conference_id", null: false
     t.datetime "created_at", null: false
-    t.jsonb "day_schedules", default: {}
+    t.json "day_schedules"
     t.integer "max_volunteers"
     t.bigint "program_id", null: false
     t.text "public_description"

--- a/test/services/timeslot_generator_test.rb
+++ b/test/services/timeslot_generator_test.rb
@@ -64,8 +64,8 @@ class TimeslotGeneratorTest < ActiveSupport::TestCase
 
     # Should generate 4 timeslots for day 0 and 4 for day 1
     assert_equal 8, @conference_program.timeslots.count
-    day_0_timeslots = @conference_program.timeslots.where("start_time::date = ?", @conference.start_date)
-    day_1_timeslots = @conference_program.timeslots.where("start_time::date = ?", @conference.end_date)
+    day_0_timeslots = @conference_program.timeslots.where("DATE(start_time) = ?", @conference.start_date)
+    day_1_timeslots = @conference_program.timeslots.where("DATE(start_time) = ?", @conference.end_date)
     assert_equal 4, day_0_timeslots.count
     assert_equal 4, day_1_timeslots.count
   end


### PR DESCRIPTION
## Summary

Makes the database engine selectable at runtime instead of being hard-coded to PostgreSQL. **PostgreSQL remains the default**; set `DATABASE_ADAPTER=mysql2` to run on MySQL/MariaDB. No Gemfile changes are needed to switch — both adapters are bundled.

## Motivation

Some deployments (e.g. Ham Radio Village) run MySQL/MariaDB rather than PostgreSQL. This lets a single codebase target either without forking.

## Changes

- **Gemfile**: bundle both `pg` and `mysql2`.
- **config/database.yml**: `DATABASE_ADAPTER` selects the adapter (default `postgresql`); `encoding`, `collation`, default username and port adjust per engine. `DATABASE_HOST`/`PORT`/`USERNAME`/`PASSWORD` remain overridable.
- **`conference_programs.day_schedules`**: portable `t.json` instead of `jsonb`, and no DB-level default (MySQL/MariaDB can't default JSON columns). `ConferenceProgram` declares `attribute :day_schedules, :json` so values serialize correctly on every engine — a no-op on PostgreSQL/MySQL (native `json`) and the fix for MariaDB, which reports the column as `longtext` with an implicit `json_valid()` CHECK constraint.
- Replace a PostgreSQL-only `start_time::date` cast in a test with portable `DATE(start_time)`.
- **`.env.example`**: document `DATABASE_ADAPTER` and related vars.

## Schema / setup note

`db/schema.rb` is committed in **PostgreSQL dialect** (the default), so it's a one-line diff from `main` (`jsonb` → `json`). A single `schema.rb` can only represent one engine's dialect, so on MySQL/MariaDB set the database up with the (portable) migrations:

```
DATABASE_ADAPTER=mysql2 bin/rails db:create db:migrate
```

## Testing

- **MySQL/MariaDB (MariaDB 11.8)**: full non-system suite green (only unrelated `city-state` gem filesystem-permission errors in the sandbox).
- **PostgreSQL**: the app boots, the `pg` gem loads, and config resolves to `postgresql`, but the suite was **not** run against a live PostgreSQL server in this environment. A CI run on PostgreSQL is recommended to confirm the default path before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)