### PR TITLE
Convert stale-inspector-node errors at the Selenium Response level

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,27 +1,31 @@
 require "test_helper"
-# Not autoloaded until a Chrome driver boots, but we patch it at load time.
-require "capybara/selenium/nodes/chrome_node"
 
 # Chrome (149+) has a DevTools race: when a node is detached from the DOM
-# between Capybara finding it and checking its visibility, chromedriver
+# between Capybara finding it and operating on it (a Turbo page swap during
+# an assert_text, a re-render during a visibility check, ...), chromedriver
 # reports a generic UnknownError ("unhandled inspector error: ... Node with
 # given id does not belong to the document") instead of a
 # StaleElementReferenceError. Capybara auto-retries stale-element errors
 # inside #synchronize (re-running the query and re-finding the node), but not
 # UnknownError — so a routine, retryable race hard-errors the test instead.
-# Re-raise it as the stale-element error it actually is. (Issue #234)
+#
+# Convert it at the single choke point every WebDriver command's error is
+# classified through, so the fix covers find/text/click/visible?/etc. alike.
+# (Issues #234, #237 — a visible?-only version of this missed the text path.)
 module RetryableStaleInspectorNode
   STALE_INSPECTOR_NODE = /Node with given id does not belong to the document/
 
-  def visible?
-    super
-  rescue Selenium::WebDriver::Error::UnknownError => e
-    raise unless e.message.match?(STALE_INSPECTOR_NODE)
+  def error
+    ex = super
+    return ex unless ex.is_a?(Selenium::WebDriver::Error::UnknownError) &&
+                     ex.message.match?(STALE_INSPECTOR_NODE)
 
-    raise Selenium::WebDriver::Error::StaleElementReferenceError, e.message
+    Selenium::WebDriver::Error::StaleElementReferenceError.new(ex.message).tap do |stale|
+      stale.set_backtrace(ex.backtrace) if ex.backtrace
+    end
   end
 end
-Capybara::Selenium::ChromeNode.prepend(RetryableStaleInspectorNode)
+Selenium::WebDriver::Remote::Response.prepend(RetryableStaleInspectorNode)
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # Use Chrome's modern headless mode. The legacy `:headless_chrome` mode

--- a/test/selenium_stale_node_patch_test.rb
+++ b/test/selenium_stale_node_patch_test.rb
@@ -1,0 +1,39 @@
+require "application_system_test_case"
+
+# Regression coverage for the stale-inspector-node conversion (#234, #237).
+# Chrome reports a detached-node race as a generic UnknownError ("unhandled
+# inspector error: ... Node with given id does not belong to the document").
+# The patch in application_system_test_case.rb must convert it — at the
+# Selenium Response level, so EVERY command path (find, text, click,
+# visible?, ...) surfaces it as the retryable StaleElementReferenceError
+# that Capybara auto-retries inside #synchronize.
+class SeleniumStaleNodePatchTest < ActiveSupport::TestCase
+  STALE_MESSAGE = 'unhandled inspector error: {"code":-32000,' \
+                  '"message":"Node with given id does not belong to the document"}'
+
+  def response_error(message)
+    # Bypass initialize (which raises via assert_ok) to unit-test #error.
+    response = Selenium::WebDriver::Remote::Response.allocate
+    response.instance_variable_set(:@code, 400)
+    response.instance_variable_set(:@payload, { "value" => { "error" => "unknown error", "message" => message } })
+    response.error
+  end
+
+  test "the stale-inspector-node message becomes a retryable StaleElementReferenceError" do
+    error = response_error(STALE_MESSAGE)
+
+    assert_instance_of Selenium::WebDriver::Error::StaleElementReferenceError, error
+    assert_match(/Node with given id does not belong to the document/, error.message)
+  end
+
+  test "unrelated UnknownErrors are left untouched" do
+    error = response_error("session deleted because of page crash")
+
+    assert_instance_of Selenium::WebDriver::Error::UnknownError, error
+  end
+
+  test "Capybara auto-retries StaleElementReferenceError" do
+    assert_includes Capybara::Selenium::Driver.new(nil).invalid_element_errors,
+                    Selenium::WebDriver::Error::StaleElementReferenceError
+  end
+end


### PR DESCRIPTION
Follow-up to #235, which converted Chrome's misclassified stale-node error (`UnknownError: "Node with given id does not belong to the document"`) into a retryable `StaleElementReferenceError` — but only in `ChromeNode#visible?`. The post-merge main run of #236 hit the same race through **`Node#text`** instead (`assert_text "Logout"` during a Turbo page swap) and failed all 3 retry attempts.

Patching Capybara method-by-method is whack-a-mole, so this moves the conversion to the single choke point: `Selenium::WebDriver::Remote::Response#error`, where every WebDriver command's error is classified. Any command hitting the race — find, text, click, visible? — now raises the stale-element error it semantically is, and Capybara auto-retries it inside `synchronize`. Unrelated `UnknownError`s pass through untouched. The CI whole-suite retry loop (#214) remains as a backstop.

## Verification
- New unit regression test (TDD: red against the old patch, green against this one): conversion happens for the exact message, unrelated errors untouched, converted class is in Capybara's retry list.
- End-to-end check: `Response.new` with the raw chromedriver payload raises the retryable class.
- Full suite: 929 runs, 0 failures. System suite: 3 consecutive clean local runs on Chrome 150. rubocop clean.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)