### PR TITLE
Use modern headless Chrome to stabilize system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,14 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+  # Use Chrome's modern headless mode. The legacy `:headless_chrome` mode
+  # (--headless) has DOM/CDP inconsistencies on recent Chrome that intermittently
+  # raise "Node with given id does not belong to the document" during Capybara
+  # visibility checks. The extra flags stabilize Chrome in CI containers.
+  driven_by :selenium, using: :chrome, screen_size: [ 1400, 1400 ] do |options|
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #203. The `system-test` CI job fails intermittently with `Node with given id does not belong to the document` (a Chrome CDP error surfaced inside Capybara's visibility checks), blocking otherwise-green PRs — e.g. #199. It's the legacy headless mode misbehaving on Chrome 149, not a code bug in any PR.

## Change

`test/application_system_test_case.rb` now drives Chrome in the **modern headless mode** (`--headless=new`) with the standard CI stability flags:

```ruby
driven_by :selenium, using: :chrome, screen_size: [ 1400, 1400 ] do |options|
  options.add_argument("--headless=new")
  options.add_argument("--no-sandbox")
  options.add_argument("--disable-dev-shm-usage")
  options.add_argument("--disable-gpu")
end
```

## Verification

This PR's own `system-test` check is the verification — CI runs Chrome 149 with a matching Selenium-Manager driver. (Local system tests can't run here due to an unrelated local Chrome/driver version skew.)

## Rollout

Merge first, then rebase the open PRs so their `system-test` jobs re-run against the stabilized driver.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)