### PR TITLE
Delegated qualification assignment

### DIFF
--- a/app/controllers/qualification_delegations_controller.rb
+++ b/app/controllers/qualification_delegations_controller.rb
@@ -1,0 +1,47 @@
+# Conference managers grant/revoke a user's right to assign a specific
+# qualification within this conference (issue #186).
+class QualificationDelegationsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference
+  before_action :authorize_manage
+
+  def index
+    @delegations = @conference.qualification_assignment_delegations
+                              .includes(:user, :qualification)
+                              .order("qualifications.name")
+    @qualifications = @conference.village.qualifications.order(:name)
+    @users = User.order(:email)
+  end
+
+  def create
+    user = User.find(params[:user_id])
+    qualification = @conference.village.qualifications.find(params[:qualification_id])
+
+    QualificationAssignmentDelegation.find_or_create_by!(
+      user: user, qualification: qualification, conference: @conference
+    )
+
+    redirect_to conference_qualification_delegations_path(@conference),
+                notice: "Delegated #{qualification.name} to #{user.email}."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to conference_qualification_delegations_path(@conference),
+                alert: "Could not delegate: #{e.message}"
+  end
+
+  def destroy
+    delegation = @conference.qualification_assignment_delegations.find(params[:id])
+    delegation.destroy
+    redirect_to conference_qualification_delegations_path(@conference),
+                notice: "Delegation removed."
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+
+  def authorize_manage
+    authorize @conference, :update?, policy_class: ConferencePolicy
+  end
+end

--- a/app/controllers/qualification_grants_controller.rb
+++ b/app/controllers/qualification_grants_controller.rb
@@ -1,0 +1,57 @@
+# Assign / unassign global qualifications to users within a conference.
+# Open to conference managers (all qualifications) and to delegates (only the
+# qualifications delegated to them for this conference) — see issue #186.
+class QualificationGrantsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_conference
+  before_action :authorize_any_assignment, only: [ :index ]
+
+  def index
+    @assignable_qualifications = current_user.assignable_qualifications(@conference)
+    @users = User.order(:email)
+  end
+
+  def create
+    qualification = find_assignable_qualification!(params[:qualification_id])
+    user = User.find(params[:user_id])
+
+    UserQualification.find_or_create_by!(user: user, qualification: qualification)
+    redirect_to conference_qualification_grants_path(@conference),
+                notice: "Granted #{qualification.name} to #{user.email}."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to conference_qualification_grants_path(@conference),
+                alert: "Could not grant qualification: #{e.message}"
+  end
+
+  def destroy
+    user_qualification = UserQualification.find(params[:id])
+    # Authorize against the specific qualification being revoked.
+    find_assignable_qualification!(user_qualification.qualification_id)
+
+    user_qualification.destroy
+    redirect_to conference_qualification_grants_path(@conference),
+                notice: "Revoked #{user_qualification.qualification.name} from #{user_qualification.user.email}."
+  end
+
+  private
+
+  def set_conference
+    @conference = Conference.find(params[:conference_id])
+  end
+
+  # The user must be able to assign at least one qualification to view the page.
+  def authorize_any_assignment
+    raise Pundit::NotAuthorizedError unless current_user.assignable_qualifications(@conference).exists?
+  end
+
+  # Load a qualification the current user is permitted to assign in this
+  # conference, or raise NotAuthorized (rescued into a redirect + flash).
+  def find_assignable_qualification!(qualification_id)
+    qualification = Qualification.find(qualification_id)
+    unless current_user.can_assign_qualification?(qualification, @conference)
+      raise Pundit::NotAuthorizedError
+    end
+
+    qualification
+  end
+end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -7,6 +7,7 @@ class Conference < ApplicationRecord
   has_many :timeslots, through: :conference_programs
   has_many :conference_qualifications, dependent: :destroy
   has_many :qualification_removals, dependent: :destroy
+  has_many :qualification_assignment_delegations, dependent: :destroy
 
   validates :name, presence: true
   validates :start_date, presence: true

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -4,6 +4,7 @@ class Qualification < ApplicationRecord
   has_many :users, through: :user_qualifications
   has_many :program_qualifications, dependent: :destroy
   has_many :programs, through: :program_qualifications
+  has_many :qualification_assignment_delegations, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { scope: :village_id }
   validates :description, presence: true

--- a/app/models/qualification_assignment_delegation.rb
+++ b/app/models/qualification_assignment_delegation.rb
@@ -1,0 +1,10 @@
+# Grants one user (the delegate) the right to assign one specific global
+# Qualification to volunteers within one Conference. Created by a conference
+# manager; consulted by User#can_assign_qualification?.
+class QualificationAssignmentDelegation < ApplicationRecord
+  belongs_to :user
+  belongs_to :qualification
+  belongs_to :conference
+
+  validates :user_id, uniqueness: { scope: [ :qualification_id, :conference_id ] }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,7 @@ class User < ApplicationRecord
   has_many :conference_user_qualifications, dependent: :destroy
   has_many :conference_qualifications, through: :conference_user_qualifications
   has_many :qualification_removals, dependent: :destroy
+  has_many :qualification_assignment_delegations, dependent: :destroy
   # Volunteer signup associations
   has_many :volunteer_signups, dependent: :destroy
   has_many :timeslots, through: :volunteer_signups
@@ -167,6 +168,24 @@ class User < ApplicationRecord
   def effective_qualification_for_conference?(qualification, conference)
     return false unless has_qualification?(qualification)
     !qualification_removed_for_conference?(qualification, conference)
+  end
+
+  # Qualification-assignment delegation (issue #186). A conference manager can
+  # always assign any qualification; a delegate may assign only the specific
+  # qualifications delegated to them within that conference.
+  def can_assign_qualification?(qualification, conference)
+    return true if can_manage_conference?(conference)
+
+    qualification_assignment_delegations.exists?(qualification: qualification, conference: conference)
+  end
+
+  # Qualifications this user is allowed to assign within the given conference.
+  def assignable_qualifications(conference)
+    return conference.village.qualifications.order(:name) if can_manage_conference?(conference)
+
+    Qualification.where(
+      id: qualification_assignment_delegations.where(conference: conference).select(:qualification_id)
+    ).order(:name)
   end
 
   # Volunteer statistics methods

--- a/app/views/conferences/show.html.erb
+++ b/app/views/conferences/show.html.erb
@@ -126,6 +126,10 @@
             <% if policy(@conference).update? %>
               <%= link_to "Dashboard", conference_dashboard_path(@conference), class: "btn btn-warning" %>
               <%= link_to "Manage Programs", conference_conference_programs_path(@conference), class: "btn btn-success" %>
+              <%= link_to "Delegate Qualifications", conference_qualification_delegations_path(@conference), class: "btn btn-outline-secondary" %>
+            <% end %>
+            <% if current_user.assignable_qualifications(@conference).exists? %>
+              <%= link_to "Assign Qualifications", conference_qualification_grants_path(@conference), class: "btn btn-outline-success" %>
             <% end %>
           </div>
         </div>

--- a/app/views/qualification_delegations/index.html.erb
+++ b/app/views/qualification_delegations/index.html.erb
@@ -1,0 +1,64 @@
+<div class="container mt-5">
+  <div class="d-flex align-items-center mb-4">
+    <%= link_to conference_path(@conference), class: "btn btn-secondary btn-sm me-3" do %>
+      <span aria-hidden="true">&larr;</span> Conference
+    <% end %>
+    <h1 class="mb-0">Qualification Delegations</h1>
+  </div>
+
+  <p class="text-muted">
+    Delegate the ability to assign a specific qualification to another user. A delegate can grant
+    (and revoke) only the qualifications delegated to them, and only within this conference.
+  </p>
+
+  <div class="card mb-4">
+    <div class="card-body">
+      <h5 class="card-title">Current Delegations</h5>
+      <% if @delegations.any? %>
+        <table class="table table-sm align-middle mb-0">
+          <thead><tr><th>User</th><th>Qualification</th><th class="text-end">Actions</th></tr></thead>
+          <tbody>
+            <% @delegations.each do |delegation| %>
+              <tr>
+                <td><%= delegation.user.email %></td>
+                <td><%= delegation.qualification.name %></td>
+                <td class="text-end">
+                  <%= link_to "Remove", conference_qualification_delegation_path(@conference, delegation),
+                      data: { turbo_method: :delete, turbo_confirm: "Remove this delegation?" },
+                      class: "btn btn-sm btn-outline-danger" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="text-muted mb-0">No delegations yet.</p>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title">Delegate a Qualification</h5>
+      <% if @qualifications.any? %>
+        <%= form_with url: conference_qualification_delegations_path(@conference), method: :post, local: true, class: "row g-2" do %>
+          <div class="col-md-5">
+            <%= select_tag :user_id,
+                options_from_collection_for_select(@users, :id, :email),
+                include_blank: "Select user...", class: "form-select", required: true %>
+          </div>
+          <div class="col-md-5">
+            <%= select_tag :qualification_id,
+                options_from_collection_for_select(@qualifications, :id, :name),
+                include_blank: "Select qualification...", class: "form-select", required: true %>
+          </div>
+          <div class="col-md-2 d-grid">
+            <%= submit_tag "Delegate", class: "btn btn-primary" %>
+          </div>
+        <% end %>
+      <% else %>
+        <p class="text-muted mb-0">No qualifications exist in this village yet.</p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/qualification_grants/index.html.erb
+++ b/app/views/qualification_grants/index.html.erb
@@ -1,0 +1,58 @@
+<div class="container mt-5">
+  <div class="d-flex align-items-center mb-4">
+    <%= link_to conference_path(@conference), class: "btn btn-secondary btn-sm me-3" do %>
+      <span aria-hidden="true">&larr;</span> Conference
+    <% end %>
+    <h1 class="mb-0">Assign Qualifications</h1>
+  </div>
+
+  <p class="text-muted">
+    Grant a qualification to a volunteer. You can assign only the qualifications you are permitted
+    to manage for this conference.
+  </p>
+
+  <div class="card mb-4">
+    <div class="card-body">
+      <h5 class="card-title">Grant a Qualification</h5>
+      <%= form_with url: conference_qualification_grants_path(@conference), method: :post, local: true, class: "row g-2" do %>
+        <div class="col-md-5">
+          <%= select_tag :user_id,
+              options_from_collection_for_select(@users, :id, :email),
+              include_blank: "Select user...", class: "form-select", required: true %>
+        </div>
+        <div class="col-md-5">
+          <%= select_tag :qualification_id,
+              options_from_collection_for_select(@assignable_qualifications, :id, :name),
+              include_blank: "Select qualification...", class: "form-select", required: true %>
+        </div>
+        <div class="col-md-2 d-grid">
+          <%= submit_tag "Grant", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <% @assignable_qualifications.each do |qualification| %>
+    <div class="card mb-3">
+      <div class="card-body">
+        <h6 class="card-title"><%= qualification.name %></h6>
+        <% holders = qualification.users.order(:email) %>
+        <% if holders.any? %>
+          <ul class="list-group list-group-flush">
+            <% holders.each do |holder| %>
+              <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                <%= holder.email %>
+                <%= link_to "Revoke",
+                    conference_qualification_grant_path(@conference, UserQualification.find_by(user: holder, qualification: qualification)),
+                    data: { turbo_method: :delete, turbo_confirm: "Revoke #{qualification.name} from #{holder.email}?" },
+                    class: "btn btn-sm btn-outline-danger" %>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="text-muted mb-0">No one holds this qualification yet.</p>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,10 @@ Rails.application.routes.draw do
     resources :conference_qualifications, path: "qualifications"
     resources :conference_user_qualifications, only: [ :create, :destroy ]
     resources :qualification_removals, only: [ :index, :create, :destroy ]
+    # Delegate the right to assign a qualification (managed by conference leads/admins)
+    resources :qualification_delegations, only: [ :index, :create, :destroy ]
+    # Assign qualifications to users (open to conference managers and delegates)
+    resources :qualification_grants, only: [ :index, :create, :destroy ]
   end
 
   # Program management

--- a/db/migrate/20260702235305_create_qualification_assignment_delegations.rb
+++ b/db/migrate/20260702235305_create_qualification_assignment_delegations.rb
@@ -1,0 +1,16 @@
+class CreateQualificationAssignmentDelegations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :qualification_assignment_delegations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :qualification, null: false, foreign_key: true
+      t.references :conference, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :qualification_assignment_delegations,
+              [ :user_id, :qualification_id, :conference_id ],
+              unique: true,
+              name: "index_qualification_delegations_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_234319) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_235305) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -131,6 +131,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_234319) do
     t.index ["conference_id"], name: "index_programs_on_conference_id"
     t.index ["village_id", "name"], name: "index_programs_on_village_id_and_name", unique: true
     t.index ["village_id"], name: "index_programs_on_village_id"
+  end
+
+  create_table "qualification_assignment_delegations", force: :cascade do |t|
+    t.bigint "conference_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "qualification_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["conference_id"], name: "index_qualification_assignment_delegations_on_conference_id"
+    t.index ["qualification_id"], name: "index_qualification_assignment_delegations_on_qualification_id"
+    t.index ["user_id", "qualification_id", "conference_id"], name: "index_qualification_delegations_unique", unique: true
+    t.index ["user_id"], name: "index_qualification_assignment_delegations_on_user_id"
   end
 
   create_table "qualification_removals", force: :cascade do |t|
@@ -263,6 +275,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_234319) do
   add_foreign_key "program_roles", "users"
   add_foreign_key "programs", "conferences"
   add_foreign_key "programs", "villages"
+  add_foreign_key "qualification_assignment_delegations", "conferences"
+  add_foreign_key "qualification_assignment_delegations", "qualifications"
+  add_foreign_key "qualification_assignment_delegations", "users"
   add_foreign_key "qualification_removals", "conferences"
   add_foreign_key "qualification_removals", "qualifications"
   add_foreign_key "qualification_removals", "users"

--- a/test/controllers/qualification_delegations_controller_test.rb
+++ b/test/controllers/qualification_delegations_controller_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class QualificationDelegationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village, name: "Test Conference",
+      start_date: Date.tomorrow, end_date: Date.tomorrow + 2.days
+    )
+    @qualification = Qualification.create!(village: @village, name: "Foobar", description: "Can foo")
+
+    @village_admin = User.create!(email: "admin@example.com", password: "password123", password_confirmation: "password123")
+    UserRole.create!(user: @village_admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+
+    @conference_lead = User.create!(email: "lead@example.com", password: "password123", password_confirmation: "password123")
+    ConferenceRole.create!(user: @conference_lead, conference: @conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+
+    @volunteer = User.create!(email: "volunteer@example.com", password: "password123", password_confirmation: "password123")
+    @candidate = User.create!(email: "candidate@example.com", password: "password123", password_confirmation: "password123")
+  end
+
+  def create_url
+    conference_qualification_delegations_url(@conference)
+  end
+
+  test "conference lead can create a delegation" do
+    sign_in @conference_lead
+    assert_difference("QualificationAssignmentDelegation.count", 1) do
+      post create_url, params: { user_id: @candidate.id, qualification_id: @qualification.id }
+    end
+    assert @candidate.can_assign_qualification?(@qualification, @conference)
+  end
+
+  test "village admin can create a delegation" do
+    sign_in @village_admin
+    assert_difference("QualificationAssignmentDelegation.count", 1) do
+      post create_url, params: { user_id: @candidate.id, qualification_id: @qualification.id }
+    end
+  end
+
+  test "a regular volunteer cannot create a delegation" do
+    sign_in @volunteer
+    assert_no_difference("QualificationAssignmentDelegation.count") do
+      post create_url, params: { user_id: @candidate.id, qualification_id: @qualification.id }
+    end
+    assert_redirected_to root_path
+  end
+
+  test "a delegate cannot create further delegations" do
+    QualificationAssignmentDelegation.create!(user: @volunteer, qualification: @qualification, conference: @conference)
+    sign_in @volunteer
+    assert_no_difference("QualificationAssignmentDelegation.count") do
+      post create_url, params: { user_id: @candidate.id, qualification_id: @qualification.id }
+    end
+    assert_redirected_to root_path
+  end
+
+  test "conference lead can remove a delegation" do
+    delegation = QualificationAssignmentDelegation.create!(user: @candidate, qualification: @qualification, conference: @conference)
+    sign_in @conference_lead
+    assert_difference("QualificationAssignmentDelegation.count", -1) do
+      delete conference_qualification_delegation_url(@conference, delegation)
+    end
+  end
+
+  test "unauthenticated requests redirect to sign-in" do
+    assert_no_difference("QualificationAssignmentDelegation.count") do
+      post create_url, params: { user_id: @candidate.id, qualification_id: @qualification.id }
+    end
+    assert_redirected_to new_user_session_path
+  end
+end

--- a/test/controllers/qualification_grants_controller_test.rb
+++ b/test/controllers/qualification_grants_controller_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+class QualificationGrantsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village, name: "Test Conference",
+      start_date: Date.tomorrow, end_date: Date.tomorrow + 2.days
+    )
+    @foobar = Qualification.create!(village: @village, name: "Foobar", description: "Can foo")
+    @bazzer = Qualification.create!(village: @village, name: "Bazzer", description: "Can baz")
+
+    @village_admin = User.create!(email: "admin@example.com", password: "password123", password_confirmation: "password123")
+    UserRole.create!(user: @village_admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+
+    @delegate = User.create!(email: "delegate@example.com", password: "password123", password_confirmation: "password123")
+    QualificationAssignmentDelegation.create!(user: @delegate, qualification: @foobar, conference: @conference)
+
+    @volunteer = User.create!(email: "volunteer@example.com", password: "password123", password_confirmation: "password123")
+    @recipient = User.create!(email: "recipient@example.com", password: "password123", password_confirmation: "password123")
+  end
+
+  def grants_url
+    conference_qualification_grants_url(@conference)
+  end
+
+  # --- index visibility ---
+  test "a manager can view the assign page" do
+    sign_in @village_admin
+    get grants_url
+    assert_response :success
+  end
+
+  test "a delegate can view the assign page" do
+    sign_in @delegate
+    get grants_url
+    assert_response :success
+  end
+
+  test "a user with no delegation cannot view the assign page" do
+    sign_in @volunteer
+    get grants_url
+    assert_redirected_to root_path
+  end
+
+  # --- granting ---
+  test "a manager can grant any qualification" do
+    sign_in @village_admin
+    assert_difference("UserQualification.count", 1) do
+      post grants_url, params: { user_id: @recipient.id, qualification_id: @bazzer.id }
+    end
+    assert @recipient.has_qualification?(@bazzer)
+  end
+
+  test "a delegate can grant their delegated qualification" do
+    sign_in @delegate
+    assert_difference("UserQualification.count", 1) do
+      post grants_url, params: { user_id: @recipient.id, qualification_id: @foobar.id }
+    end
+    assert @recipient.has_qualification?(@foobar)
+  end
+
+  test "a delegate cannot grant a non-delegated qualification" do
+    sign_in @delegate
+    assert_no_difference("UserQualification.count") do
+      post grants_url, params: { user_id: @recipient.id, qualification_id: @bazzer.id }
+    end
+    assert_redirected_to root_path
+    assert_not @recipient.has_qualification?(@bazzer)
+  end
+
+  # --- revoking ---
+  test "a delegate can revoke a qualification they can assign" do
+    uq = UserQualification.create!(user: @recipient, qualification: @foobar)
+    sign_in @delegate
+    assert_difference("UserQualification.count", -1) do
+      delete conference_qualification_grant_url(@conference, uq)
+    end
+  end
+
+  test "a delegate cannot revoke a non-delegated qualification" do
+    uq = UserQualification.create!(user: @recipient, qualification: @bazzer)
+    sign_in @delegate
+    assert_no_difference("UserQualification.count") do
+      delete conference_qualification_grant_url(@conference, uq)
+    end
+    assert_redirected_to root_path
+  end
+
+  test "unauthenticated requests redirect to sign-in" do
+    post grants_url, params: { user_id: @recipient.id, qualification_id: @foobar.id }
+    assert_redirected_to new_user_session_path
+  end
+end

--- a/test/models/qualification_assignment_delegation_test.rb
+++ b/test/models/qualification_assignment_delegation_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class QualificationAssignmentDelegationTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village, name: "Test Conference",
+      start_date: Date.tomorrow, end_date: Date.tomorrow + 2.days
+    )
+    @qualification = Qualification.create!(village: @village, name: "Foobar", description: "Can foo")
+    @other_qualification = Qualification.create!(village: @village, name: "Bazzer", description: "Can baz")
+    @user = User.create!(email: "delegate@example.com", password: "password123", password_confirmation: "password123")
+  end
+
+  test "is valid with user, qualification, and conference" do
+    delegation = QualificationAssignmentDelegation.new(user: @user, qualification: @qualification, conference: @conference)
+    assert delegation.valid?
+  end
+
+  test "does not allow duplicate delegation for the same user, qualification, and conference" do
+    QualificationAssignmentDelegation.create!(user: @user, qualification: @qualification, conference: @conference)
+    dup = QualificationAssignmentDelegation.new(user: @user, qualification: @qualification, conference: @conference)
+    assert_not dup.valid?
+  end
+
+  test "can_assign_qualification? is true for a delegate of that qualification and conference only" do
+    QualificationAssignmentDelegation.create!(user: @user, qualification: @qualification, conference: @conference)
+
+    assert @user.can_assign_qualification?(@qualification, @conference)
+    assert_not @user.can_assign_qualification?(@other_qualification, @conference)
+
+    other_conference = Conference.create!(
+      village: @village, name: "Other", start_date: Date.tomorrow, end_date: Date.tomorrow + 1.day
+    )
+    assert_not @user.can_assign_qualification?(@qualification, other_conference)
+  end
+
+  test "can_assign_qualification? is true for any conference manager" do
+    admin = User.create!(email: "admin@example.com", password: "password123", password_confirmation: "password123")
+    UserRole.create!(user: admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+    assert admin.can_assign_qualification?(@qualification, @conference)
+    assert admin.can_assign_qualification?(@other_qualification, @conference)
+  end
+
+  test "assignable_qualifications returns only delegated ones for a delegate" do
+    QualificationAssignmentDelegation.create!(user: @user, qualification: @qualification, conference: @conference)
+    assert_equal [ @qualification ], @user.assignable_qualifications(@conference).to_a
+  end
+
+  test "assignable_qualifications returns all village qualifications for a manager" do
+    admin = User.create!(email: "admin@example.com", password: "password123", password_confirmation: "password123")
+    UserRole.create!(user: admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+    assert_equal [ @other_qualification, @qualification ].sort_by(&:name), admin.assignable_qualifications(@conference).to_a
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #186. A conference manager can **delegate** the right to assign a specific global qualification to another user, scoped to one conference. A delegate can then grant and revoke only their delegated qualification(s) for that conference; managers can still assign anything.

## Changes

- New `QualificationAssignmentDelegation` model + migration (unique per user/qualification/conference).
- `User#can_assign_qualification?` / `#assignable_qualifications`.
- `QualificationDelegationsController` (manager-only) to create/remove delegations.
- `QualificationGrantsController` (managers + delegates) to grant/revoke qualifications to users, authorized per-qualification against the delegation.
- Conference show page links: "Delegate Qualifications" (managers) and "Assign Qualifications" (anyone with an assignable qualification).

## Scope decisions (from the issue)

- Delegation is **conference-wide** (keyed on user + qualification + conference).
- Delegates may **grant and revoke** their delegated qualification.
- Targets the **global `Qualification`** system (the one that gates signups), not the decorative `ConferenceQualification`.

## Testing

- Model + `User` helpers; delegation controller (only managers may delegate); grants controller (manager grants anything; delegate only their qualification; a non-delegate is denied; revoke rules). Full non-system suite passes.
- Manually verified end-to-end: manager delegates Foobar to a user; that delegate sees only Foobar on the assign page and can grant/revoke it; a user with no delegation gets no access.

## Follow-up
- Inline schedule CSS extraction (#197) is unrelated but shares the broader cleanup queue.

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)