### PR TITLE
Make the enable-existing-program flow discoverable

### DIFF
--- a/app/views/conference_programs/index.html.erb
+++ b/app/views/conference_programs/index.html.erb
@@ -94,28 +94,36 @@
     </div>
   <% end %>
 
-  <% if @available_programs.any? && policy(ConferenceProgram.new(conference: @conference)).create? %>
+  <% if policy(ConferenceProgram.new(conference: @conference)).create? %>
     <div class="mt-4">
       <h3>Available Programs</h3>
-      <p class="text-muted">The following programs are available but not yet enabled for this conference:</p>
-      <ul class="list-group">
-        <% @available_programs.each do |program| %>
-          <li class="list-group-item d-flex justify-content-between align-items-center">
-            <div>
-              <strong><%= program.name %></strong>
-              <% if program.conference_specific? %>
-                <span class="badge bg-info ms-1">Conference Only</span>
-              <% else %>
-                <span class="badge bg-secondary ms-1">Village-Wide</span>
-              <% end %>
-              <% if program.description.present? %>
-                <br><small class="text-muted"><%= truncate(program.description, length: 150) %></small>
-              <% end %>
-            </div>
-            <%= link_to "Enable", conference_new_conference_program_path(@conference, program_id: program.id), class: "btn btn-sm btn-primary" %>
-          </li>
-        <% end %>
-      </ul>
+      <% if @available_programs.any? %>
+        <p class="text-muted">Enable an existing village or conference program instead of creating a new one:</p>
+        <ul class="list-group">
+          <% @available_programs.each do |program| %>
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+              <div>
+                <strong><%= program.name %></strong>
+                <% if program.conference_specific? %>
+                  <span class="badge bg-info ms-1">Conference Only</span>
+                <% else %>
+                  <span class="badge bg-secondary ms-1">Village-Wide</span>
+                <% end %>
+                <% if program.description.present? %>
+                  <br><small class="text-muted"><%= truncate(program.description, length: 150) %></small>
+                <% end %>
+              </div>
+              <%= link_to "Enable", conference_new_conference_program_path(@conference, program_id: program.id), class: "btn btn-sm btn-primary" %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-muted mb-0">
+          No more programs are available to enable.
+          <%= link_to "Create a new program", new_conference_custom_program_path(@conference), class: "alert-link" %>
+          to add one to this conference.
+        </p>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/test/controllers/conference_programs_controller_test.rb
+++ b/test/controllers/conference_programs_controller_test.rb
@@ -86,6 +86,23 @@ class ConferenceProgramsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
+  test "index shows an empty available-programs state when all village programs are enabled" do
+    # The only village program is already enabled in setup, so none are available.
+    sign_in @village_admin
+    get conference_conference_programs_path(@conference)
+    assert_select "h3", text: "Available Programs"
+    assert_match(/No more programs are available to enable/, response.body)
+  end
+
+  test "index lists village programs available to enable" do
+    Program.create!(name: "Not Yet Enabled", description: "x", village: @village)
+    sign_in @village_admin
+    get conference_conference_programs_path(@conference)
+    assert_select "h3", text: "Available Programs"
+    assert_match(/Not Yet Enabled/, response.body)
+    assert_select "a", text: "Enable"
+  end
+
   test "should get new as village admin" do
     sign_in @village_admin
     get conference_new_conference_program_path(@conference)


### PR DESCRIPTION
## Summary

Fixes #190. On `/conferences/:id/programs`, the "Enable Existing Program" button and "Available Programs" list only rendered `if @available_programs.any?`. So when every village program was already enabled, the whole flow disappeared — users saw only "Create Conference Program" and had no signal that enabling an existing program was even possible (which led to duplicate-name attempts, i.e. #189).

## Change

Always render the "Available Programs" section for managers, with an explicit empty state when nothing is available:

> No more programs are available to enable. **Create a new program** to add one to this conference.

(The message is neutral so it reads correctly whether all village programs are enabled or the village has none yet.)

## Testing

- Controller/view test: with all village programs enabled, the page still shows the "Available Programs" heading + empty-state message; with an unenabled program present, it's listed with an Enable action.
- Full suite passes (836 runs, 0 failures); rubocop clean.

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)