### PR TITLE
Per-conference shift block size (minimum shift duration)

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -134,6 +134,6 @@ class ConferencesController < ApplicationController
   end
 
   def conference_params
-    params.require(:conference).permit(:name, :country, :state, :city, :start_date, :end_date, :conference_hours_start, :conference_hours_end, :reminder_hours_before)
+    params.require(:conference).permit(:name, :country, :state, :city, :start_date, :end_date, :conference_hours_start, :conference_hours_end, :reminder_hours_before, :minimum_shift_duration)
   end
 end

--- a/app/controllers/volunteer_signups_controller.rb
+++ b/app/controllers/volunteer_signups_controller.rb
@@ -38,11 +38,12 @@ class VolunteerSignupsController < ApplicationController
       requested_minutes = ((end_time - start_timeslot.start_time) / 60).to_i
     end
 
-    # Enforce the conference minimum shift duration
-    minimum_minutes = @conference.effective_minimum_shift_duration
-    if requested_minutes < minimum_minutes
+    # Enforce the conference shift block: durations must be at least one block
+    # and a whole number of blocks (e.g. 30-min blocks => 30, 60, 90, ...).
+    block_minutes = @conference.effective_minimum_shift_duration
+    if requested_minutes < block_minutes || (requested_minutes % block_minutes).nonzero?
       redirect_to conference_schedule_path(@conference),
-                  alert: "Shifts must be at least #{minimum_minutes} minutes (the minimum for this conference)."
+                  alert: "Shifts must be booked in #{block_minutes}-minute blocks for this conference."
       return
     end
 

--- a/app/controllers/volunteer_signups_controller.rb
+++ b/app/controllers/volunteer_signups_controller.rb
@@ -31,9 +31,19 @@ class VolunteerSignupsController < ApplicationController
 
     # Calculate end time from duration or use provided end_time
     if params[:duration_minutes].present?
-      end_time = start_timeslot.start_time + params[:duration_minutes].to_i.minutes
+      requested_minutes = params[:duration_minutes].to_i
+      end_time = start_timeslot.start_time + requested_minutes.minutes
     else
       end_time = Time.zone.parse(params[:end_time])
+      requested_minutes = ((end_time - start_timeslot.start_time) / 60).to_i
+    end
+
+    # Enforce the conference minimum shift duration
+    minimum_minutes = @conference.effective_minimum_shift_duration
+    if requested_minutes < minimum_minutes
+      redirect_to conference_schedule_path(@conference),
+                  alert: "Shifts must be at least #{minimum_minutes} minutes (the minimum for this conference)."
+      return
     end
 
     # Find all timeslots in the range for this program
@@ -119,6 +129,7 @@ class VolunteerSignupsController < ApplicationController
       start_time: start_timeslot.start_time.iso8601,
       start_time_display: start_timeslot.start_time.strftime("%l:%M %p").strip,
       program_name: conference_program.program.name,
+      minimum_shift_duration: @conference.effective_minimum_shift_duration,
       available_end_times: available_end_times
     }
   end

--- a/app/javascript/controllers/shift_signup_controller.js
+++ b/app/javascript/controllers/shift_signup_controller.js
@@ -3,7 +3,7 @@ import * as bootstrap from "bootstrap"
 
 // Connects to data-controller="shift-signup"
 export default class extends Controller {
-  static targets = ["modal", "startTime", "endTimeSelect", "durationDisplay", "submitBtn", "programName", "loading"]
+  static targets = ["modal", "startTime", "endTimeSelect", "durationDisplay", "submitBtn", "programName", "loading", "minimumNote", "error"]
   static values = {
     availableTimeslotsUrl: String,
     bulkCreateUrl: String,
@@ -55,12 +55,29 @@ export default class extends Controller {
   }
 
   populateModal(data) {
+    // Clear any prior validation error
+    this.hideError()
+
     // Set start time display
     this.startTimeTarget.textContent = data.start_time_display
     this.startTimeTarget.dataset.isoTime = data.start_time
 
     // Set program name
     this.programNameTarget.textContent = data.program_name
+
+    // Conference minimum shift duration (defaults to 15 if not provided).
+    // Stored so submit() can guard against a too-short shift.
+    this.minDuration = data.minimum_shift_duration || 15
+
+    // Tell the user the minimum block for this conference (only when > 15 min)
+    if (this.hasMinimumNoteTarget) {
+      if (this.minDuration > 15) {
+        this.minimumNoteTarget.textContent = `Minimum shift for this conference: ${this.formatDuration(this.minDuration)}.`
+        this.minimumNoteTarget.classList.remove("d-none")
+      } else {
+        this.minimumNoteTarget.classList.add("d-none")
+      }
+    }
 
     // Populate end time options
     this.endTimeSelectTarget.innerHTML = ""
@@ -88,8 +105,7 @@ export default class extends Controller {
       ? data.available_end_times[data.available_end_times.length - 1].duration_minutes
       : 0
 
-    // Conference minimum shift duration (defaults to 15 if not provided)
-    const minDuration = data.minimum_shift_duration || 15
+    const minDuration = this.minDuration
 
     // Create option group for durations
     const durationGroup = document.createElement("optgroup")
@@ -172,11 +188,42 @@ export default class extends Controller {
     this.updateDurationDisplay()
   }
 
+  selectedDurationMinutes() {
+    const selected = this.endTimeSelectTarget.selectedOptions[0]
+    if (!selected) return null
+
+    return selected.dataset.type === "duration"
+      ? parseInt(selected.value)
+      : parseInt(selected.dataset.durationMinutes)
+  }
+
+  showError(message) {
+    if (!this.hasErrorTarget) return
+    this.errorTarget.textContent = message
+    this.errorTarget.classList.remove("d-none")
+  }
+
+  hideError() {
+    if (!this.hasErrorTarget) return
+    this.errorTarget.textContent = ""
+    this.errorTarget.classList.add("d-none")
+  }
+
   async submit(event) {
     event.preventDefault()
+    this.hideError()
 
     const selected = this.endTimeSelectTarget.selectedOptions[0]
     if (!selected) return
+
+    // Guard against a shift shorter than the conference minimum, in case a
+    // too-short option is submitted anyway. The server also enforces this.
+    const durationMinutes = this.selectedDurationMinutes()
+    const minDuration = this.minDuration || 15
+    if (durationMinutes < minDuration) {
+      this.showError(`Shifts must be at least ${this.formatDuration(minDuration)} for this conference.`)
+      return
+    }
 
     this.submitBtnTarget.disabled = true
     this.submitBtnTarget.textContent = "Signing up..."

--- a/app/javascript/controllers/shift_signup_controller.js
+++ b/app/javascript/controllers/shift_signup_controller.js
@@ -88,13 +88,16 @@ export default class extends Controller {
       ? data.available_end_times[data.available_end_times.length - 1].duration_minutes
       : 0
 
+    // Conference minimum shift duration (defaults to 15 if not provided)
+    const minDuration = data.minimum_shift_duration || 15
+
     // Create option group for durations
     const durationGroup = document.createElement("optgroup")
     durationGroup.label = "Select Duration"
 
     let defaultSelected = false
     durations.forEach(d => {
-      if (d.minutes <= maxDuration) {
+      if (d.minutes >= minDuration && d.minutes <= maxDuration) {
         const option = document.createElement("option")
         option.value = d.minutes
         option.dataset.type = "duration"
@@ -125,6 +128,8 @@ export default class extends Controller {
     endTimeGroup.label = "Or Select End Time"
 
     data.available_end_times.forEach(et => {
+      if (et.duration_minutes < minDuration) return
+
       const option = document.createElement("option")
       option.value = et.end_time
       option.dataset.type = "end_time"

--- a/app/javascript/controllers/shift_signup_controller.js
+++ b/app/javascript/controllers/shift_signup_controller.js
@@ -65,14 +65,14 @@ export default class extends Controller {
     // Set program name
     this.programNameTarget.textContent = data.program_name
 
-    // Conference minimum shift duration (defaults to 15 if not provided).
-    // Stored so submit() can guard against a too-short shift.
+    // Conference shift block size (defaults to 15 if not provided). Durations
+    // must be a whole number of blocks. Stored so submit() can guard too.
     this.minDuration = data.minimum_shift_duration || 15
 
-    // Tell the user the minimum block for this conference (only when > 15 min)
+    // Tell the user the block size for this conference (only when > 15 min)
     if (this.hasMinimumNoteTarget) {
       if (this.minDuration > 15) {
-        this.minimumNoteTarget.textContent = `Minimum shift for this conference: ${this.formatDuration(this.minDuration)}.`
+        this.minimumNoteTarget.textContent = `Shifts are booked in ${this.formatDuration(this.minDuration)} blocks.`
         this.minimumNoteTarget.classList.remove("d-none")
       } else {
         this.minimumNoteTarget.classList.add("d-none")
@@ -113,7 +113,7 @@ export default class extends Controller {
 
     let defaultSelected = false
     durations.forEach(d => {
-      if (d.minutes >= minDuration && d.minutes <= maxDuration) {
+      if (d.minutes >= minDuration && d.minutes <= maxDuration && d.minutes % minDuration === 0) {
         const option = document.createElement("option")
         option.value = d.minutes
         option.dataset.type = "duration"
@@ -144,7 +144,7 @@ export default class extends Controller {
     endTimeGroup.label = "Or Select End Time"
 
     data.available_end_times.forEach(et => {
-      if (et.duration_minutes < minDuration) return
+      if (et.duration_minutes < minDuration || et.duration_minutes % minDuration !== 0) return
 
       const option = document.createElement("option")
       option.value = et.end_time
@@ -216,12 +216,12 @@ export default class extends Controller {
     const selected = this.endTimeSelectTarget.selectedOptions[0]
     if (!selected) return
 
-    // Guard against a shift shorter than the conference minimum, in case a
-    // too-short option is submitted anyway. The server also enforces this.
+    // Guard against a shift that isn't a whole number of blocks, in case such
+    // an option is submitted anyway. The server also enforces this.
     const durationMinutes = this.selectedDurationMinutes()
-    const minDuration = this.minDuration || 15
-    if (durationMinutes < minDuration) {
-      this.showError(`Shifts must be at least ${this.formatDuration(minDuration)} for this conference.`)
+    const block = this.minDuration || 15
+    if (durationMinutes < block || durationMinutes % block !== 0) {
+      this.showError(`Shifts must be booked in ${this.formatDuration(block)} blocks for this conference.`)
       return
     }
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -129,6 +129,12 @@ class Conference < ApplicationRecord
     reminder_hours_before || village.reminder_hours_before || 24
   end
 
+  # Returns the effective minimum shift duration (in minutes) for this conference
+  # Uses conference-specific value if set, otherwise falls back to 15 minutes
+  def effective_minimum_shift_duration
+    minimum_shift_duration || 15
+  end
+
   private
 
   def end_date_after_start_date

--- a/app/views/conferences/edit.html.erb
+++ b/app/views/conferences/edit.html.erb
@@ -48,6 +48,18 @@
             </div>
 
             <div class="mb-3">
+              <%= form.label :minimum_shift_duration, "Minimum Shift Duration", class: "form-label" %>
+              <%= form.select :minimum_shift_duration,
+                  options_for_select([ [ "15 minutes", 15 ], [ "30 minutes", 30 ], [ "45 minutes", 45 ], [ "1 hour", 60 ], [ "2 hours", 120 ] ], @conference.minimum_shift_duration),
+                  { include_blank: "No minimum (15 min)" },
+                  { class: "form-select" } %>
+              <div class="form-text">
+                Volunteers cannot sign up for a shift shorter than this.
+                Leave blank to allow the default 15-minute minimum.
+              </div>
+            </div>
+
+            <div class="mb-3">
               <%= label_tag :conference_lead_id, "Conference Lead", class: "form-label" %>
               <%= select_tag :conference_lead_id,
                   options_from_collection_for_select(@users, :id, :email, @current_lead&.id),

--- a/app/views/conferences/edit.html.erb
+++ b/app/views/conferences/edit.html.erb
@@ -48,14 +48,15 @@
             </div>
 
             <div class="mb-3">
-              <%= form.label :minimum_shift_duration, "Minimum Shift Duration", class: "form-label" %>
+              <%= form.label :minimum_shift_duration, "Shift Block Size", class: "form-label" %>
               <%= form.select :minimum_shift_duration,
                   options_for_select([ [ "15 minutes", 15 ], [ "30 minutes", 30 ], [ "45 minutes", 45 ], [ "1 hour", 60 ], [ "2 hours", 120 ] ], @conference.minimum_shift_duration),
-                  { include_blank: "No minimum (15 min)" },
+                  { include_blank: "15 minutes (default)" },
                   { class: "form-select" } %>
               <div class="form-text">
-                Volunteers cannot sign up for a shift shorter than this.
-                Leave blank to allow the default 15-minute minimum.
+                Volunteers book shifts in whole blocks of this length
+                (e.g. 30-minute blocks allow 30, 60, 90&hellip; but not 45).
+                Leave blank for the default 15-minute blocks.
               </div>
             </div>
 

--- a/app/views/conferences/new.html.erb
+++ b/app/views/conferences/new.html.erb
@@ -48,6 +48,18 @@
             </div>
 
             <div class="mb-3">
+              <%= form.label :minimum_shift_duration, "Minimum Shift Duration", class: "form-label" %>
+              <%= form.select :minimum_shift_duration,
+                  options_for_select([ [ "15 minutes", 15 ], [ "30 minutes", 30 ], [ "45 minutes", 45 ], [ "1 hour", 60 ], [ "2 hours", 120 ] ], @conference.minimum_shift_duration),
+                  { include_blank: "No minimum (15 min)" },
+                  { class: "form-select" } %>
+              <div class="form-text">
+                Volunteers cannot sign up for a shift shorter than this.
+                Leave blank to allow the default 15-minute minimum.
+              </div>
+            </div>
+
+            <div class="mb-3">
               <%= form.label :conference_lead_id, "Conference Lead", class: "form-label" %>
               <%= form.select :conference_lead_id, 
                   options_from_collection_for_select(@users, :id, :email, params[:conference_lead_id]),

--- a/app/views/conferences/new.html.erb
+++ b/app/views/conferences/new.html.erb
@@ -48,14 +48,15 @@
             </div>
 
             <div class="mb-3">
-              <%= form.label :minimum_shift_duration, "Minimum Shift Duration", class: "form-label" %>
+              <%= form.label :minimum_shift_duration, "Shift Block Size", class: "form-label" %>
               <%= form.select :minimum_shift_duration,
                   options_for_select([ [ "15 minutes", 15 ], [ "30 minutes", 30 ], [ "45 minutes", 45 ], [ "1 hour", 60 ], [ "2 hours", 120 ] ], @conference.minimum_shift_duration),
-                  { include_blank: "No minimum (15 min)" },
+                  { include_blank: "15 minutes (default)" },
                   { class: "form-select" } %>
               <div class="form-text">
-                Volunteers cannot sign up for a shift shorter than this.
-                Leave blank to allow the default 15-minute minimum.
+                Volunteers book shifts in whole blocks of this length
+                (e.g. 30-minute blocks allow 30, 60, 90&hellip; but not 45).
+                Leave blank for the default 15-minute blocks.
               </div>
             </div>
 

--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -207,7 +207,10 @@
             <select id="shiftDuration" class="form-select" data-shift-signup-target="endTimeSelect" data-action="change->shift-signup#selectionChanged">
               <option>Loading options...</option>
             </select>
+            <div class="form-text d-none" data-shift-signup-target="minimumNote"></div>
           </div>
+
+          <div class="alert alert-danger d-none" data-shift-signup-target="error"></div>
 
           <div class="alert alert-info mb-0">
             <small>

--- a/db/migrate/20260702234200_add_minimum_shift_duration_to_conferences.rb
+++ b/db/migrate/20260702234200_add_minimum_shift_duration_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddMinimumShiftDurationToConferences < ActiveRecord::Migration[8.1]
+  def change
+    add_column :conferences, :minimum_shift_duration, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_234200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -66,6 +66,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
     t.string "country", default: "US"
     t.datetime "created_at", null: false
     t.date "end_date"
+    t.integer "minimum_shift_duration"
     t.string "name"
     t.integer "reminder_hours_before"
     t.date "start_date"

--- a/test/controllers/conferences_controller_test.rb
+++ b/test/controllers/conferences_controller_test.rb
@@ -143,6 +143,34 @@ class ConferencesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "US", @conference.country
   end
 
+  test "should permit and persist minimum_shift_duration on create" do
+    sign_in @village_admin
+    assert_difference("Conference.count") do
+      post conferences_url, params: {
+        conference: {
+          name: "Min Duration Conference",
+          start_date: Date.today,
+          end_date: Date.tomorrow,
+          minimum_shift_duration: 30
+        }
+      }
+    end
+    assert_equal 30, Conference.last.minimum_shift_duration
+  end
+
+  test "should permit and persist minimum_shift_duration on update" do
+    sign_in @village_admin
+    patch conference_url(@conference), params: {
+      conference: {
+        name: @conference.name,
+        minimum_shift_duration: 60
+      }
+    }
+    assert_redirected_to @conference
+    @conference.reload
+    assert_equal 60, @conference.minimum_shift_duration
+  end
+
   test "should update conference lead" do
     sign_in @village_admin
     new_lead = User.create!(

--- a/test/controllers/volunteer_signups_controller_test.rb
+++ b/test/controllers/volunteer_signups_controller_test.rb
@@ -206,6 +206,51 @@ class VolunteerSignupsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to conference_volunteer_signups_path(@conference)
   end
 
+  test "bulk create rejects duration below conference minimum_shift_duration" do
+    @conference.update!(minimum_shift_duration: 60)
+
+    timeslots = []
+    4.times do |i|
+      timeslots << Timeslot.create!(
+        conference_program: @conference_program,
+        start_time: Date.tomorrow.to_datetime + 11.hours + (i * 15).minutes,
+        max_volunteers: 2
+      )
+    end
+
+    sign_in @volunteer
+    assert_no_difference("VolunteerSignup.count") do
+      post bulk_create_conference_volunteer_signups_url(@conference), params: {
+        timeslot_id: timeslots.first.id,
+        duration_minutes: 30
+      }
+    end
+    assert_redirected_to conference_schedule_path(@conference)
+    assert_match(/minimum/i, flash[:alert])
+  end
+
+  test "bulk create allows duration at conference minimum_shift_duration" do
+    @conference.update!(minimum_shift_duration: 60)
+
+    timeslots = []
+    4.times do |i|
+      timeslots << Timeslot.create!(
+        conference_program: @conference_program,
+        start_time: Date.tomorrow.to_datetime + 11.hours + (i * 15).minutes,
+        max_volunteers: 2
+      )
+    end
+
+    sign_in @volunteer
+    assert_difference("VolunteerSignup.count", 4) do
+      post bulk_create_conference_volunteer_signups_url(@conference), params: {
+        timeslot_id: timeslots.first.id,
+        duration_minutes: 60
+      }
+    end
+    assert_redirected_to conference_volunteer_signups_path(@conference)
+  end
+
   test "bulk create fails if any timeslot is full" do
     timeslots = []
     4.times do |i|

--- a/test/controllers/volunteer_signups_controller_test.rb
+++ b/test/controllers/volunteer_signups_controller_test.rb
@@ -226,7 +226,31 @@ class VolunteerSignupsControllerTest < ActionDispatch::IntegrationTest
       }
     end
     assert_redirected_to conference_schedule_path(@conference)
-    assert_match(/minimum/i, flash[:alert])
+    assert_match(/block/i, flash[:alert])
+  end
+
+  test "bulk create rejects a duration that is not a whole number of blocks" do
+    @conference.update!(minimum_shift_duration: 30)
+
+    timeslots = []
+    4.times do |i|
+      timeslots << Timeslot.create!(
+        conference_program: @conference_program,
+        start_time: Date.tomorrow.to_datetime + 11.hours + (i * 15).minutes,
+        max_volunteers: 2
+      )
+    end
+
+    sign_in @volunteer
+    # 45 minutes is >= the 30-min minimum but is not a multiple of 30
+    assert_no_difference("VolunteerSignup.count") do
+      post bulk_create_conference_volunteer_signups_url(@conference), params: {
+        timeslot_id: timeslots.first.id,
+        duration_minutes: 45
+      }
+    end
+    assert_redirected_to conference_schedule_path(@conference)
+    assert_match(/block/i, flash[:alert])
   end
 
   test "bulk create allows duration at conference minimum_shift_duration" do

--- a/test/models/conference_test.rb
+++ b/test/models/conference_test.rb
@@ -356,4 +356,29 @@ class ConferenceTest < ActiveSupport::TestCase
 
     assert_equal 24, conference.effective_reminder_hours
   end
+
+  # Minimum shift duration tests
+  test "effective_minimum_shift_duration returns conference value when set" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days,
+      minimum_shift_duration: 30
+    )
+
+    assert_equal 30, conference.effective_minimum_shift_duration
+  end
+
+  test "effective_minimum_shift_duration returns 15 when not set" do
+    conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 3.days
+    )
+
+    assert_nil conference.minimum_shift_duration
+    assert_equal 15, conference.effective_minimum_shift_duration
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #182. Adds an optional per-conference **shift block size**: volunteers book shifts in whole multiples of the configured block (e.g. 30-minute blocks allow 30, 60, 90… but not 45). The underlying 15-minute schedule grid is unchanged (Interpretation A from the issue — a booking constraint, not a change to timeslot generation).

## Changes

- Migration: nullable `minimum_shift_duration` (minutes) on `conferences`; `Conference#effective_minimum_shift_duration` (defaults to 15).
- "Shift Block Size" dropdown on the conference new/edit forms; permitted in `conference_params`.
- Enforcement in three places so it's consistent:
  - Signup modal dropdown filters options to whole multiples of the block.
  - Client-side submit guard shows an inline error if a non-multiple is submitted anyway.
  - Server (`bulk_create`) rejects durations that are below the block or not a whole multiple.
- `available_timeslots` exposes the block size to the modal.

## Testing

- Model: `effective_minimum_shift_duration` fallback.
- Controller: param permitted/persisted; `bulk_create` rejects below-minimum and non-multiple (e.g. 45 under a 30-min block), allows valid multiples.
- Full suite: **772 runs, 0 failures**. bundler-audit clean.

> Note: system tests don't run in the build environment (ChromeDriver/Chrome mismatch); the dropdown filtering was verified manually and the enforcement is covered by controller tests.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)