### PR TITLE
Bump websocket-driver, loofah, rails-html-sanitizer for CVE advisories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -342,8 +342,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -462,7 +462,7 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
`scan_ruby` (bundler-audit) is failing on every PR because the advisory DB now flags three transitive dependencies. Conservative, lockfile-only bumps:

- **websocket-driver** 0.8.0 → 0.8.2 — CVE-2026-54464, CVE-2026-54465, Host-header DoS
- **loofah** 2.25.1 → 2.25.2 — `javascript:` URI + SVG `href` XSS bypasses
- **rails-html-sanitizer** 1.7.0 → 1.7.1 — XSS with certain configs

`bundle exec bundler-audit` clean; full suite green (847 runs, 0 failures). Same class of fix as #193.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)