### PR TITLE
Add optional per-conference Activity Lead role

### DIFF
--- a/app/controllers/conference_program_roles_controller.rb
+++ b/app/controllers/conference_program_roles_controller.rb
@@ -1,0 +1,41 @@
+class ConferenceProgramRolesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference
+  before_action :set_conference_program
+
+  def create
+    @user = User.find(params[:user_id])
+    authorize @conference_program, :update?, policy_class: ConferenceProgramPolicy
+
+    ConferenceProgramRole.find_or_create_by!(
+      user: @user,
+      conference_program: @conference_program,
+      role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+
+    redirect_to conference_conference_program_path(@conference, @conference_program),
+                notice: "Activity lead assigned successfully."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to conference_conference_program_path(@conference, @conference_program),
+                alert: "Could not assign activity lead: #{e.message}"
+  end
+
+  def destroy
+    @conference_program_role = @conference_program.conference_program_roles.find(params[:id])
+    authorize @conference_program, :update?, policy_class: ConferenceProgramPolicy
+
+    @conference_program_role.destroy
+    redirect_to conference_conference_program_path(@conference, @conference_program),
+                notice: "Activity lead removed successfully."
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+
+  def set_conference_program
+    @conference_program = @conference.conference_programs.find(params[:conference_program_id])
+  end
+end

--- a/app/controllers/conference_programs_controller.rb
+++ b/app/controllers/conference_programs_controller.rb
@@ -1,6 +1,7 @@
 class ConferenceProgramsController < ApplicationController
   before_action :set_conference
   before_action :set_conference_program, only: [ :show, :edit, :update, :destroy ]
+  before_action :authorize_conference_management, except: [ :show ]
 
   def index
     @conference_programs = @conference.conference_programs.includes(:program).order("programs.name")
@@ -67,6 +68,13 @@ class ConferenceProgramsController < ApplicationController
 
   def set_conference
     @conference = Conference.find(params[:conference_id])
+  end
+
+  # Managing the conference's activities (listing, creating, editing, deleting)
+  # requires conference-level management rights. The #show action is exempt: it
+  # authorizes at the activity level so an activity lead can view their own
+  # activity (and manage its leads).
+  def authorize_conference_management
     authorize @conference, :update?, policy_class: ConferencePolicy
   end
 

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -5,6 +5,12 @@ class ScheduleController < ApplicationController
   def show
     authorize @conference, :show?, policy_class: ConferencePolicy
 
+    # Conference managers manage every activity; an activity lead manages only
+    # their own. @manageable_program_ids is the set of Program ids whose columns
+    # the current user may administer (see full volunteer names, add/remove
+    # volunteers, edit capacity). @can_see_all_volunteers stays true only for
+    # full conference managers (used for the page-level view badge).
+    @manageable_program_ids = manageable_program_ids
     @can_see_all_volunteers = current_user.can_manage_conference?(@conference)
 
     # Build time slots for each day (15-minute increments)
@@ -25,14 +31,33 @@ class ScheduleController < ApplicationController
     # Build user's effective qualifications for this conference
     @user_qualification_ids = build_user_qualification_ids
 
-    # Get all users for admin dropdown
-    @users = User.order(:email) if @can_see_all_volunteers
+    # Get all users for admin dropdown (needed whenever the user can manage at
+    # least one activity, so activity leads get the add-volunteer picker too)
+    @users = User.order(:email) if @manageable_program_ids.any?
   end
 
   private
 
   def set_conference
     @conference = Conference.find(params[:conference_id])
+  end
+
+  # Set of Program ids the current user may administer on this schedule.
+  # Conference managers get all of them; activity leads get only the programs
+  # they lead at this conference.
+  def manageable_program_ids
+    if current_user.can_manage_conference?(@conference)
+      return @conference.conference_programs.pluck(:program_id).to_set
+    end
+
+    ConferenceProgram.where(conference: @conference)
+                     .joins(:conference_program_roles)
+                     .where(conference_program_roles: {
+                              user_id: current_user.id,
+                              role_name: ConferenceProgramRole::ACTIVITY_LEAD
+                            })
+                     .pluck(:program_id)
+                     .to_set
   end
 
   def build_schedule_data

--- a/app/controllers/timeslots_controller.rb
+++ b/app/controllers/timeslots_controller.rb
@@ -4,7 +4,7 @@ class TimeslotsController < ApplicationController
   before_action :set_timeslot
 
   def update
-    authorize @conference, :update?, policy_class: ConferencePolicy
+    authorize @timeslot.conference_program, :update?, policy_class: ConferenceProgramPolicy
 
     if @timeslot.update(timeslot_params)
       redirect_to conference_schedule_path(@conference), notice: "Timeslot updated successfully."
@@ -14,7 +14,7 @@ class TimeslotsController < ApplicationController
   end
 
   def add_volunteer
-    authorize @conference, :update?, policy_class: ConferencePolicy
+    authorize @timeslot.conference_program, :update?, policy_class: ConferenceProgramPolicy
 
     user = User.find(params[:user_id])
     signup = VolunteerSignup.new(user: user, timeslot: @timeslot)
@@ -27,7 +27,7 @@ class TimeslotsController < ApplicationController
   end
 
   def remove_volunteer
-    authorize @conference, :update?, policy_class: ConferencePolicy
+    authorize @timeslot.conference_program, :update?, policy_class: ConferenceProgramPolicy
 
     signup = @timeslot.volunteer_signups.find_by!(user_id: params[:user_id])
     user_email = signup.user.email

--- a/app/models/conference_program.rb
+++ b/app/models/conference_program.rb
@@ -10,6 +10,10 @@ class ConferenceProgram < ApplicationRecord
   belongs_to :conference
   belongs_to :program
   has_many :timeslots, dependent: :destroy
+  has_many :conference_program_roles, dependent: :destroy
+  has_many :activity_leads,
+           -> { where(conference_program_roles: { role_name: ConferenceProgramRole::ACTIVITY_LEAD }) },
+           through: :conference_program_roles, source: :user
 
   validates :conference, presence: true
   validates :program, presence: true, uniqueness: { scope: :conference_id }

--- a/app/models/conference_program_role.rb
+++ b/app/models/conference_program_role.rb
@@ -1,0 +1,10 @@
+class ConferenceProgramRole < ApplicationRecord
+  belongs_to :user
+  belongs_to :conference_program
+
+  validates :user_id, uniqueness: { scope: [ :conference_program_id, :role_name ] }
+  validates :role_name, inclusion: { in: %w[activity_lead] }
+
+  # Role names
+  ACTIVITY_LEAD = "activity_lead"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,6 +65,7 @@ class User < ApplicationRecord
   has_many :roles, through: :user_roles
   has_many :conference_roles, dependent: :destroy
   has_many :program_roles, dependent: :destroy
+  has_many :conference_program_roles, dependent: :destroy
   # Qualification associations
   has_many :user_qualifications, dependent: :destroy
   has_many :qualifications, through: :user_qualifications
@@ -114,6 +115,17 @@ class User < ApplicationRecord
 
   def led_programs
     Program.joins(:program_roles).where(program_roles: { user_id: id, role_name: ProgramRole::PROGRAM_LEAD })
+  end
+
+  def activity_lead?(conference_program)
+    conference_program_roles.exists?(
+      conference_program: conference_program,
+      role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+  end
+
+  def can_manage_conference_program?(conference_program)
+    can_manage_conference?(conference_program.conference) || activity_lead?(conference_program)
   end
 
   def volunteer?

--- a/app/policies/conference_program_policy.rb
+++ b/app/policies/conference_program_policy.rb
@@ -4,15 +4,18 @@ class ConferenceProgramPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.can_manage_conference?(record.conference)
+    user&.can_manage_conference_program?(record)
   end
 
   def create?
     user&.can_manage_conference?(record.conference)
   end
 
+  # Permits conference managers AND the activity lead of this specific program.
+  # This is the chokepoint for managing an activity's timeslots (add/remove
+  # volunteers, edit capacity) and for appointing/removing its activity leads.
   def update?
-    user&.can_manage_conference?(record.conference)
+    user&.can_manage_conference_program?(record)
   end
 
   def destroy?

--- a/app/views/conference_programs/index.html.erb
+++ b/app/views/conference_programs/index.html.erb
@@ -52,6 +52,9 @@
             </div>
             <div class="card-footer bg-transparent">
               <div class="d-flex flex-wrap gap-2">
+                <% if policy(cp).show? %>
+                  <%= link_to "Manage Leads", conference_conference_program_path(@conference, cp), class: "btn btn-sm btn-outline-primary" %>
+                <% end %>
                 <% if policy(cp).update? %>
                   <%= link_to "Edit Schedule", edit_conference_conference_program_path(@conference, cp), class: "btn btn-sm btn-outline-primary" %>
                 <% end %>

--- a/app/views/conference_programs/show.html.erb
+++ b/app/views/conference_programs/show.html.erb
@@ -1,0 +1,92 @@
+<div class="container mt-5">
+  <div class="d-flex align-items-center mb-4">
+    <%= link_to conference_conference_programs_path(@conference), class: "btn btn-secondary btn-sm me-3" do %>
+      <span aria-hidden="true">&larr;</span> Programs
+    <% end %>
+    <h1 class="mb-0">
+      <%= @conference_program.program.name %>
+      <% if @conference_program.program.conference_specific? %>
+        <span class="badge bg-info">Conference Only</span>
+      <% end %>
+    </h1>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-7">
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h5 class="card-title">Details</h5>
+          <% description = @conference_program.public_description.presence || @conference_program.program.description %>
+          <% if description.present? %>
+            <p class="card-text text-muted"><%= description %></p>
+          <% else %>
+            <p class="text-muted">No description.</p>
+          <% end %>
+
+          <% if @conference_program.day_schedules.any? %>
+            <h6 class="mt-3">Schedule</h6>
+            <ul class="list-unstyled mb-0">
+              <% @conference_program.day_schedules.each do |day, schedule| %>
+                <% if schedule["enabled"] %>
+                  <li><small class="text-muted">Day <%= day.to_i + 1 %>: <%= schedule["start"] %> &ndash; <%= schedule["end"] %></small></li>
+                <% end %>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <% if policy(@conference_program).update? %>
+            <div class="mt-3">
+              <%= link_to "Edit Schedule", edit_conference_conference_program_path(@conference, @conference_program), class: "btn btn-sm btn-outline-primary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-5">
+      <div class="card bg-light">
+        <div class="card-body">
+          <h5 class="card-title">Activity Leads</h5>
+          <p class="text-muted small">
+            Activity leads have admin rights for this activity only &mdash; they can manage
+            volunteers and shifts here, but nothing else in the conference.
+          </p>
+
+          <% leads = @conference_program.conference_program_roles.includes(:user).where(role_name: ConferenceProgramRole::ACTIVITY_LEAD) %>
+          <% if leads.any? %>
+            <ul class="list-group list-group-flush mb-3">
+              <% leads.each do |role| %>
+                <li class="list-group-item d-flex justify-content-between align-items-center bg-transparent">
+                  <%= role.user.email %>
+                  <% if policy(@conference_program).update? %>
+                    <%= link_to "Remove", conference_conference_program_conference_program_role_path(@conference, @conference_program, role),
+                        data: { turbo_method: :delete, turbo_confirm: "Remove this activity lead?" },
+                        class: "btn btn-sm btn-danger" %>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% else %>
+            <p class="text-muted">No activity leads assigned.</p>
+          <% end %>
+
+          <% if policy(@conference_program).update? %>
+            <% existing_lead_ids = @conference_program.activity_leads.pluck(:id) %>
+            <% available_users = User.where.not(id: existing_lead_ids).order(:email) %>
+            <% if available_users.any? %>
+              <%= form_with url: conference_conference_program_conference_program_roles_path(@conference, @conference_program), method: :post, local: true, class: "d-flex gap-2" do |f| %>
+                <select name="user_id" class="form-select form-select-sm" required>
+                  <option value="">Select user...</option>
+                  <% available_users.each do |user| %>
+                    <option value="<%= user.id %>"><%= user.email %></option>
+                  <% end %>
+                </select>
+                <%= f.submit "Add Lead", class: "btn btn-sm btn-primary" %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -12,6 +12,8 @@
       <p class="text-muted">
         <% if @can_see_all_volunteers %>
           <span class="badge bg-primary">Admin View</span> Showing all volunteers across all programs
+        <% elsif @manageable_program_ids.any? %>
+          <span class="badge bg-info">Activity Lead View</span> Showing all volunteers for the activities you lead
         <% else %>
           <span class="badge bg-secondary">Volunteer View</span> Your shifts are highlighted
         <% end %>
@@ -109,7 +111,7 @@
                             </div>
                           </div>
 
-                          <% if @can_see_all_volunteers %>
+                          <% if @manageable_program_ids.include?(program_id) %>
                             <%# Volunteer list - fills available space %>
                             <div class="volunteer-list flex-grow-1 mt-1">
                               <% slot_data[:volunteers].each do |volunteer| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,9 @@ Rails.application.routes.draw do
     get "dashboard", to: "conference_dashboard#show", as: :dashboard
     get "calendar_export", to: "calendar_exports#show", as: :calendar_export
     get "programs/new", to: "conference_programs#new", as: :new_conference_program
-    resources :conference_programs, except: [ :new ], path: "programs"
+    resources :conference_programs, except: [ :new ], path: "programs" do
+      resources :conference_program_roles, only: [ :create, :destroy ]
+    end
     resources :custom_programs, only: [ :new, :create, :edit, :update, :destroy ]
     resources :conference_roles, only: [ :create, :destroy ]
     get "schedule", to: "schedule#show", as: :schedule

--- a/db/migrate/20260702234319_create_conference_program_roles.rb
+++ b/db/migrate/20260702234319_create_conference_program_roles.rb
@@ -1,0 +1,16 @@
+class CreateConferenceProgramRoles < ActiveRecord::Migration[8.1]
+  def change
+    create_table :conference_program_roles do |t|
+      t.references :conference_program, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :role_name, null: false
+
+      t.timestamps
+    end
+
+    add_index :conference_program_roles,
+              [ :user_id, :conference_program_id, :role_name ],
+              unique: true,
+              name: "index_conference_program_roles_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_234200) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_234319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "conference_program_roles", force: :cascade do |t|
+    t.bigint "conference_program_id", null: false
+    t.datetime "created_at", null: false
+    t.string "role_name", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["conference_program_id"], name: "index_conference_program_roles_on_conference_program_id"
+    t.index ["user_id", "conference_program_id", "role_name"], name: "index_conference_program_roles_unique", unique: true
+    t.index ["user_id"], name: "index_conference_program_roles_on_user_id"
+  end
 
   create_table "conference_programs", force: :cascade do |t|
     t.bigint "conference_id", null: false
@@ -235,6 +246,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_234200) do
     t.index ["user_id"], name: "index_volunteer_signups_on_user_id"
   end
 
+  add_foreign_key "conference_program_roles", "conference_programs"
+  add_foreign_key "conference_program_roles", "users"
   add_foreign_key "conference_programs", "conferences"
   add_foreign_key "conference_programs", "programs"
   add_foreign_key "conference_qualifications", "conferences"

--- a/test/controllers/conference_program_roles_controller_test.rb
+++ b/test/controllers/conference_program_roles_controller_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+class ConferenceProgramRolesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @village_admin = User.create!(email: "admin@example.com", password: "password123", password_confirmation: "password123")
+    @conference_lead = User.create!(email: "lead@example.com", password: "password123", password_confirmation: "password123")
+    @volunteer = User.create!(email: "volunteer@example.com", password: "password123", password_confirmation: "password123")
+    @candidate = User.create!(email: "candidate@example.com", password: "password123", password_confirmation: "password123")
+
+    UserRole.create!(user: @village_admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+
+    @conference = Conference.create!(
+      village: @village, name: "Test Conference",
+      start_date: Date.tomorrow, end_date: Date.tomorrow + 2.days
+    )
+    ConferenceRole.create!(user: @conference_lead, conference: @conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+
+    @program = Program.create!(name: "Test Program", village: @village)
+    @conference_program = ConferenceProgram.create!(conference: @conference, program: @program)
+  end
+
+  def assign_url
+    conference_conference_program_conference_program_roles_url(@conference, @conference_program)
+  end
+
+  test "village admin can assign an activity lead" do
+    sign_in @village_admin
+    assert_difference("ConferenceProgramRole.count", 1) do
+      post assign_url, params: { user_id: @candidate.id }
+    end
+    assert @candidate.activity_lead?(@conference_program)
+  end
+
+  test "conference lead can assign an activity lead" do
+    sign_in @conference_lead
+    assert_difference("ConferenceProgramRole.count", 1) do
+      post assign_url, params: { user_id: @candidate.id }
+    end
+    assert @candidate.activity_lead?(@conference_program)
+  end
+
+  test "an existing activity lead can appoint a co-lead for the same activity" do
+    ConferenceProgramRole.create!(user: @volunteer, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in @volunteer
+    assert_difference("ConferenceProgramRole.count", 1) do
+      post assign_url, params: { user_id: @candidate.id }
+    end
+    assert @candidate.activity_lead?(@conference_program)
+  end
+
+  test "a regular volunteer cannot assign an activity lead" do
+    sign_in @volunteer
+    assert_no_difference("ConferenceProgramRole.count") do
+      post assign_url, params: { user_id: @candidate.id }
+    end
+    assert_redirected_to root_path
+    assert_not @candidate.activity_lead?(@conference_program)
+  end
+
+  test "an activity lead of another activity cannot assign a lead here" do
+    other_program = Program.create!(name: "Other Program", village: @village)
+    other_cp = ConferenceProgram.create!(conference: @conference, program: other_program)
+    ConferenceProgramRole.create!(user: @volunteer, conference_program: other_cp, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in @volunteer
+    assert_no_difference("ConferenceProgramRole.count") do
+      post assign_url, params: { user_id: @candidate.id }
+    end
+    assert_redirected_to root_path
+  end
+
+  test "does not duplicate an existing activity lead" do
+    ConferenceProgramRole.create!(user: @candidate, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in @village_admin
+    assert_no_difference("ConferenceProgramRole.count") do
+      post assign_url, params: { user_id: @candidate.id }
+    end
+  end
+
+  test "village admin can remove an activity lead" do
+    role = ConferenceProgramRole.create!(user: @candidate, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in @village_admin
+    assert_difference("ConferenceProgramRole.count", -1) do
+      delete conference_conference_program_conference_program_role_url(@conference, @conference_program, role)
+    end
+  end
+
+  test "a regular volunteer cannot remove an activity lead" do
+    role = ConferenceProgramRole.create!(user: @candidate, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in @volunteer
+    assert_no_difference("ConferenceProgramRole.count") do
+      delete conference_conference_program_conference_program_role_url(@conference, @conference_program, role)
+    end
+    assert_redirected_to root_path
+  end
+
+  test "redirects to login when unauthenticated" do
+    assert_no_difference("ConferenceProgramRole.count") do
+      post assign_url, params: { user_id: @candidate.id }
+    end
+    assert_redirected_to new_user_session_path
+  end
+end

--- a/test/controllers/timeslots_controller_test.rb
+++ b/test/controllers/timeslots_controller_test.rb
@@ -173,4 +173,52 @@ class TimeslotsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to root_path
   end
+
+  # Activity lead tests: an activity lead may manage timeslots for THEIR activity
+  # only, not other activities or the conference at large.
+  test "activity lead can update, add, and remove on their own activity's timeslot" do
+    activity_lead = @volunteer2
+    ConferenceProgramRole.create!(
+      user: activity_lead,
+      conference_program: @conference_program,
+      role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+    sign_in activity_lead
+
+    patch conference_timeslot_url(@conference, @timeslot), params: { timeslot: { max_volunteers: 4 } }
+    assert_redirected_to conference_schedule_path(@conference)
+    assert_equal 4, @timeslot.reload.max_volunteers
+
+    assert_difference("VolunteerSignup.count", 1) do
+      post add_volunteer_conference_timeslot_url(@conference, @timeslot), params: { user_id: @volunteer.id }
+    end
+    assert_difference("VolunteerSignup.count", -1) do
+      delete remove_volunteer_conference_timeslot_url(@conference, @timeslot), params: { user_id: @volunteer.id }
+    end
+  end
+
+  test "activity lead cannot manage a different activity's timeslot" do
+    other_program = Program.create!(name: "Other Program", village: @village)
+    other_cp = ConferenceProgram.create!(conference: @conference, program: other_program)
+    other_timeslot = Timeslot.create!(
+      conference_program: other_cp,
+      start_time: Date.tomorrow.to_datetime + 10.hours,
+      max_volunteers: 2
+    )
+    # Lead of @conference_program only
+    ConferenceProgramRole.create!(
+      user: @volunteer2,
+      conference_program: @conference_program,
+      role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+    sign_in @volunteer2
+
+    patch conference_timeslot_url(@conference, other_timeslot), params: { timeslot: { max_volunteers: 9 } }
+    assert_redirected_to root_path
+    assert_equal 2, other_timeslot.reload.max_volunteers
+
+    assert_no_difference("VolunteerSignup.count") do
+      post add_volunteer_conference_timeslot_url(@conference, other_timeslot), params: { user_id: @volunteer.id }
+    end
+  end
 end

--- a/test/models/conference_program_role_test.rb
+++ b/test/models/conference_program_role_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class ConferenceProgramRoleTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      city: "Test City", state: "NV", country: "US",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 3.days,
+      village: @village
+    )
+    @program = Program.create!(name: "Test Program", description: "A test program", village: @village)
+    @conference_program = ConferenceProgram.create!(conference: @conference, program: @program)
+    @user = User.create!(email: "lead@example.com", password: "password123", password_confirmation: "password123")
+  end
+
+  test "is valid with an activity_lead role" do
+    role = ConferenceProgramRole.new(
+      user: @user, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+    assert role.valid?
+  end
+
+  test "rejects an unknown role_name" do
+    role = ConferenceProgramRole.new(
+      user: @user, conference_program: @conference_program, role_name: "wizard"
+    )
+    assert_not role.valid?
+  end
+
+  test "does not allow duplicate role for the same user and program" do
+    ConferenceProgramRole.create!(
+      user: @user, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+    dup = ConferenceProgramRole.new(
+      user: @user, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+    assert_not dup.valid?
+  end
+
+  test "User#activity_lead? reflects the role" do
+    assert_not @user.activity_lead?(@conference_program)
+    ConferenceProgramRole.create!(
+      user: @user, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+    assert @user.reload.activity_lead?(@conference_program)
+  end
+
+  test "User#can_manage_conference_program? is true for the activity lead and false otherwise" do
+    other_program = Program.create!(name: "Other", description: "other", village: @village)
+    other_cp = ConferenceProgram.create!(conference: @conference, program: other_program)
+
+    ConferenceProgramRole.create!(
+      user: @user, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+
+    assert @user.can_manage_conference_program?(@conference_program)
+    assert_not @user.can_manage_conference_program?(other_cp)
+  end
+
+  test "ConferenceProgram#activity_leads lists assigned leads" do
+    ConferenceProgramRole.create!(
+      user: @user, conference_program: @conference_program, role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+    assert_includes @conference_program.activity_leads, @user
+  end
+end

--- a/test/policies/conference_program_policy_test.rb
+++ b/test/policies/conference_program_policy_test.rb
@@ -130,6 +130,32 @@ class ConferenceProgramPolicyTest < ActiveSupport::TestCase
     assert_not policy.destroy?
   end
 
+  test "activity lead can show and update their own activity but not create or destroy it" do
+    ConferenceProgramRole.create!(
+      user: @volunteer,
+      conference_program: @conference_program,
+      role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+    policy = ConferenceProgramPolicy.new(@volunteer, @conference_program)
+    assert policy.show?
+    assert policy.update?
+    assert_not policy.create?
+    assert_not policy.destroy?
+  end
+
+  test "activity lead cannot manage a different activity in the same conference" do
+    other_program = Program.create!(name: "Other Program", description: "other", village: @village)
+    other_cp = ConferenceProgram.create!(conference: @conference, program: other_program)
+    ConferenceProgramRole.create!(
+      user: @volunteer,
+      conference_program: @conference_program,
+      role_name: ConferenceProgramRole::ACTIVITY_LEAD
+    )
+    policy = ConferenceProgramPolicy.new(@volunteer, other_cp)
+    assert_not policy.show?
+    assert_not policy.update?
+  end
+
   test "anonymous user cannot manage conference programs" do
     policy = ConferenceProgramPolicy.new(nil, @conference_program)
     assert_not policy.index?


### PR DESCRIPTION
## Summary

Fixes #185. Adds an optional **Activity Lead** role: a conference manager can assign a user as lead of one specific activity (`ConferenceProgram`) at one conference. An activity lead gets admin-level rights **scoped to that one activity only** — see full volunteer names, add/remove volunteers, edit capacity — but cannot touch other activities or conference-wide settings.

## Changes

- New `ConferenceProgramRole` model + migration (`activity_lead`; unique per user/activity/role).
- `User#activity_lead?` / `#can_manage_conference_program?`.
- `ConferenceProgramPolicy#show?`/`#update?` permit the activity lead of that program; `TimeslotsController` (update / add_volunteer / remove_volunteer) authorizes through it so a lead manages only their activity's shifts.
- Schedule view gates admin controls and full volunteer names **per activity** (`@manageable_program_ids`) instead of a single conference-wide boolean; adds an "Activity Lead View" badge.
- `ConferenceProgramRolesController` + "Manage Leads" UI on `conference_programs#show` (activity-scoped, so a lead can appoint co-leads for their own activity).

## Testing

- Model, policy (own vs. other activity), timeslots controller (lead manages own, forbidden on others), roles controller (who may appoint/remove). Full non-system suite passes.
- Manually verified end-to-end: an activity lead sees admin controls only on their activity's schedule column and is blocked elsewhere; managers are unaffected.

## Follow-ups
- Navigation link for leads to reach their Manage page (filed separately — leads currently reach it by direct URL).
- Inline schedule CSS extraction (#197).

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)