### PR TITLE
Float (sticky) the program-name header row on the schedule page

### DIFF
--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -235,6 +235,41 @@
     table-layout: fixed;
   }
 
+  /*
+   * Sticky header: keep each day's program-name header row pinned to the top
+   * of the viewport while scrolling that day's (tall) table. The navbar is not
+   * fixed/sticky, so it scrolls away and top: 0 pins the header to the viewport.
+   *
+   * Bootstrap's .table-responsive wrapper sets overflow-x: auto, which makes the
+   * browser compute overflow-y as auto too, creating a scroll container that
+   * breaks vertical position: sticky. We override overflow-y: visible on this
+   * page so vertical sticky works against the viewport while horizontal scroll
+   * is preserved.
+   */
+  .table-responsive {
+    overflow-y: visible;
+  }
+
+  .schedule-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background-color: #f8f9fa; /* opaque bg (matches .table-light) so scrolled rows don't show through */
+  }
+
+  /* Keep the Time label column visible on horizontal scroll (top + left). */
+  .schedule-table .time-column {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    background-color: #fff;
+  }
+
+  .schedule-table thead th.time-column {
+    z-index: 3; /* top-left corner sits above both sticky row and sticky column */
+    background-color: #f8f9fa;
+  }
+
   .time-column {
     width: 100px;
     white-space: nowrap;

--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -236,18 +236,19 @@
   }
 
   /*
-   * Sticky header: keep each day's program-name header row pinned to the top
-   * of the viewport while scrolling that day's (tall) table. The navbar is not
-   * fixed/sticky, so it scrolls away and top: 0 pins the header to the viewport.
+   * Sticky header: keep each day's program-name header row pinned while
+   * scrolling that day's (tall) table.
    *
-   * Bootstrap's .table-responsive wrapper sets overflow-x: auto, which makes the
-   * browser compute overflow-y as auto too, creating a scroll container that
-   * breaks vertical position: sticky. We override overflow-y: visible on this
-   * page so vertical sticky works against the viewport while horizontal scroll
-   * is preserved.
+   * Bootstrap's .table-responsive sets overflow-x: auto. Per the CSS spec, when
+   * one overflow axis is auto the other cannot be `visible` (it computes to
+   * auto), so we can't make vertical sticky resolve against the viewport here.
+   * Instead we make the wrapper a bounded scroll region (max-height + overflow),
+   * so position: sticky pins the header to the top of that scrolling area while
+   * horizontal scroll is preserved.
    */
   .table-responsive {
-    overflow-y: visible;
+    max-height: 75vh;
+    overflow: auto;
   }
 
   .schedule-table thead th {

--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -237,15 +237,19 @@
 
   /*
    * Sticky header: the program-name header row stays pinned to the top of the
-   * viewport while scrolling a day's (tall) table. The columns are laid out
-   * with table-layout: fixed and size to fit the viewport, so there is no
-   * horizontal scroll to preserve. We drop .table-responsive's overflow so no
-   * scroll-container ancestor sits between the header and the viewport, letting
-   * the whole page scroll naturally and the header pin against it. The navbar is
-   * not fixed, so top: 0 pins to the very top.
+   * viewport while scrolling a day's (tall) table. The columns use table-layout:
+   * fixed and size to fit the viewport, so there is no horizontal scroll to keep.
+   *
+   * overflow-y must stay visible so no scroll-container ancestor sits between the
+   * header and the viewport (that's what lets the whole page scroll and the
+   * header pin against it). overflow-x: clip contains any stray horizontal
+   * overflow (e.g. a wide cell) without adding a page scrollbar and — unlike
+   * auto/hidden — does NOT create a scroll container, so sticky keeps working.
+   * The navbar is not fixed, so top: 0 pins to the very top.
    */
   .table-responsive {
-    overflow: visible;
+    overflow-x: clip;
+    overflow-y: visible;
   }
 
   .schedule-table thead th {

--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -236,19 +236,16 @@
   }
 
   /*
-   * Sticky header: keep each day's program-name header row pinned while
-   * scrolling that day's (tall) table.
-   *
-   * Bootstrap's .table-responsive sets overflow-x: auto. Per the CSS spec, when
-   * one overflow axis is auto the other cannot be `visible` (it computes to
-   * auto), so we can't make vertical sticky resolve against the viewport here.
-   * Instead we make the wrapper a bounded scroll region (max-height + overflow),
-   * so position: sticky pins the header to the top of that scrolling area while
-   * horizontal scroll is preserved.
+   * Sticky header: the program-name header row stays pinned to the top of the
+   * viewport while scrolling a day's (tall) table. The columns are laid out
+   * with table-layout: fixed and size to fit the viewport, so there is no
+   * horizontal scroll to preserve. We drop .table-responsive's overflow so no
+   * scroll-container ancestor sits between the header and the viewport, letting
+   * the whole page scroll naturally and the header pin against it. The navbar is
+   * not fixed, so top: 0 pins to the very top.
    */
   .table-responsive {
-    max-height: 75vh;
-    overflow: auto;
+    overflow: visible;
   }
 
   .schedule-table thead th {
@@ -256,19 +253,6 @@
     top: 0;
     z-index: 2;
     background-color: #f8f9fa; /* opaque bg (matches .table-light) so scrolled rows don't show through */
-  }
-
-  /* Keep the Time label column visible on horizontal scroll (top + left). */
-  .schedule-table .time-column {
-    position: sticky;
-    left: 0;
-    z-index: 1;
-    background-color: #fff;
-  }
-
-  .schedule-table thead th.time-column {
-    z-index: 3; /* top-left corner sits above both sticky row and sticky column */
-    background-color: #f8f9fa;
   }
 
   .time-column {

--- a/test/system/schedule_test.rb
+++ b/test/system/schedule_test.rb
@@ -150,6 +150,23 @@ class ScheduleTest < ApplicationSystemTestCase
     assert day_two.has_text?("No programs scheduled")
   end
 
+  test "schedule header row is sticky" do
+    login_as @volunteer
+    visit conference_schedule_path(@conference)
+
+    # The program-name header cells should use position: sticky so they stay
+    # pinned to the top of the viewport while scrolling a day's table.
+    position = page.evaluate_script(
+      "getComputedStyle(document.querySelector('.schedule-table thead th')).position"
+    )
+    assert_equal "sticky", position
+
+    top = page.evaluate_script(
+      "getComputedStyle(document.querySelector('.schedule-table thead th')).top"
+    )
+    assert_equal "0px", top
+  end
+
   test "schedule has signup buttons with modal trigger" do
     login_as @volunteer
     visit conference_schedule_path(@conference)


### PR DESCRIPTION
## Summary

Fixes #183. On the schedule page the program-name header row now stays pinned to the top of the viewport while scrolling a day's (tall) table, so the column labels remain visible.

## Changes

- `.schedule-table thead th` uses `position: sticky; top: 0` with an opaque background.
- `.table-responsive` uses `overflow-x: clip; overflow-y: visible`:
  - `overflow-y: visible` keeps the page (not an inner frame) as the scroll context, so the header pins to the viewport — no awkward scroll-within-scroll.
  - `overflow-x: clip` contains any stray horizontal overflow without adding a page-wide scrollbar, and (unlike `auto`/`hidden`) does not create a scroll container, so sticky keeps working. The columns use `table-layout: fixed` and size to the viewport, so there's no horizontal scroll to preserve.

CSS-only (inline `<style>` in `app/views/schedule/show.html.erb`).

## Testing

- Added a system test asserting the header cell computes `position: sticky` / `top: 0`.
- Manually verified against the demo conference: header pins on scroll, no horizontal scrollbar, and long qualification pills wrap (via #184) rather than spilling.
- Full non-system suite passes. (System tests don't run in the build environment — ChromeDriver/Chrome mismatch — so behavior was verified manually.)

> Note: the schedule view's inline `<style>` block will be extracted to a compiled stylesheet as a follow-up (#197).

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)