### PR TITLE
Hide schedule columns for programs with no shifts that day

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -47,13 +47,10 @@ class ScheduleController < ApplicationController
       # Get timeslots for this day grouped by program
       @conference.conference_programs.includes(:program).each do |cp|
         program = cp.program
-        schedule[date][:programs][program.id] = {
-          name: program.name,
-          timeslots: {}
-        }
+        timeslots = {}
 
         cp.timeslots.where("DATE(start_time) = ?", date).includes(:volunteer_signups, :users).each do |timeslot|
-          schedule[date][:programs][program.id][:timeslots][timeslot.start_time.strftime("%H:%M")] = {
+          timeslots[timeslot.start_time.strftime("%H:%M")] = {
             timeslot: timeslot,
             volunteers: timeslot.users,
             signed_up_count: timeslot.current_volunteers_count,
@@ -61,6 +58,15 @@ class ScheduleController < ApplicationController
             full: timeslot.full?
           }
         end
+
+        # Skip programs that have no timeslots on this day so empty columns are
+        # not rendered (issue #181).
+        next if timeslots.empty?
+
+        schedule[date][:programs][program.id] = {
+          name: program.name,
+          timeslots: timeslots
+        }
       end
     end
 

--- a/test/controllers/schedule_controller_test.rb
+++ b/test/controllers/schedule_controller_test.rb
@@ -72,6 +72,14 @@ class ScheduleControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "schedule shows programs for conference" do
+    # A program only renders a column on days where it has timeslots.
+    Timeslot.create!(
+      conference_program: @conference_program,
+      start_time: @conference.start_date.to_datetime + 9.hours,
+      max_volunteers: 2,
+      current_volunteers_count: 0
+    )
+
     sign_in @volunteer
     get conference_schedule_url(@conference)
     assert_response :success
@@ -98,6 +106,26 @@ class ScheduleControllerTest < ActionDispatch::IntegrationTest
     get conference_schedule_url(@conference)
     assert_response :success
     # Schedule should show each day of the conference
+  end
+
+  test "hides program column on days with no timeslots" do
+    # Enable the program only on the first day of the multi-day conference,
+    # which generates timeslots for day 1 but none for days 2 and 3.
+    @conference_program.update!(
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+
+    sign_in @volunteer
+    get conference_schedule_url(@conference)
+    assert_response :success
+
+    # The program column header should render exactly once (only on day 1),
+    # not once per conference day.
+    assert_equal 1, response.body.scan('class="program-column text-center"').count
+    # Days with no scheduled program fall back to the empty-day message.
+    assert_match "No programs scheduled", response.body
   end
 
   test "schedule shows qualification required pill for unqualified user" do

--- a/test/system/schedule_test.rb
+++ b/test/system/schedule_test.rb
@@ -136,6 +136,20 @@ class ScheduleTest < ApplicationSystemTestCase
            "Qualification pill (#{pill.native.size.width}px) overflowed the program column (#{column.native.size.width}px)"
   end
 
+  test "hides program column on days with no timeslots" do
+    login_as @volunteer
+    visit conference_schedule_path(@conference)
+
+    # Program is enabled only on day 0, so day 1's card shows the program header
+    # while day 2's card omits it and shows the empty-day fallback.
+    day_one = find(".card", text: Date.today.strftime("%A, %B %d"))
+    assert day_one.has_selector?("th.program-column", text: @program.name)
+
+    day_two = find(".card", text: (Date.today + 1.day).strftime("%A, %B %d"))
+    assert_not day_two.has_selector?("th.program-column", text: @program.name)
+    assert day_two.has_text?("No programs scheduled")
+  end
+
   test "schedule has signup buttons with modal trigger" do
     login_as @volunteer
     visit conference_schedule_path(@conference)


### PR DESCRIPTION
## Summary

Fixes #181. On the schedule page, a program that had no shifts on a given day still rendered as an empty column, adding wasted whitespace. Now a program only gets a column on days it actually has timeslots.

## Changes

`ScheduleController#build_schedule_data` builds each program's timeslot hash for the day first and skips the program entirely when it's empty (`next if timeslots.empty?`), instead of unconditionally adding an entry for every conference program. No view change is needed — the existing "No programs scheduled" / `-` fallback still handles days where no program runs.

## Testing

- Controller test: a program enabled only on some days appears as a column only on those days.
- System test: on a multi-day conference, the program header is present on its scheduled day and absent (with the empty-day fallback) on days it isn't.
- Full non-system suite passes.

> Note: shares `app/views/schedule/show.html.erb` with #183/#184/#185; the inline `<style>` extraction is tracked separately as #197.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)