### PR TITLE
Upgrade devise to 5.0 and fix Turbo form submissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "cssbundling-rails"
 gem "jbuilder"
 
 # Authentication
-gem "devise", "~> 4.9"
+gem "devise", "~> 5.0"
 
 # Authorization
 gem "pundit", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
@@ -118,10 +118,10 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    devise (4.9.4)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     dotenv (3.2.0)
@@ -166,8 +166,9 @@ GEM
       mini_magick (>= 4.9.5, < 6)
       ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.2)
-    irb (1.16.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jbuilder (2.14.1)
@@ -268,12 +269,12 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.6.0)
+    prism (1.9.0)
     propshaft (1.3.1)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (6.0.2)
@@ -309,8 +310,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
-      loofah (~> 2.21)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -322,8 +323,8 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
-    rdoc (7.1.0)
+    rake (13.4.2)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -432,7 +433,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.4)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux
@@ -455,7 +456,7 @@ DEPENDENCIES
   cssbundling-rails
   csv
   debug
-  devise (~> 4.9)
+  devise (~> 5.0)
   dotenv-rails
   icalendar
   image_processing (~> 1.2)

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, data: { turbo: false } }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -6,7 +6,7 @@
           <h2 class="h4 mb-0 text-center">Change your password</h2>
         </div>
         <div class="card-body">
-          <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, local: true) do |f| %>
+          <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, data: { turbo: false } }) do |f| %>
             <%= render "devise/shared/error_messages", resource: resource %>
             <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -6,7 +6,7 @@
           <h2 class="h4 mb-0 text-center">Forgot your password?</h2>
         </div>
         <div class="card-body">
-          <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, local: true) do |f| %>
+          <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, data: { turbo: false } }) do |f| %>
             <%= render "devise/shared/error_messages", resource: resource %>
 
             <p class="text-muted mb-4">Enter your email address and we'll send you instructions to reset your password.</p>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -9,7 +9,7 @@
           <h2 class="h4 mb-0">Edit Profile</h2>
         </div>
         <div class="card-body">
-          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, local: true) do |f| %>
+          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, data: { turbo: false } }) do |f| %>
             <%= render "devise/shared/error_messages", resource: resource %>
 
             <h5 class="mb-3">Account Information</h5>
@@ -133,7 +133,7 @@
           <h5 class="mb-3">Notification Preferences</h5>
           <div class="card border-info mb-4">
             <div class="card-body">
-              <%= form_with url: notification_preferences_path, method: :patch, local: true do |f| %>
+              <%= form_with url: notification_preferences_path, method: :patch, data: { turbo: false } do |f| %>
                 <div class="form-check mb-2">
                   <%= hidden_field_tag "user[notify_in_app]", "0" %>
                   <%= check_box_tag "user[notify_in_app]", "1", resource.notify_in_app?, class: "form-check-input", id: "notify_in_app" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,7 @@
           <h2 class="h4 mb-0 text-center">Sign up</h2>
         </div>
         <div class="card-body">
-          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), local: true) do |f| %>
+          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { data: { turbo: false } }) do |f| %>
             <%= render "devise/shared/error_messages", resource: resource %>
 
             <div class="mb-3">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -6,7 +6,7 @@
           <h2 class="h4 mb-0 text-center">Log in</h2>
         </div>
         <div class="card-body">
-          <%= form_for(resource, as: resource_name, url: session_path(resource_name), local: true) do |f| %>
+          <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { data: { turbo: false } }) do |f| %>
             <%= render "devise/shared/error_messages", resource: resource %>
 
             <div class="mb-3">

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend unlock instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, data: { turbo: false } }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">


### PR DESCRIPTION
## Summary
- Bump devise 4.9.4 → 5.0.4, resolving the last two `scan_ruby` CVEs (session fixation + open redirect in the Timeoutable concern)
- Replace `local: true` with `data: { turbo: false }` on every Devise form so submissions go through standard HTML navigation

## The Turbo gotcha

Devise 5 + Rails 7+ Turbo: passing `local: true` to `form_for` no longer disables Turbo. After the bump, the login form was POSTing as `TURBO_STREAM`, Devise's 303 redirect was followed as a Turbo Stream request, and the page body never swapped — so the user appeared still on the login page even though authentication had succeeded. Switching to `data: { turbo: false }` forces standard form submission.

Closes #162

## Test plan
- [x] `bin/bundler-audit` — **No vulnerabilities found**
- [x] `bin/rails test:all` — 762 runs, 0 failures, 0 errors (includes the system test that caught the Turbo issue)
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman --no-pager` — 0 warnings
- [ ] CI passes on the PR (including scan_ruby — should finally go green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)