### PR TITLE
Update Brakeman from 7.1.2 to 8.0.5 to fix CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)


### PR DESCRIPTION
## Summary
- Bump `brakeman` from 7.1.2 to 8.0.5 in `Gemfile.lock`
- Brakeman exits non-zero (code 5) when a newer version is available, which was failing CI on every run
- Scan still reports 0 security warnings on the updated version

Closes #158

## Test plan
- [x] `bin/brakeman --no-pager` — clean, 0 warnings
- [x] `bin/rails test:all` — 762 runs, 0 failures, 0 errors
- [x] `bin/rubocop -a` — no offenses
- [ ] CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)