### PR TITLE
Give activity leads a nav link to their Manage page

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -20,6 +20,7 @@ class ConferencesController < ApplicationController
   def show
     authorize @conference, :show?, policy_class: ConferencePolicy
     @conference_roles = @conference.conference_roles.includes(:user)
+    @led_conference_programs = current_user.led_conference_programs(@conference)
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,6 +129,15 @@ class User < ApplicationRecord
     can_manage_conference?(conference_program.conference) || activity_lead?(conference_program)
   end
 
+  # The activities (conference programs) this user leads within a conference.
+  def led_conference_programs(conference)
+    conference.conference_programs
+              .joins(:conference_program_roles)
+              .where(conference_program_roles: { user_id: id, role_name: ConferenceProgramRole::ACTIVITY_LEAD })
+              .includes(:program)
+              .order("programs.name")
+  end
+
   def volunteer?
     # Any registered user is a volunteer
     persisted?

--- a/app/views/conferences/show.html.erb
+++ b/app/views/conferences/show.html.erb
@@ -117,6 +117,20 @@
               </div>
             </div>
           <% end %>
+
+          <% if @led_conference_programs.any? %>
+            <hr>
+            <h5>Activities You Lead</h5>
+            <p class="text-muted small">You have activity-lead rights for these activities. Manage their volunteers and shifts from the schedule, or their leads here.</p>
+            <ul class="list-group mt-2">
+              <% @led_conference_programs.each do |cp| %>
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <%= cp.program.name %>
+                  <%= link_to "Manage", conference_conference_program_path(@conference, cp), class: "btn btn-sm btn-outline-primary" %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
         </div>
         <div class="card-footer">
           <div class="d-flex flex-wrap gap-2">

--- a/test/controllers/conferences_controller_test.rb
+++ b/test/controllers/conferences_controller_test.rb
@@ -49,6 +49,26 @@ class ConferencesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "conference show lists activities the current user leads with a manage link" do
+    program = Program.create!(name: "Foo Barring", village: @village)
+    cp = ConferenceProgram.create!(conference: @conference, program: program)
+    ConferenceProgramRole.create!(user: @volunteer, conference_program: cp, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+
+    sign_in @volunteer
+    get conference_url(@conference)
+    assert_match(/Activities You Lead/, response.body)
+    assert_select "a[href=?]", conference_conference_program_path(@conference, cp), text: "Manage"
+  end
+
+  test "conference show hides the activities-you-lead section for non-leads" do
+    program = Program.create!(name: "Foo Barring", village: @village)
+    ConferenceProgram.create!(conference: @conference, program: program)
+
+    sign_in @volunteer
+    get conference_url(@conference)
+    assert_no_match(/Activities You Lead/, response.body)
+  end
+
   test "should get new as village admin" do
     sign_in @village_admin
     get new_conference_url


### PR DESCRIPTION
## Summary

Fixes #200. An activity lead could manage their activity (`conference_programs#show`) only via the direct URL — the "Manage Leads" links live on the programs index, which is manager-only. This adds a discoverable path.

## Change

- New `User#led_conference_programs(conference)` — the activities a user leads in a conference.
- `ConferencesController#show` exposes `@led_conference_programs`.
- The conference show page now renders an **"Activities You Lead"** section (only when the current user leads at least one activity) listing each with a **Manage** link to its page.

Purely additive; server-side authorization was already correct.

## Testing

- Controller: an activity lead sees the section + a Manage link to the right activity; a non-lead does not.
- Full suite passes (836 runs, 0 failures); rubocop clean.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)