### PR TITLE
Wrap qualification-required pills within the schedule column

### DIFF
--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -275,6 +275,10 @@
   .qualification-pill {
     font-size: 0.7rem;
     font-weight: normal;
+    white-space: normal;
+    word-break: break-word;
+    text-align: left;
+    min-width: 0;
   }
 
   .schedule-slot {

--- a/test/system/schedule_test.rb
+++ b/test/system/schedule_test.rb
@@ -111,6 +111,31 @@ class ScheduleTest < ApplicationSystemTestCase
     assert_text (Date.today + 1.day).strftime("%A, %B %d")
   end
 
+  test "long qualification-required pill wraps within the program column" do
+    qualification = Qualification.create!(
+      village: @village,
+      name: "Amateur Radio Extra Class License with Vanity Callsign Endorsement",
+      description: "A qualification with a deliberately long name"
+    )
+    @program.qualifications << qualification
+
+    login_as @volunteer
+    visit conference_schedule_path(@conference)
+
+    pill = find(".qualification-pill", match: :first)
+    assert_match(/qualification required/, pill.text)
+
+    # The pill must allow its text to wrap and long words to break so it
+    # stays within the fixed-width program column instead of overflowing.
+    assert_equal "normal", pill.native.css_value("white-space")
+    assert_equal "break-word", pill.native.css_value("word-break")
+
+    # The rendered pill should not be wider than its containing program column.
+    column = find(".program-column", match: :first)
+    assert pill.native.size.width <= column.native.size.width,
+           "Qualification pill (#{pill.native.size.width}px) overflowed the program column (#{column.native.size.width}px)"
+  end
+
   test "schedule has signup buttons with modal trigger" do
     login_as @volunteer
     visit conference_schedule_path(@conference)


### PR DESCRIPTION
## Summary

Fixes #184. On the schedule page, "…qualification required" pills overflowed the fixed-width program column when the qualification name was long. This makes them wrap cleanly within the column.

## Changes

`.qualification-pill` now sets `white-space: normal; word-break: break-word; text-align: left; min-width: 0;` so the badge text wraps and long names break inside the ~200px `.program-column` (which is `table-layout: fixed`), instead of overflowing.

CSS-only change (inline `<style>` in `app/views/schedule/show.html.erb`).

## Testing

- Verified manually against a program requiring a long-named qualification (demo conference): the pill wraps within the column.
- Full non-system suite passes. (System tests can't run in the build environment — ChromeDriver/Chrome mismatch — so this was verified visually.)

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)