### PR TITLE
Preserve volunteer signups when schedules are edited

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -148,9 +148,10 @@ class Conference < ApplicationRecord
     return unless saved_change_to_start_date? || saved_change_to_end_date? ||
                   saved_change_to_conference_hours_start? || saved_change_to_conference_hours_end?
 
-    # Regenerate timeslots for all conference programs
+    # Reconcile timeslots for all conference programs. TimeslotGenerator keeps
+    # timeslots (and signups) whose start time still fits the new dates/hours
+    # instead of destroying and recreating everything (issue #225).
     conference_programs.find_each do |cp|
-      cp.timeslots.destroy_all
       TimeslotGenerator.new(cp).generate
     end
   end

--- a/app/models/conference_program.rb
+++ b/app/models/conference_program.rb
@@ -38,12 +38,11 @@ class ConferenceProgram < ApplicationRecord
   end
 
   def regenerate_timeslots_if_needed
-    return unless saved_change_to_day_schedules? || saved_change_to_public_description?
-
-    # Only regenerate if day_schedules changed
     return unless saved_change_to_day_schedules?
 
-    timeslots.destroy_all
+    # Reconcile timeslots against the new schedule. TimeslotGenerator preserves
+    # timeslots (and their volunteer signups) whose start time is unchanged, so
+    # editing the schedule no longer silently drops existing signups (issue #225).
     generate_timeslots
   end
 end

--- a/app/services/timeslot_generator.rb
+++ b/app/services/timeslot_generator.rb
@@ -5,20 +5,37 @@ class TimeslotGenerator
     @day_schedules = conference_program.day_schedules
   end
 
+  # Reconciles the conference program's timeslots against its current schedule.
+  #
+  # Rather than destroying every timeslot and recreating from scratch (which
+  # would cascade-delete all volunteer signups), this keeps timeslots whose
+  # start time still exists in the schedule, creates any newly-scheduled slots,
+  # and removes only the slots that no longer belong. Volunteers signed up for a
+  # removed slot are notified that their shift was cancelled (issue #225).
   def generate
-    return if @day_schedules.empty?
+    desired_start_times = compute_desired_start_times
 
-    (@conference.start_date..@conference.end_date).each_with_index do |date, day_index|
-      day_schedule = @day_schedules[day_index.to_s]
-      next unless day_schedule && day_schedule["enabled"] == true
-
-      generate_timeslots_for_day(date, day_schedule)
-    end
+    remove_obsolete_timeslots(desired_start_times)
+    create_missing_timeslots(desired_start_times)
   end
 
   private
 
-  def generate_timeslots_for_day(date, day_schedule)
+  # Every start time the current schedule calls for, as Time objects.
+  def compute_desired_start_times
+    return [] if @day_schedules.empty?
+
+    start_times = []
+    (@conference.start_date..@conference.end_date).each_with_index do |date, day_index|
+      day_schedule = @day_schedules[day_index.to_s]
+      next unless day_schedule && day_schedule["enabled"] == true
+
+      start_times.concat(start_times_for_day(date, day_schedule))
+    end
+    start_times
+  end
+
+  def start_times_for_day(date, day_schedule)
     start_time_str = day_schedule["start"]
     end_time_str = day_schedule["end"]
 
@@ -34,19 +51,51 @@ class TimeslotGenerator
       end_time_str = time_obj.utc.strftime("%H:%M")
     end
 
-    return unless start_time_str && end_time_str
+    return [] unless start_time_str && end_time_str
 
     start_time = Time.zone.parse("#{date} #{start_time_str}")
     end_time = Time.zone.parse("#{date} #{end_time_str}")
 
+    times = []
     current_time = start_time
     while current_time < end_time
+      times << current_time
+      current_time += 15.minutes
+    end
+    times
+  end
+
+  # Remove timeslots that no longer belong to the schedule. Compare by epoch
+  # seconds so persisted (DB-loaded) and freshly-parsed times match regardless
+  # of adapter or timezone representation.
+  def remove_obsolete_timeslots(desired_start_times)
+    desired_keys = desired_start_times.map(&:to_i).to_set
+
+    @conference_program.timeslots.includes(volunteer_signups: :user).find_each do |timeslot|
+      next if desired_keys.include?(timeslot.start_time.to_i)
+
+      notify_affected_volunteers(timeslot)
+      timeslot.destroy!
+    end
+  end
+
+  def create_missing_timeslots(desired_start_times)
+    existing_keys = @conference_program.timeslots.pluck(:start_time).map(&:to_i).to_set
+
+    desired_start_times.each do |start_time|
+      next if existing_keys.include?(start_time.to_i)
+
       Timeslot.create!(
         conference_program: @conference_program,
-        start_time: current_time,
+        start_time: start_time,
         max_volunteers: @conference_program.effective_max_volunteers
       )
-      current_time += 15.minutes
+    end
+  end
+
+  def notify_affected_volunteers(timeslot)
+    timeslot.volunteer_signups.each do |signup|
+      NotificationService.notify_shift_cancelled(user: signup.user, timeslot: timeslot)
     end
   end
 end

--- a/test/models/timeslot_signup_preservation_test.rb
+++ b/test/models/timeslot_signup_preservation_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+# Regression coverage for issue #225: editing a conference program's schedule
+# (or the conference dates/hours) must not silently destroy volunteer signups
+# for timeslots that still exist after the edit, and volunteers whose shifts
+# genuinely disappear must be notified.
+class TimeslotSignupPreservationTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      name: "Test Conference",
+      city: "Test City", state: "NV", country: "US",
+      start_date: Date.today + 1.day,
+      end_date: Date.today + 2.days,
+      conference_hours_start: Time.zone.parse("2000-01-01 09:00"),
+      conference_hours_end: Time.zone.parse("2000-01-01 17:00"),
+      village: @village
+    )
+    @program = Program.create!(
+      name: "Test Program",
+      description: "A test program",
+      village: @village
+    )
+    @conference_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" }
+      }
+    )
+    @user = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  def timeslot_at(day_offset, hhmm)
+    date = @conference.start_date + day_offset.days
+    @conference_program.timeslots.find_by(start_time: Time.zone.parse("#{date} #{hhmm}"))
+  end
+
+  test "extending the schedule preserves signups on unchanged timeslots" do
+    slot = timeslot_at(0, "09:00")
+    VolunteerSignup.create!(user: @user, timeslot: slot)
+
+    @conference_program.update!(
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "12:00" } }
+    )
+
+    assert VolunteerSignup.exists?(user: @user, timeslot: timeslot_at(0, "09:00")),
+      "signup on an unchanged timeslot should survive a schedule edit"
+  end
+
+  test "editing one day's schedule preserves signups on other unchanged days" do
+    @conference_program.update!(
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" },
+        "1" => { "enabled" => true, "start" => "09:00", "end" => "11:00" }
+      }
+    )
+    day1_slot = timeslot_at(1, "09:00")
+    VolunteerSignup.create!(user: @user, timeslot: day1_slot)
+
+    # Change only day 0's times
+    @conference_program.update!(
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "13:00", "end" => "15:00" },
+        "1" => { "enabled" => true, "start" => "09:00", "end" => "11:00" }
+      }
+    )
+
+    assert VolunteerSignup.exists?(user: @user, timeslot: timeslot_at(1, "09:00")),
+      "editing one day must not wipe signups on other days"
+  end
+
+  test "removing a timeslot destroys its signup but notifies the volunteer" do
+    slot = timeslot_at(0, "10:30")
+    VolunteerSignup.create!(user: @user, timeslot: slot)
+    slot_id = slot.id
+
+    @conference_program.update!(
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+
+    assert_not VolunteerSignup.exists?(timeslot_id: slot_id),
+      "signup on a removed timeslot should be gone"
+    assert @user.notifications.where(notification_type: Notification::SHIFT_CANCELLED).exists?,
+      "volunteer must be notified when their shift is removed by a schedule edit"
+  end
+
+  test "changing conference hours preserves signups on surviving timeslots" do
+    slot = timeslot_at(0, "09:00")
+    VolunteerSignup.create!(user: @user, timeslot: slot)
+
+    # Widen conference hours; day_schedules use explicit times so the 09:00
+    # slot survives. This exercises the Conference-level regeneration path.
+    @conference.update!(conference_hours_end: Time.zone.parse("2000-01-01 20:00"))
+
+    assert VolunteerSignup.exists?(user: @user, timeslot: timeslot_at(0, "09:00")),
+      "conference-level regeneration must preserve signups on surviving timeslots"
+  end
+end


### PR DESCRIPTION
## Summary

Editing a conference program's `day_schedules` (or the conference dates/hours) previously destroyed every timeslot and recreated them from scratch. Because `Timeslot has_many :volunteer_signups, dependent: :destroy`, this silently cascade-deleted **all** volunteer signups for the program — including signups on days and timeslots the edit never touched — with no warning to organizers or notification to volunteers.

## What changed

- `TimeslotGenerator#generate` now **reconciles** instead of rebuilding:
  - keeps timeslots whose start time still exists in the schedule (**preserving their signups**),
  - creates newly-scheduled slots,
  - removes only slots that no longer belong.
- Volunteers signed up for a removed slot are notified via `NotificationService.notify_shift_cancelled` that their shift was cancelled.
- Both regeneration callers (`ConferenceProgram#regenerate_timeslots_if_needed` and `Conference#regenerate_timeslots_if_schedule_changed`) drop their `timeslots.destroy_all` and delegate reconciliation to the generator.

## Testing

- New `test/models/timeslot_signup_preservation_test.rb` (TDD — written failing first): extending a schedule, editing one day preserving other days, removed-slot destroys signup + notifies the volunteer, and conference-hours changes preserving surviving slots.
- `bin/rails test` → 847 runs, 0 failures, 0 errors.
- `bin/rubocop -a` → clean.
- (`bin/rails test:all` system-test errors in my local env are Chrome/Selenium launch failures, unrelated to this change.)

## Follow-up

While investigating I found a separate, related bug filed as #226: changing a conference's `start_date` silently re-aligns each program's positional per-day schedule onto the wrong calendar dates. That is out of scope here and tracked independently.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)