### PR TITLE
Restrict conference-lead assignment to village admins

### DIFF
--- a/app/controllers/conference_roles_controller.rb
+++ b/app/controllers/conference_roles_controller.rb
@@ -5,10 +5,10 @@ class ConferenceRolesController < ApplicationController
     @user = User.find(params[:user_id])
     role_name = params[:role_name] || ConferenceRole::CONFERENCE_ADMIN
 
-    # Only conference leads and village admins can delegate admins
-    # Only village admins can change leads
+    # Only village admins can appoint conference leads.
+    # Conference leads and village admins can delegate conference admins.
     if role_name == ConferenceRole::CONFERENCE_LEAD
-      authorize @conference, :update?, policy_class: ConferencePolicy
+      authorize @conference, :assign_lead?, policy_class: ConferencePolicy
     else
       authorize @conference, :update?, policy_class: ConferencePolicy
     end

--- a/app/policies/conference_policy.rb
+++ b/app/policies/conference_policy.rb
@@ -19,6 +19,13 @@ class ConferencePolicy < ApplicationPolicy
     user&.village_admin?
   end
 
+  def assign_lead?
+    # Only village admins can appoint or change conference leads.
+    # Conference leads/admins can delegate admins (see ConferenceRolesController),
+    # but not promote other leads.
+    user&.village_admin?
+  end
+
   def archive?
     # Village admins can archive any conference
     # Conference leads can archive their assigned conferences

--- a/test/controllers/conference_roles_controller_test.rb
+++ b/test/controllers/conference_roles_controller_test.rb
@@ -78,6 +78,18 @@ class ConferenceRolesControllerTest < ActionDispatch::IntegrationTest
     assert @volunteer.conference_admin?(@conference)
   end
 
+  test "should not create conference lead role as conference lead" do
+    sign_in @conference_lead
+    assert_no_difference("ConferenceRole.count") do
+      post conference_conference_roles_url(@conference), params: {
+        user_id: @volunteer.id,
+        role_name: ConferenceRole::CONFERENCE_LEAD
+      }
+    end
+    assert_redirected_to root_path
+    assert_not @volunteer.conference_lead?(@conference)
+  end
+
   test "should not create role as regular volunteer" do
     sign_in @volunteer
     assert_no_difference("ConferenceRole.count") do

--- a/test/policies/conference_policy_test.rb
+++ b/test/policies/conference_policy_test.rb
@@ -76,6 +76,22 @@ class ConferencePolicyTest < ActiveSupport::TestCase
     assert_not ConferencePolicy.new(@volunteer, @conference).update?
   end
 
+  test "village admin can assign conference leads" do
+    assert ConferencePolicy.new(@village_admin, @conference).assign_lead?
+  end
+
+  test "conference lead cannot assign conference leads" do
+    assert_not ConferencePolicy.new(@conference_lead, @conference).assign_lead?
+  end
+
+  test "conference admin cannot assign conference leads" do
+    assert_not ConferencePolicy.new(@conference_admin, @conference).assign_lead?
+  end
+
+  test "volunteer cannot assign conference leads" do
+    assert_not ConferencePolicy.new(@volunteer, @conference).assign_lead?
+  end
+
   test "village admin can destroy conferences" do
     assert ConferencePolicy.new(@village_admin, @conference).destroy?
   end


### PR DESCRIPTION
## Summary

Fixes #167. `ConferenceRolesController#create` had a dead `if/else` where both branches ran the identical authorization check, so a conference lead or admin could appoint *another* conference lead — contradicting the intended rule (only village admins may assign leads). The UI already hid the "Assign Conference Lead" form from non-admins, so this was a server-side authorization gap reachable by a direct POST.

## Changes

- Added `ConferencePolicy#assign_lead?` (village-admin only).
- The `CONFERENCE_LEAD` branch now authorizes `:assign_lead?`; the admin branch keeps `:update?` (which conference leads/admins satisfy).

## Testing

- Policy: `assign_lead?` is true for a village admin, false for conference lead, conference admin, and volunteer.
- Controller: a conference lead cannot create a `conference_lead` role (no change + redirect to root); a village admin still can; a conference lead can still delegate a `conference_admin`.
- Full non-system suite: **0 failures, 0 errors**.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)