### PR TITLE
Bump crass, faraday, msgpack to clear bundler-audit CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       unaccent (~> 0.3)
     country_select (11.0.0)
       countries (> 6.0, < 9.0)
-    crass (1.0.6)
+    crass (1.0.7)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
@@ -136,7 +136,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -225,7 +225,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.0)
+    msgpack (1.8.3)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)


### PR DESCRIPTION
## Summary

Fixes #192. The `scan_ruby` CI job has been failing intermittently across branches (e.g. #191) — not the test suite, but **bundler-audit**, which re-downloads the advisory DB each run and flags newly-published CVEs in currently-locked gems. No code change triggers it, which is why it looks like a flaky test.

## Changes

Conservative bump of three transitive dependencies to patched versions:

- `crass` 1.0.6 → 1.0.7 (CSS parsing DoS advisories)
- `faraday` 2.14.2 → 2.14.3 (CVE-2026-54297)
- `msgpack` 1.8.0 → 1.8.3 (CVE-2026-54522)

Only `Gemfile.lock` changes.

## Verification

- `bundler-audit` → **No vulnerabilities found**
- Full test suite → **765 runs, 0 failures, 0 errors**

Companion to the earlier #160/#161 CVE cleanups (recurring maintenance as the advisory DB updates).

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)