### PR TITLE
Treat Chrome's stale-inspector-node error as retryable in system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,27 @@
 require "test_helper"
+# Not autoloaded until a Chrome driver boots, but we patch it at load time.
+require "capybara/selenium/nodes/chrome_node"
+
+# Chrome (149+) has a DevTools race: when a node is detached from the DOM
+# between Capybara finding it and checking its visibility, chromedriver
+# reports a generic UnknownError ("unhandled inspector error: ... Node with
+# given id does not belong to the document") instead of a
+# StaleElementReferenceError. Capybara auto-retries stale-element errors
+# inside #synchronize (re-running the query and re-finding the node), but not
+# UnknownError — so a routine, retryable race hard-errors the test instead.
+# Re-raise it as the stale-element error it actually is. (Issue #234)
+module RetryableStaleInspectorNode
+  STALE_INSPECTOR_NODE = /Node with given id does not belong to the document/
+
+  def visible?
+    super
+  rescue Selenium::WebDriver::Error::UnknownError => e
+    raise unless e.message.match?(STALE_INSPECTOR_NODE)
+
+    raise Selenium::WebDriver::Error::StaleElementReferenceError, e.message
+  end
+end
+Capybara::Selenium::ChromeNode.prepend(RetryableStaleInspectorNode)
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # Use Chrome's modern headless mode. The legacy `:headless_chrome` mode
@@ -10,5 +33,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")
     options.add_argument("--disable-gpu")
+    # Escape hatch when selenium-manager picks the wrong local browser (e.g. a
+    # stale "Chrome for Testing" install shadowing the real Chrome):
+    #   CHROME_BINARY="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" bin/rails test:system
+    options.binary = ENV["CHROME_BINARY"] if ENV["CHROME_BINARY"].present?
   end
 end


### PR DESCRIPTION
Root-cause fix for the CDP flake that has been failing system tests for weeks (#203/#204, #213/#214) and turned main red after #230 merged (6 consecutive retry attempts failed on run 29709336465).

**Root cause:** when a DOM node is detached between Capybara finding it and checking its visibility, chromedriver reports a generic `UnknownError` ("unhandled inspector error: … Node with given id does not belong to the document") instead of a `StaleElementReferenceError`. Capybara auto-retries stale-element errors inside `synchronize` — re-running the query and re-finding the node — but not `UnknownError`, so a routine retryable race hard-errors the test. It concentrates on schedule-page tests because that page's DOM is the heaviest (most visibility checks per query), and got worse on Chrome 150.

**Fix:** prepend a module to `Capybara::Selenium::ChromeNode#visible?` that rescues exactly this message and re-raises it as the `StaleElementReferenceError` it actually is, restoring Capybara's built-in retry. Unrelated `UnknownError`s pass through untouched. The CI whole-suite retry loop (#214) stays as a backstop.

Also adds a `CHROME_BINARY` env escape hatch so system tests can run locally when selenium-manager pairs a stale "Chrome for Testing" install with a current chromedriver.

**Verification**
- Unit-checked both rescue paths (target message converts; unrelated `UnknownError` passes through).
- Full system suite on Chrome 150 locally: 3 consecutive clean runs (45 runs, 0 failures each) — first time local system tests have been runnable in this repo.
- Full non-system suite green (875 runs, 0 failures); rubocop clean.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)