### PR TITLE
Fix 500 when a program name matches one in another scope

### DIFF
--- a/db/migrate/20260703171842_change_programs_unique_index_to_include_conference_id.rb
+++ b/db/migrate/20260703171842_change_programs_unique_index_to_include_conference_id.rb
@@ -1,0 +1,14 @@
+class ChangeProgramsUniqueIndexToIncludeConferenceId < ActiveRecord::Migration[8.1]
+  # A program name only needs to be unique within a village *and conference
+  # scope*: a conference-specific program may reuse a village-wide name (or a
+  # name used by another conference's program). The old [village_id, name] index
+  # forbade that at the DB level even though the model allowed it, causing an
+  # unhandled RecordNotUnique (500) on save. Include conference_id so the index
+  # matches the model's uniqueness scope.
+  def change
+    remove_index :programs, column: [ :village_id, :name ], unique: true,
+                            name: "index_programs_on_village_id_and_name"
+    add_index :programs, [ :village_id, :conference_id, :name ], unique: true,
+                         name: "index_programs_on_village_id_and_conference_id_and_name"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_235305) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_171842) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -129,7 +129,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_235305) do
     t.datetime "updated_at", null: false
     t.bigint "village_id", null: false
     t.index ["conference_id"], name: "index_programs_on_conference_id"
-    t.index ["village_id", "name"], name: "index_programs_on_village_id_and_name", unique: true
+    t.index ["village_id", "conference_id", "name"], name: "index_programs_on_village_id_and_conference_id_and_name", unique: true
     t.index ["village_id"], name: "index_programs_on_village_id"
   end
 

--- a/test/controllers/custom_programs_controller_test.rb
+++ b/test/controllers/custom_programs_controller_test.rb
@@ -152,4 +152,29 @@ class CustomProgramsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @conference, program.conference
     assert_redirected_to conference_conference_programs_path(@conference)
   end
+
+  test "can create a custom program whose name matches a village-wide program (issue #189)" do
+    Program.create!(name: "Shared Name", village: @village, max_volunteers: 2)
+    sign_in @conference_lead
+    assert_difference("Program.count", 1) do
+      post conference_custom_programs_path(@conference), params: {
+        program: { name: "Shared Name", max_volunteers: 2 }
+      }
+    end
+    created = Program.find_by(name: "Shared Name", conference: @conference)
+    assert created.present?
+    assert created.conference_specific?
+    assert_redirected_to conference_conference_programs_path(@conference)
+  end
+
+  test "duplicate name within the same conference re-renders the form instead of 500ing" do
+    Program.create!(name: "Dup In Conf", village: @village, conference: @conference, max_volunteers: 2)
+    sign_in @conference_lead
+    assert_no_difference("Program.count") do
+      post conference_custom_programs_path(@conference), params: {
+        program: { name: "Dup In Conf", max_volunteers: 2 }
+      }
+    end
+    assert_response :unprocessable_entity
+  end
 end

--- a/test/models/program_test.rb
+++ b/test/models/program_test.rb
@@ -157,12 +157,33 @@ class ProgramTest < ActiveSupport::TestCase
     )
     Program.create!(name: "Ham Test", village: @village)
 
-    conference_program = Program.new(
+    # Must persist without raising RecordNotUnique (issue #189): the DB unique
+    # index is scoped by conference_id, matching the model.
+    conference_program = Program.create!(
       name: "Ham Test",
       village: @village,
       conference: conference
     )
-    assert conference_program.valid?
+    assert conference_program.persisted?
+  end
+
+  test "same name can exist in two different conferences" do
+    conf_a = Conference.create!(name: "Conf A", village: @village, start_date: Date.tomorrow, end_date: Date.tomorrow + 1)
+    conf_b = Conference.create!(name: "Conf B", village: @village, start_date: Date.tomorrow, end_date: Date.tomorrow + 1)
+    Program.create!(name: "Setup Crew", village: @village, conference: conf_a)
+
+    dup = Program.new(name: "Setup Crew", village: @village, conference: conf_b)
+    assert dup.valid?
+    assert dup.save
+  end
+
+  test "duplicate name within the same conference is invalid" do
+    conference = Conference.create!(name: "Test Conference", village: @village, start_date: Date.tomorrow, end_date: Date.tomorrow + 1)
+    Program.create!(name: "Setup Crew", village: @village, conference: conference)
+
+    dup = Program.new(name: "Setup Crew", village: @village, conference: conference)
+    assert_not dup.valid?
+    assert_includes dup.errors[:name], "must be unique within the village"
   end
 
   # Program lead tests


### PR DESCRIPTION
## Summary

Fixes #189. Creating a conference-specific program whose name matched a village-wide program (or another conference's program) returned a **500**. The model validates name uniqueness scoped to `[village_id, conference_id]` (which allows it), but the DB unique index was on `[village_id, name]` (which forbids it), so the save raised `ActiveRecord::RecordNotUnique`.

## Change

Loosen the DB unique index to `[village_id, conference_id, name]` so it matches the model's uniqueness scope. Per the product decision, a conference-specific program **may** reuse a village-wide name (or a name used by another conference); duplicates **within the same conference** are still rejected — now as a normal validation error that re-renders the form, not a 500.

No model change was needed (its scope already permitted this); only the index changed.

## Testing

- Model: same name allowed across village-level/conference and across two conferences (now persisted via `create!`, proving the DB accepts it); duplicate within the same conference is invalid with the expected message.
- Controller: `custom_programs#create` with a name matching a village-wide program now succeeds; a same-conference duplicate re-renders with `:unprocessable_entity` instead of 500ing.
- Full suite passes; rubocop clean.

## Merge note
Carries a migration (`20260703171842`, the latest timestamp across the open PRs) — merge after the other migration-bearing PRs (#182/#185/#186) to keep the schema version monotonic.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)