### PR TITLE
Require authentication by default; redirect anonymous users to sign-in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,13 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  # Require authentication everywhere by default. Public pages opt out with
+  # skip_before_action: the home page (RootController), the first-run setup
+  # wizard (SetupController), the health endpoint (HealthController), and all
+  # Devise controllers (sign in/up, password reset, confirmations, OAuth).
+  before_action :authenticate_user!
+  skip_before_action :authenticate_user!, if: :devise_controller?
+
   # Make Devise helpers available in all views
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :load_past_unarchived_conferences
@@ -27,7 +34,11 @@ class ApplicationController < ActionController::Base
 
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."
-    redirect_to(request.referer || root_path)
+    if user_signed_in?
+      redirect_to(request.referer || root_path)
+    else
+      redirect_to new_user_session_path
+    end
   end
 
   def load_past_unarchived_conferences

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HealthController < ApplicationController
+  # Hit by load balancers / uptime monitors, not humans — must stay public.
+  skip_before_action :authenticate_user!
   skip_before_action :load_past_unarchived_conferences
 
   def show

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,4 +1,7 @@
 class RootController < ApplicationController
+  # The home page is public; it shows a dashboard only when signed in.
+  skip_before_action :authenticate_user!
+
   def show
     if Village.setup_complete?
       @village = Village.first

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -1,4 +1,7 @@
 class SetupController < ApplicationController
+  # The first-run wizard runs before any user account exists, so it must be
+  # reachable without authentication.
+  skip_before_action :authenticate_user!
   before_action :redirect_if_setup_complete
 
   def show

--- a/test/controllers/custom_programs_controller_test.rb
+++ b/test/controllers/custom_programs_controller_test.rb
@@ -44,8 +44,8 @@ class CustomProgramsControllerTest < ActionDispatch::IntegrationTest
 
   test "requires authentication for new" do
     get new_conference_custom_program_path(@conference)
-    # Pundit redirects to root_path when unauthorized
-    assert_redirected_to root_path
+    # Unauthenticated users are sent to sign in (issue #180)
+    assert_redirected_to new_user_session_path
   end
 
   test "conference lead can access new custom program form" do

--- a/test/integration/authentication_redirect_test.rb
+++ b/test/integration/authentication_redirect_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+# Covers issue #180: unauthenticated requests to protected pages must redirect
+# to the sign-in page (previously some raised a 500), while the intended public
+# pages stay reachable without logging in.
+class AuthenticationRedirectTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village, name: "Test Conference",
+      start_date: Date.tomorrow, end_date: Date.tomorrow + 2.days
+    )
+  end
+
+  # --- Protected pages redirect anonymous users to sign-in ---
+  test "anonymous access to conferences index redirects to sign-in (was a 500)" do
+    get conferences_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "anonymous access to a conference redirects to sign-in" do
+    get conference_path(@conference)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "anonymous access to programs redirects to sign-in" do
+    get programs_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "anonymous access to qualifications redirects to sign-in" do
+    get qualifications_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "anonymous access to the village page redirects to sign-in" do
+    get village_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "anonymous access to the schedule redirects to sign-in" do
+    get conference_schedule_path(@conference)
+    assert_redirected_to new_user_session_path
+  end
+
+  # --- Public pages remain reachable without authentication ---
+  test "home page is public" do
+    get root_path
+    assert_response :success
+  end
+
+  test "health endpoint is public" do
+    get health_path
+    assert_response :success
+  end
+
+  test "sign-in page is public" do
+    get new_user_session_path
+    assert_response :success
+  end
+
+  test "sign-up page is public" do
+    get new_user_registration_path
+    assert_response :success
+  end
+
+  test "password reset flow is public" do
+    get new_user_password_path
+    assert_response :success
+  end
+
+  test "setup wizard is not gated behind sign-in" do
+    get setup_path
+    # Setup is complete here, so it bounces to root — the point is it does NOT
+    # redirect to the sign-in page.
+    assert_not_equal new_user_session_path, URI(response.location.to_s).path if response.redirect?
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #180. Unauthenticated requests to management pages (conferences, programs, villages, qualifications, etc.) previously reached action bodies that dereferenced `current_user` on `nil`, raising a **500** — or, on Pundit-guarded actions, redirected to the home page instead of the sign-in page.

## Changes

- Added a global `before_action :authenticate_user!` in `ApplicationController`, so Devise redirects anonymous users to the sign-in page before any action body runs.
- Public pages opt out via `skip_before_action :authenticate_user!`:
  - Home page (`RootController`)
  - First-run setup wizard (`SetupController`) — runs before any user exists
  - Health endpoint (`HealthController`) — hit by load balancers/uptime monitors
  - All Devise controllers (sign in/up, password reset, confirmations, OAuth) via `if: :devise_controller?`
- Fixed `user_not_authorized` to send signed-out users to the sign-in page rather than root.

## Public surface (confirmed)

Everything requires login **except**: the home page, the Devise sign-in/up workflows, plus the setup wizard (bootstrap) and health endpoint (infra).

## Testing

- New integration test (`test/integration/authentication_redirect_test.rb`): protected pages redirect anonymous users to `new_user_session_path`; public pages (home, health, sign-in/up, password reset, setup) stay reachable.
- Updated one existing test that asserted the old (buggy) redirect-to-root behavior.
- Full non-system suite: **777 runs, 0 failures, 0 errors**.
- Manually verified: logged-out access to protected pages redirects to sign-in; public/auth flows work.

> Note: system tests were not run in the build environment (ChromeDriver/Chrome version mismatch), but this change is covered by controller/integration tests and was manually verified.

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)