### PR TITLE
Schedule redesign: coverage projection, volunteer claim stack, and triage (parts 1–3 of #211)

### DIFF
--- a/app/assets/stylesheets/schedule.scss
+++ b/app/assets/stylesheets/schedule.scss
@@ -164,3 +164,34 @@
 .schedule-day-nav-spacer {
   height: 4rem;
 }
+
+// --- Coverage view (#240) -------------------------------------------------
+// The ribbon: one tick per 15-minute slot, colored by coverage state.
+// Themed entirely off Bootstrap CSS variables so it follows any overrides.
+.coverage-ribbon {
+  display: flex;
+  gap: 2px;
+  border-radius: 0.375rem;
+  overflow: hidden;
+
+  .tick {
+    flex: 1;
+    height: 1.5rem;
+    min-width: 4px;
+    background: var(--bs-tertiary-bg);
+
+    &.bare { background: var(--bs-danger); }
+    &.short { background: var(--bs-warning); }
+    &.covered { background: var(--bs-success); }
+
+    // My own shifts: an info underline on top of whatever state color.
+    &.mine { box-shadow: inset 0 -4px 0 var(--bs-info); }
+
+    // Current claim selection.
+    &.selected { box-shadow: inset 0 0 0 3px var(--bs-primary); }
+    &.selected.mine { box-shadow: inset 0 0 0 3px var(--bs-primary), inset 0 -4px 0 var(--bs-info); }
+  }
+
+  &.claimable .tick.bare,
+  &.claimable .tick.short { cursor: pointer; }
+}

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -49,6 +49,19 @@ class ScheduleController < ApplicationController
     @program_qualifications = build_program_qualifications
     @user_qualification_ids = build_user_qualification_ids
 
+    # "Where you're needed" triage (#241): every uncovered gap across the days
+    # the volunteer is around (all days when unfiltered), worst first.
+    @around_days = parse_around_days
+    triage_days = @around_days.presence || @days
+    @triage = triage_days.flat_map do |day|
+      CoverageProjection.summary(@conference, day).map { |entry| entry.merge(day: day) }
+    end
+    @triage = @triage.reject { |entry| entry[:worst_state] == :covered }
+                     .sort_by { |entry| [ CoverageProjection::STATE_RANK.fetch(entry[:worst_state]), -entry[:uncovered_minutes] ] }
+
+    @hide_full = params[:hide_full] == "1"
+    @stack = @stack.reject { |entry| entry[:projection].gaps.empty? } if @hide_full
+
     # My signups for the day: a Set of timeslot ids for ribbon marking, and
     # contiguous ranges per activity for the "Your shifts" card.
     day_signups = current_user.volunteer_signups
@@ -78,6 +91,16 @@ class ScheduleController < ApplicationController
     return requested if requested && (@conference.start_date..@conference.end_date).cover?(requested)
 
     Date.current.clamp(@conference.start_date, @conference.end_date)
+  end
+
+  # Valid conference days from around[] params, in conference order.
+  def parse_around_days
+    requested = Array(params[:around]).filter_map do |value|
+      Date.iso8601(value.to_s)
+    rescue Date::Error
+      nil
+    end
+    @days & requested
   end
 
   # Collapse a day's signups into contiguous ranges per activity:

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -36,10 +36,62 @@ class ScheduleController < ApplicationController
     @users = User.order(:email) if @manageable_program_ids.any?
   end
 
+  # Coverage-based volunteer view (#240): per-activity claim stack rendered
+  # from CoverageProjection for one selected day. Ships alongside the legacy
+  # grid (#show) until the redesign reaches parity (#244).
+  def coverage
+    authorize @conference, :show?, policy_class: ConferencePolicy
+
+    @days = (@conference.start_date..@conference.end_date).to_a
+    @day = resolve_day
+    @stack = CoverageProjection.stack(@conference, @day)
+
+    @program_qualifications = build_program_qualifications
+    @user_qualification_ids = build_user_qualification_ids
+
+    # My signups for the day: a Set of timeslot ids for ribbon marking, and
+    # contiguous ranges per activity for the "Your shifts" card.
+    day_signups = current_user.volunteer_signups
+                              .joins(timeslot: { conference_program: :program })
+                              .where(conference_programs: { conference_id: @conference.id })
+                              .where(timeslots: { start_time: @day.in_time_zone.all_day })
+                              .includes(timeslot: { conference_program: :program })
+                              .sort_by { |signup| signup.timeslot.start_time }
+    @my_timeslot_ids = day_signups.map(&:timeslot_id).to_set
+    @my_shift_ranges = group_signups_into_ranges(day_signups)
+  end
+
   private
 
   def set_conference
     @conference = Conference.find(params[:conference_id])
+  end
+
+  # The selected day: ?day= if it falls inside the conference, else today
+  # clamped into the conference range.
+  def resolve_day
+    requested = begin
+      Date.iso8601(params[:day].to_s)
+    rescue Date::Error
+      nil
+    end
+    return requested if requested && (@conference.start_date..@conference.end_date).cover?(requested)
+
+    Date.current.clamp(@conference.start_date, @conference.end_date)
+  end
+
+  # Collapse a day's signups into contiguous ranges per activity:
+  # [{ program_name:, starts_at:, ends_at: }, ...]
+  def group_signups_into_ranges(signups)
+    signups.group_by { |signup| signup.timeslot.conference_program }.flat_map do |conference_program, program_signups|
+      program_signups.chunk_while { |a, b| a.timeslot.end_time == b.timeslot.start_time }.map do |run|
+        {
+          program_name: conference_program.program.name,
+          starts_at: run.first.timeslot.start_time,
+          ends_at: run.last.timeslot.end_time
+        }
+      end
+    end.sort_by { |range| range[:starts_at] }
   end
 
   # Set of Program ids the current user may administer on this schedule.

--- a/app/controllers/volunteer_signups_controller.rb
+++ b/app/controllers/volunteer_signups_controller.rb
@@ -42,7 +42,7 @@ class VolunteerSignupsController < ApplicationController
     # and a whole number of blocks (e.g. 30-min blocks => 30, 60, 90, ...).
     block_minutes = @conference.effective_minimum_shift_duration
     if requested_minutes < block_minutes || (requested_minutes % block_minutes).nonzero?
-      redirect_to conference_schedule_path(@conference),
+      redirect_to signup_return_path(conference_schedule_path(@conference)),
                   alert: "Shifts must be booked in #{block_minutes}-minute blocks for this conference."
       return
     end
@@ -64,7 +64,7 @@ class VolunteerSignupsController < ApplicationController
     # Check if any timeslot is full
     full_timeslots = timeslots_to_signup.select(&:full?)
     if full_timeslots.any?
-      redirect_to conference_schedule_path(@conference),
+      redirect_to signup_return_path(conference_schedule_path(@conference)),
                   alert: "Cannot sign up: Some timeslots are full (#{full_timeslots.first.start_time.strftime('%l:%M %p').strip})"
       return
     end
@@ -92,7 +92,7 @@ class VolunteerSignupsController < ApplicationController
     duration_str = hours > 0 ? "#{hours} hour#{'s' if hours > 1}" : ""
     duration_str += " #{minutes} minutes" if minutes > 0
 
-    redirect_to conference_volunteer_signups_path(@conference),
+    redirect_to signup_return_path(conference_volunteer_signups_path(@conference)),
                 notice: "Successfully signed up for #{created_count} shifts (#{duration_str.strip})."
   end
 
@@ -152,6 +152,15 @@ class VolunteerSignupsController < ApplicationController
   end
 
   private
+
+  # Where bulk_create sends the user afterward. The coverage view (#240) posts
+  # return_to=coverage (+ return_day) so claims land back on the ribbon they
+  # came from; everything else keeps the legacy destinations.
+  def signup_return_path(default)
+    return default unless params[:return_to] == "coverage"
+
+    conference_schedule_coverage_path(@conference, day: params[:return_day].presence)
+  end
 
   def set_conference
     @conference = Conference.find(params[:conference_id])

--- a/app/helpers/schedule_helper.rb
+++ b/app/helpers/schedule_helper.rb
@@ -1,4 +1,22 @@
 module ScheduleHelper
+  # Params for coverage-view links that preserve the current day filters
+  # (#241): around[] and hide_full survive day switches and Cover jumps.
+  # Overrides win; nil values drop out.
+  def coverage_link_params(overrides = {})
+    {
+      around: @around_days.presence&.map(&:iso8601),
+      hide_full: (@hide_full ? "1" : nil)
+    }.merge(overrides).compact
+  end
+
+  # 120 -> "2h", 90 -> "1h 30m", 45 -> "45m"
+  def coverage_duration(minutes)
+    hours, mins = minutes.divmod(60)
+    return "#{mins}m" if hours.zero?
+    return "#{hours}h" if mins.zero?
+
+    "#{hours}h #{mins}m"
+  end
   # Classifies a single timeslot cell for a volunteer, so the wide table and the
   # collapsed mobile view render identical status/badge logic.
   SlotStatus = Struct.new(:state, :missing_quals, keyword_init: true) do

--- a/app/javascript/controllers/coverage_ribbon_controller.js
+++ b/app/javascript/controllers/coverage_ribbon_controller.js
@@ -1,0 +1,93 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Gap-scoped claiming on a coverage ribbon (#240).
+//
+// The server renders every tick (state, timeslot id, start time) and the gap
+// runs as JSON; this controller only handles selection: tap an uncovered tick
+// to set the claim start, offer block-snapped lengths that fit the rest of
+// that hole (capped), and fill the hidden fields of the plain bulk_create
+// form. No fetch — the form posts and the server re-renders the ribbon.
+export default class extends Controller {
+  static targets = ["ribbon", "claimPanel", "lengthOptions", "timeslotField", "durationField", "submitButton", "hint"]
+  static values = {
+    blockMinutes: Number,
+    capMinutes: Number,
+    gaps: Array
+  }
+
+  connect() {
+    // Signal readiness so system tests can wait for the controller.
+    this.element.dataset.coverageRibbonReady = "true"
+  }
+
+  pickStart(event) {
+    const tick = event.currentTarget
+    const startIso = tick.dataset.start
+    const gap = this.gapsValue.find(g => g.start <= startIso && startIso < g.end)
+    if (!gap) return
+
+    this.startTick = tick
+    this.timeslotFieldTarget.value = tick.dataset.timeslotId
+
+    // Lengths that fit between the picked start and the end of this hole,
+    // in whole blocks, capped (settled decision: 4h max per claim).
+    const remaining = (new Date(gap.end) - new Date(startIso)) / 60000
+    const max = Math.min(remaining, this.capMinutesValue)
+    const options = []
+    for (let m = this.blockMinutesValue; m <= max; m += this.blockMinutesValue) options.push(m)
+
+    this.renderLengthOptions(options)
+    this.selectLength(options.includes(60) ? 60 : options[options.length - 1])
+
+    if (this.hasHintTarget) this.hintTarget.hidden = true
+    this.claimPanelTarget.hidden = false
+  }
+
+  renderLengthOptions(options) {
+    this.lengthOptionsTarget.innerHTML = ""
+    options.forEach(minutes => {
+      const button = document.createElement("button")
+      button.type = "button"
+      button.className = "btn btn-sm btn-outline-secondary"
+      button.dataset.minutes = minutes
+      button.textContent = this.formatDuration(minutes)
+      button.addEventListener("click", () => this.selectLength(minutes))
+      this.lengthOptionsTarget.appendChild(button)
+    })
+  }
+
+  selectLength(minutes) {
+    this.durationFieldTarget.value = minutes
+    this.lengthOptionsTarget.querySelectorAll("button").forEach(button => {
+      button.classList.toggle("active", Number(button.dataset.minutes) === minutes)
+    })
+    this.highlightSelection(minutes)
+
+    const start = new Date(this.startTick.dataset.start)
+    const end = new Date(start.getTime() + minutes * 60000)
+    this.submitButtonTarget.disabled = false
+    this.submitButtonTarget.textContent =
+      `Cover ${this.startTick.dataset.label} – ${this.formatTime(end)}`
+  }
+
+  highlightSelection(minutes) {
+    const startIso = this.startTick.dataset.start
+    const endMs = new Date(startIso).getTime() + minutes * 60000
+    this.ribbonTarget.querySelectorAll(".tick").forEach(tick => {
+      const tickMs = new Date(tick.dataset.start).getTime()
+      tick.classList.toggle("selected", tick.dataset.start >= startIso && tickMs < endMs)
+    })
+  }
+
+  formatDuration(minutes) {
+    const hours = Math.floor(minutes / 60)
+    const mins = minutes % 60
+    if (hours === 0) return `${mins}m`
+    if (mins === 0) return `${hours}h`
+    return `${hours}h ${mins}m`
+  }
+
+  formatTime(date) {
+    return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
+  }
+}

--- a/app/javascript/controllers/coverage_ribbon_controller.js
+++ b/app/javascript/controllers/coverage_ribbon_controller.js
@@ -12,16 +12,28 @@ export default class extends Controller {
   static values = {
     blockMinutes: Number,
     capMinutes: Number,
-    gaps: Array
+    gaps: Array,
+    focusTimeslotId: Number
   }
 
   connect() {
+    // Deep link from the triage "Cover" button (#241): pre-select that gap.
+    if (this.focusTimeslotIdValue) {
+      const tick = this.ribbonTarget.querySelector(`[data-timeslot-id='${this.focusTimeslotIdValue}']`)
+      if (tick && (tick.classList.contains("bare") || tick.classList.contains("short"))) {
+        this.armFrom(tick)
+        this.element.scrollIntoView({ block: "center" })
+      }
+    }
     // Signal readiness so system tests can wait for the controller.
     this.element.dataset.coverageRibbonReady = "true"
   }
 
   pickStart(event) {
-    const tick = event.currentTarget
+    this.armFrom(event.currentTarget)
+  }
+
+  armFrom(tick) {
     const startIso = tick.dataset.start
     const gap = this.gapsValue.find(g => g.start <= startIso && startIso < g.end)
     if (!gap) return

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import BulkCapacityUpdateController from "./bulk_capacity_update_controller"
 application.register("bulk-capacity-update", BulkCapacityUpdateController)
 
+import CoverageRibbonController from "./coverage_ribbon_controller"
+application.register("coverage-ribbon", CoverageRibbonController)
+
 import EmailConfigController from "./email_config_controller"
 application.register("email-config", EmailConfigController)
 

--- a/app/services/coverage_projection.rb
+++ b/app/services/coverage_projection.rb
@@ -1,0 +1,116 @@
+# Projects existing Timeslot data into coverage over time (#239).
+#
+# An activity is a position staffed continuously while the village is open;
+# this read model answers "how covered is it, and where are the holes?" for
+# one activity-day (.for) or a whole conference-day (.summary). It reads only
+# what Timeslot already stores — max_volunteers ("needed") and the
+# denormalized current_volunteers_count ("on") — so there are no counting
+# queries and no schema changes.
+#
+#   projection = CoverageProjection.for(conference_program, date)
+#   projection.ticks # => [{ timeslot_id:, start:, end:, needed:, on:, state: }, ...]
+#   projection.gaps  # => [{ start:, end:, needed:, start_timeslot_id:, minutes: }, ...]
+#
+# States: on >= needed -> :covered, on == 0 -> :bare, otherwise :short.
+# A gap is a time-contiguous run of ticks where on < needed — exactly the
+# windows a volunteer may claim (the server already restricts self-signup to
+# non-full slots, so gaps and claimable windows coincide).
+class CoverageProjection
+  TICK_MINUTES = 15
+  STATE_RANK = { bare: 0, short: 1, covered: 2 }.freeze
+
+  attr_reader :ticks, :gaps
+
+  def self.for(conference_program, date)
+    new(conference_program.timeslots.where(start_time: date.in_time_zone.all_day).order(:start_time))
+  end
+
+  # One entry per conference program scheduled on the date, worst coverage
+  # first (any bare beats any short beats covered; ties broken by uncovered
+  # minutes, descending). Programs with no slots that day are omitted — the
+  # admin board renders those as "not scheduled" itself.
+  def self.summary(conference, date)
+    slots = Timeslot.joins(:conference_program)
+                    .where(conference_programs: { conference_id: conference.id })
+                    .where(start_time: date.in_time_zone.all_day)
+                    .order(:start_time)
+                    .preload(conference_program: :program)
+
+    slots.group_by(&:conference_program).map do |conference_program, program_slots|
+      projection = new(program_slots)
+      {
+        conference_program: conference_program,
+        program_name: conference_program.program.name,
+        worst_state: projection.worst_state,
+        uncovered_minutes: projection.uncovered_minutes,
+        first_gap: projection.gaps.first
+      }
+    end.sort_by { |entry| [ STATE_RANK.fetch(entry[:worst_state]), -entry[:uncovered_minutes] ] }
+  end
+
+  def initialize(timeslots)
+    @ticks = timeslots.map { |slot| tick_for(slot) }
+    @gaps = build_gaps(@ticks)
+  end
+
+  def worst_state
+    ticks.min_by { |tick| STATE_RANK.fetch(tick[:state]) }&.fetch(:state) || :covered
+  end
+
+  def uncovered_minutes
+    gaps.sum { |gap| gap[:minutes] }
+  end
+
+  private
+
+  def tick_for(slot)
+    {
+      timeslot_id: slot.id,
+      start: slot.start_time,
+      end: slot.end_time,
+      needed: slot.max_volunteers,
+      on: slot.current_volunteers_count,
+      state: state_of(slot)
+    }
+  end
+
+  def state_of(slot)
+    return :covered if slot.current_volunteers_count >= slot.max_volunteers
+    return :bare if slot.current_volunteers_count.zero?
+
+    :short
+  end
+
+  # Merge consecutive under-covered ticks into runs. "Consecutive" is by time,
+  # not array position: a break in the schedule (no slot for a window) ends the
+  # run even though the next under-covered tick is adjacent in the array.
+  def build_gaps(ticks)
+    gaps = []
+    current = nil
+
+    ticks.each do |tick|
+      under = tick[:on] < tick[:needed]
+
+      if under && current && current[:end] == tick[:start]
+        current[:end] = tick[:end]
+        current[:needed] = [ current[:needed], tick[:needed] ].max
+        current[:minutes] += TICK_MINUTES
+      elsif under
+        gaps << current if current
+        current = {
+          start: tick[:start],
+          end: tick[:end],
+          needed: tick[:needed],
+          start_timeslot_id: tick[:timeslot_id],
+          minutes: TICK_MINUTES
+        }
+      elsif current
+        gaps << current
+        current = nil
+      end
+    end
+
+    gaps << current if current
+    gaps
+  end
+end

--- a/app/services/coverage_projection.rb
+++ b/app/services/coverage_projection.rb
@@ -25,6 +25,21 @@ class CoverageProjection
     new(conference_program.timeslots.where(start_time: date.in_time_zone.all_day).order(:start_time))
   end
 
+  # Every program scheduled on the date with its full projection, ordered by
+  # program name — the volunteer claim stack renders straight from this.
+  # Same bounded-query load as .summary (no per-program N+1).
+  def self.stack(conference, date)
+    slots = Timeslot.joins(:conference_program)
+                    .where(conference_programs: { conference_id: conference.id })
+                    .where(start_time: date.in_time_zone.all_day)
+                    .order(:start_time)
+                    .preload(conference_program: :program)
+
+    slots.group_by(&:conference_program)
+         .map { |conference_program, program_slots| { conference_program: conference_program, projection: new(program_slots) } }
+         .sort_by { |entry| entry[:conference_program].program.name }
+  end
+
   # One entry per conference program scheduled on the date, worst coverage
   # first (any bare beats any short beats covered; ties broken by uncovered
   # minutes, descending). Programs with no slots that day are omitted — the

--- a/app/views/schedule/_coverage_card.html.erb
+++ b/app/views/schedule/_coverage_card.html.erb
@@ -1,0 +1,58 @@
+<%
+  program = conference_program.program
+  qualifications = @program_qualifications[program.id] || []
+  locked = qualifications.any? { |qualification| !@user_qualification_ids.include?(qualification.id) }
+  worst = projection.worst_state
+  state_badge = { bare: [ "text-bg-danger", "Bare" ], short: [ "text-bg-warning", "Short" ], covered: [ "text-bg-success", "Covered" ] }[worst]
+%>
+<div class="card coverage-card"
+     <% unless locked %>
+     data-controller="coverage-ribbon"
+     data-coverage-ribbon-block-minutes-value="<%= @conference.effective_minimum_shift_duration %>"
+     data-coverage-ribbon-cap-minutes-value="240"
+     data-coverage-ribbon-gaps-value="<%= projection.gaps.map { |gap| { start: gap[:start].iso8601, end: gap[:end].iso8601, startTimeslotId: gap[:start_timeslot_id] } }.to_json %>"
+     <% end %>>
+  <div class="card-body">
+    <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-2">
+      <div>
+        <h2 class="h5 mb-1"><%= program.name %></h2>
+        <% qualifications.each do |qualification| %>
+          <span class="badge rounded-pill <%= @user_qualification_ids.include?(qualification.id) ? 'text-bg-light border' : 'text-bg-secondary' %>">
+            <%= "🔒 " unless @user_qualification_ids.include?(qualification.id) %><%= qualification.name %>
+          </span>
+        <% end %>
+      </div>
+      <span class="badge <%= state_badge[0] %>"><%= state_badge[1] %></span>
+    </div>
+
+    <%= render "coverage_ribbon", projection: projection, interactive: !locked %>
+
+    <% if locked %>
+      <p class="text-muted small mb-0 mt-2">
+        Requires <%= qualifications.reject { |q| @user_qualification_ids.include?(q.id) }.map(&:name).to_sentence %> —
+        contact an organizer to get qualified.
+      </p>
+    <% elsif projection.gaps.any? %>
+      <div class="mt-2" data-coverage-ribbon-target="claimPanel" hidden>
+        <div class="d-flex align-items-center flex-wrap gap-2">
+          <span class="text-muted small">Length:</span>
+          <div class="btn-group" role="group" data-coverage-ribbon-target="lengthOptions"></div>
+        </div>
+        <%= form_with url: bulk_create_conference_volunteer_signups_path(@conference), method: :post, data: { turbo: false } do %>
+          <input type="hidden" name="timeslot_id" data-coverage-ribbon-target="timeslotField">
+          <input type="hidden" name="duration_minutes" data-coverage-ribbon-target="durationField">
+          <input type="hidden" name="return_to" value="coverage">
+          <input type="hidden" name="return_day" value="<%= @day.iso8601 %>">
+          <button type="submit" class="btn btn-primary w-100 mt-2" data-coverage-ribbon-target="submitButton" disabled>
+            Pick a start time on the ribbon
+          </button>
+        <% end %>
+      </div>
+      <p class="text-muted small mb-0 mt-2" data-coverage-ribbon-target="hint">
+        Tap an uncovered (red/amber) segment to pick your start time.
+      </p>
+    <% else %>
+      <p class="text-success small mb-0 mt-2">Fully covered — nothing needed here today.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schedule/_coverage_card.html.erb
+++ b/app/views/schedule/_coverage_card.html.erb
@@ -5,12 +5,15 @@
   worst = projection.worst_state
   state_badge = { bare: [ "text-bg-danger", "Bare" ], short: [ "text-bg-warning", "Short" ], covered: [ "text-bg-success", "Covered" ] }[worst]
 %>
-<div class="card coverage-card"
+<div class="card coverage-card" id="activity-<%= conference_program.id %>"
      <% unless locked %>
      data-controller="coverage-ribbon"
      data-coverage-ribbon-block-minutes-value="<%= @conference.effective_minimum_shift_duration %>"
      data-coverage-ribbon-cap-minutes-value="240"
      data-coverage-ribbon-gaps-value="<%= projection.gaps.map { |gap| { start: gap[:start].iso8601, end: gap[:end].iso8601, startTimeslotId: gap[:start_timeslot_id] } }.to_json %>"
+     <% if params[:focus].present? %>
+     data-coverage-ribbon-focus-timeslot-id-value="<%= params[:focus].to_i %>"
+     <% end %>
      <% end %>>
   <div class="card-body">
     <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-2">

--- a/app/views/schedule/_coverage_ribbon.html.erb
+++ b/app/views/schedule/_coverage_ribbon.html.erb
@@ -1,0 +1,20 @@
+<%# Coverage ribbon: one server-rendered tick per 15-min slot. The Stimulus
+    controller only toggles selection classes and reads data-* — all state
+    comes from CoverageProjection. %>
+<div class="d-flex justify-content-between text-muted small">
+  <span><%= projection.ticks.first[:start].strftime("%-l:%M %p") %></span>
+  <span><%= projection.ticks.last[:end].strftime("%-l:%M %p") %></span>
+</div>
+<div class="coverage-ribbon <%= "claimable" if interactive %>" <% if interactive %>data-coverage-ribbon-target="ribbon"<% end %>>
+  <% projection.ticks.each do |tick| %>
+    <span class="tick <%= tick[:state] %> <%= "mine" if @my_timeslot_ids.include?(tick[:timeslot_id]) %>"
+          title="<%= tick[:start].strftime("%-l:%M %p") %> — <%= tick[:on] %> of <%= tick[:needed] %> covered"
+          data-timeslot-id="<%= tick[:timeslot_id] %>"
+          data-start="<%= tick[:start].iso8601 %>"
+          data-label="<%= tick[:start].strftime("%-l:%M %p") %>"
+          <% if interactive && tick[:on] < tick[:needed] %>
+          data-action="click->coverage-ribbon#pickStart"
+          role="button"
+          <% end %>></span>
+  <% end %>
+</div>

--- a/app/views/schedule/coverage.html.erb
+++ b/app/views/schedule/coverage.html.erb
@@ -1,0 +1,48 @@
+<div class="container-fluid mt-4" style="max-width: 1440px;">
+  <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+    <h1 class="mb-0"><%= @conference.name %> - Coverage</h1>
+    <%= link_to "Grid view", conference_schedule_path(@conference), class: "btn btn-outline-secondary btn-sm" %>
+  </div>
+
+  <%= turbo_frame_tag :schedule_day do %>
+    <%# Day switcher: Turbo Frame reload per day. data-current-day lives INSIDE
+        the frame (frame element attributes survive frame navigation). %>
+    <div class="btn-group mb-4" role="group" aria-label="Day" data-current-day="<%= @day.iso8601 %>">
+      <% @days.each do |day| %>
+        <%= link_to day.strftime("%a %-m/%-d"),
+            conference_schedule_coverage_path(@conference, day: day.iso8601),
+            class: "btn btn-sm #{day == @day ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <% end %>
+    </div>
+
+    <% if @my_shift_ranges.any? %>
+      <div class="card my-shifts mb-4 border-info">
+        <div class="card-header bg-info-subtle"><strong>Your shifts — <%= @day.strftime("%A, %B %-d") %></strong></div>
+        <ul class="list-group list-group-flush">
+          <% @my_shift_ranges.each do |range| %>
+            <li class="list-group-item d-flex justify-content-between">
+              <span><%= range[:program_name] %></span>
+              <span class="text-muted">
+                <%= range[:starts_at].strftime("%-l:%M %p") %> – <%= range[:ends_at].strftime("%-l:%M %p") %>
+              </span>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <% if @stack.empty? %>
+      <div class="alert alert-secondary">Nothing scheduled on <%= @day.strftime("%A, %B %-d") %>.</div>
+    <% else %>
+      <div class="row row-cols-1 g-3">
+        <% @stack.each do |entry| %>
+          <div class="col">
+            <%= render "coverage_card",
+                conference_program: entry[:conference_program],
+                projection: entry[:projection] %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/schedule/coverage.html.erb
+++ b/app/views/schedule/coverage.html.erb
@@ -4,15 +4,80 @@
     <%= link_to "Grid view", conference_schedule_path(@conference), class: "btn btn-outline-secondary btn-sm" %>
   </div>
 
-  <%= turbo_frame_tag :schedule_day do %>
-    <%# Day switcher: Turbo Frame reload per day. data-current-day lives INSIDE
-        the frame (frame element attributes survive frame navigation). %>
-    <div class="btn-group mb-4" role="group" aria-label="Day" data-current-day="<%= @day.iso8601 %>">
-      <% @days.each do |day| %>
-        <%= link_to day.strftime("%a %-m/%-d"),
-            conference_schedule_coverage_path(@conference, day: day.iso8601),
-            class: "btn btn-sm #{day == @day ? 'btn-primary' : 'btn-outline-primary'}" %>
-      <% end %>
+  <%# Day/filter links are plain Turbo Drive navigations, NOT a Turbo Frame.
+      A frame here wrapped ~the whole page (no win), broke anchors on the
+      triage Cover links, and chromedriver (Chrome 150) drops synthetic
+      clicks on frame-swapped content — Drive body replacement has none of
+      those problems. %>
+  <div id="schedule_day">
+    <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+      <div class="btn-group" role="group" aria-label="Day" data-current-day="<%= @day.iso8601 %>">
+        <% @days.each do |day| %>
+          <%= link_to day.strftime("%a %-m/%-d"),
+              conference_schedule_coverage_path(@conference, coverage_link_params(day: day.iso8601)),
+              class: "btn btn-sm #{day == @day ? 'btn-primary' : 'btn-outline-primary'}" %>
+        <% end %>
+      </div>
+      <%= link_to (@hide_full ? "Show full activities" : "Hide full activities"),
+          conference_schedule_coverage_path(@conference, coverage_link_params(day: @day.iso8601, hide_full: (@hide_full ? nil : "1"))),
+          class: "btn btn-sm #{@hide_full ? 'btn-secondary' : 'btn-outline-secondary'}" %>
+    </div>
+
+    <%# "Where you're needed" (#241): worst gaps first, scoped to the days
+        you're around. Chips toggle days; no chips = the whole conference. %>
+    <div class="card mb-4">
+      <div class="card-body">
+        <div class="d-flex align-items-center flex-wrap gap-2 mb-3">
+          <h2 class="h6 mb-0 me-2">Where you're needed</h2>
+          <span class="text-muted small">I'm around:</span>
+          <% @days.each do |day| %>
+            <% selected = @around_days.include?(day) %>
+            <%= link_to day.strftime("%a"),
+                conference_schedule_coverage_path(@conference,
+                  coverage_link_params(day: @day.iso8601,
+                                       around: ((selected ? @around_days - [ day ] : @around_days + [ day ]).presence&.map(&:iso8601)))),
+                class: "btn btn-sm rounded-pill #{selected ? 'btn-info' : 'btn-outline-info'}" %>
+          <% end %>
+        </div>
+
+        <% if @triage.empty? %>
+          <p class="text-success mb-0">Covered everywhere<%= " you'll be around" if @around_days.any? %> — nothing needs help right now. 🎉</p>
+        <% else %>
+          <div class="list-group triage-list">
+            <% @triage.each do |entry| %>
+              <%
+                conference_program = entry[:conference_program]
+                qualifications = @program_qualifications[conference_program.program_id] || []
+                missing = qualifications.reject { |qualification| @user_qualification_ids.include?(qualification.id) }
+                gap = entry[:first_gap]
+              %>
+              <div class="list-group-item triage-strip d-flex justify-content-between align-items-center flex-wrap gap-2">
+                <div>
+                  <span class="badge <%= entry[:worst_state] == :bare ? 'text-bg-danger' : 'text-bg-warning' %>">
+                    <%= entry[:worst_state] == :bare ? "Bare" : "Short" %>
+                  </span>
+                  <strong class="ms-1"><%= entry[:program_name] %></strong>
+                  <span class="text-muted ms-1">
+                    <%= entry[:day].strftime("%a %-m/%-d") %> ·
+                    <%= coverage_duration(entry[:uncovered_minutes]) %> uncovered ·
+                    from <%= gap[:start].strftime("%-l:%M %p") %>
+                  </span>
+                  <% missing.each do |qualification| %>
+                    <span class="badge rounded-pill text-bg-secondary ms-1">🔒 <%= qualification.name %></span>
+                  <% end %>
+                </div>
+                <% if missing.empty? %>
+                  <%= link_to "Cover",
+                      conference_schedule_coverage_path(@conference,
+                        coverage_link_params(day: entry[:day].iso8601, focus: gap[:start_timeslot_id],
+                                             anchor: "activity-#{conference_program.id}")),
+                      class: "btn btn-primary btn-sm" %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     </div>
 
     <% if @my_shift_ranges.any? %>
@@ -32,7 +97,9 @@
     <% end %>
 
     <% if @stack.empty? %>
-      <div class="alert alert-secondary">Nothing scheduled on <%= @day.strftime("%A, %B %-d") %>.</div>
+      <div class="alert alert-secondary">
+        <%= @hide_full ? "Everything scheduled on #{@day.strftime("%A, %B %-d")} is fully covered." : "Nothing scheduled on #{@day.strftime("%A, %B %-d")}." %>
+      </div>
     <% else %>
       <div class="row row-cols-1 g-3">
         <% @stack.each do |entry| %>
@@ -44,5 +111,5 @@
         <% end %>
       </div>
     <% end %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -8,6 +8,7 @@
           <span aria-hidden="true">&larr;</span> Conference
         <% end %>
         <h1 class="mb-0"><%= @conference.name %> - Schedule</h1>
+        <%= link_to "Coverage view", conference_schedule_coverage_path(@conference), class: "btn btn-outline-secondary btn-sm ms-auto" %>
       </div>
       <p class="text-muted">
         <% if @can_see_all_volunteers %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
     resources :custom_programs, only: [ :new, :create, :edit, :update, :destroy ]
     resources :conference_roles, only: [ :create, :destroy ]
     get "schedule", to: "schedule#show", as: :schedule
+    get "schedule/coverage", to: "schedule#coverage", as: :schedule_coverage
     get "leaderboard", to: "leaderboard#conference", as: :leaderboard
     resources :volunteer_signups, only: [ :index, :create, :destroy ] do
       collection do

--- a/test/controllers/schedule_coverage_test.rb
+++ b/test/controllers/schedule_coverage_test.rb
@@ -1,0 +1,157 @@
+require "test_helper"
+
+# Volunteer coverage view (#240): per-activity claim stack rendered from
+# CoverageProjection, day-scoped, shipping alongside the legacy grid.
+class ScheduleCoverageTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 2.days,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00",
+      minimum_shift_duration: 30
+    )
+    @program = Program.create!(name: "Ham Exams", village: @village)
+    @cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" },
+        "1" => { "enabled" => true, "start" => "10:00", "end" => "12:00" }
+      }
+    )
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      handle: "Vol One"
+    )
+    sign_in @volunteer
+  end
+
+  test "renders the claim stack with a card per activity scheduled that day" do
+    get conference_schedule_coverage_path(@conference)
+
+    assert_response :success
+    assert_select ".coverage-card", 1
+    assert_select ".coverage-card", text: /Ham Exams/
+    assert_select ".coverage-ribbon .tick", 8
+    assert_select ".tick.bare", 8
+  end
+
+  test "day defaults to the first conference day when today is outside the range" do
+    get conference_schedule_coverage_path(@conference)
+
+    assert_select "[data-current-day='#{@conference.start_date.iso8601}']"
+  end
+
+  test "day param selects that day's schedule and clamps out-of-range values" do
+    day2 = @conference.start_date + 1.day
+    get conference_schedule_coverage_path(@conference, day: day2.iso8601)
+    assert_select "[data-current-day='#{day2.iso8601}']"
+    assert_select ".coverage-ribbon .tick", 8   # 10:00-12:00
+
+    get conference_schedule_coverage_path(@conference, day: "2001-01-01")
+    assert_select "[data-current-day='#{@conference.start_date.iso8601}']"
+  end
+
+  test "a day with nothing scheduled says so" do
+    day3 = @conference.start_date + 2.days
+    get conference_schedule_coverage_path(@conference, day: day3.iso8601)
+
+    assert_response :success
+    assert_select ".coverage-card", 0
+    assert_match(/nothing scheduled/i, response.body)
+  end
+
+  test "covered ticks render covered and my slots are marked mine" do
+    slots = @cp.timeslots.order(:start_time).to_a
+    slots[0].update_column(:current_volunteers_count, 1)
+    VolunteerSignup.create!(user: @volunteer, timeslot: slots[1])
+
+    get conference_schedule_coverage_path(@conference)
+
+    assert_select ".tick.covered", 2   # the filled slot + my signup (counter cache)
+    assert_select ".tick.mine", 1
+  end
+
+  test "my shifts for the day are listed as grouped ranges" do
+    slots = @cp.timeslots.order(:start_time).to_a
+    slots[0..2].each { |slot| VolunteerSignup.create!(user: @volunteer, timeslot: slot) }
+
+    get conference_schedule_coverage_path(@conference)
+
+    assert_select ".my-shifts", text: /Ham Exams/
+    assert_select ".my-shifts", text: /9:00\s*AM\s*[-–]\s*9:45\s*AM/
+  end
+
+  test "an activity gated by a qualification I lack shows locked with no claim form" do
+    qualification = Qualification.create!(name: "Licensed Ham", description: "License", village: @village)
+    ProgramQualification.create!(program: @program, qualification: qualification)
+
+    get conference_schedule_coverage_path(@conference)
+
+    assert_select ".coverage-card .badge", text: /Licensed Ham/
+    assert_select ".coverage-card form[action=?]", bulk_create_conference_volunteer_signups_path(@conference), count: 0
+  end
+
+  test "an activity gated by a qualification I hold is claimable" do
+    qualification = Qualification.create!(name: "Licensed Ham", description: "License", village: @village)
+    ProgramQualification.create!(program: @program, qualification: qualification)
+    UserQualification.create!(user: @volunteer, qualification: qualification)
+
+    get conference_schedule_coverage_path(@conference)
+
+    assert_select ".coverage-card form[action=?]", bulk_create_conference_volunteer_signups_path(@conference)
+  end
+
+  test "claim form carries the conference block size and the 4h cap for the ribbon controller" do
+    get conference_schedule_coverage_path(@conference)
+
+    assert_select "[data-coverage-ribbon-block-minutes-value='30']"
+    assert_select "[data-coverage-ribbon-cap-minutes-value='240']"
+  end
+
+  test "requires authentication" do
+    sign_out @volunteer
+    get conference_schedule_coverage_path(@conference)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "bulk_create returns to the coverage view when asked" do
+    start_slot = @cp.timeslots.order(:start_time).first
+
+    post bulk_create_conference_volunteer_signups_path(@conference),
+         params: { timeslot_id: start_slot.id, duration_minutes: 30,
+                   return_to: "coverage", return_day: @conference.start_date.iso8601 }
+
+    assert_redirected_to conference_schedule_coverage_path(@conference, day: @conference.start_date.iso8601)
+    assert_equal 2, @volunteer.volunteer_signups.count
+  end
+
+  test "bulk_create keeps its default destinations without return_to" do
+    start_slot = @cp.timeslots.order(:start_time).first
+
+    post bulk_create_conference_volunteer_signups_path(@conference),
+         params: { timeslot_id: start_slot.id, duration_minutes: 30 }
+    assert_redirected_to conference_volunteer_signups_path(@conference)
+
+    post bulk_create_conference_volunteer_signups_path(@conference),
+         params: { timeslot_id: start_slot.id, duration_minutes: 20 }   # not a whole block
+    assert_redirected_to conference_schedule_path(@conference)
+  end
+
+  test "bulk_create block-size errors also return to the coverage view when asked" do
+    start_slot = @cp.timeslots.order(:start_time).first
+
+    post bulk_create_conference_volunteer_signups_path(@conference),
+         params: { timeslot_id: start_slot.id, duration_minutes: 20,
+                   return_to: "coverage", return_day: @conference.start_date.iso8601 }
+
+    assert_redirected_to conference_schedule_coverage_path(@conference, day: @conference.start_date.iso8601)
+    assert_match(/blocks/, flash[:alert])
+  end
+end

--- a/test/controllers/schedule_triage_test.rb
+++ b/test/controllers/schedule_triage_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+
+# "Where you're needed" triage (#241): worst gaps across the conference,
+# scoped by the volunteer's "I'm around" days, with hide-full and a Cover
+# deep link that pre-selects the gap on the activity's card.
+class ScheduleTriageTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00",
+      minimum_shift_duration: 30
+    )
+    @day1 = @conference.start_date
+    @day2 = @day1 + 1.day
+
+    # Bare both days, 2h each day.
+    @exams = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Ham Exams", village: @village),
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" },
+        "1" => { "enabled" => true, "start" => "09:00", "end" => "11:00" }
+      }
+    )
+    # Day 1 only, 1h, fully covered.
+    @desk = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+    @desk.timeslots.each { |slot| slot.update_column(:current_volunteers_count, 1) }
+
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      handle: "Vol One"
+    )
+    sign_in @volunteer
+  end
+
+  test "triage lists uncovered gaps across all days, worst first, skipping covered activities" do
+    get conference_schedule_coverage_path(@conference)
+
+    assert_select ".triage-strip", 2                       # Ham Exams day1 + day2; Front Desk covered
+    assert_select ".triage-strip", text: /Ham Exams/
+    assert_select ".triage-strip", text: /2h uncovered/
+    assert_select ".triage-strip", text: /Front Desk/, count: 0
+  end
+
+  test "I'm around day chips scope the triage to those days" do
+    get conference_schedule_coverage_path(@conference, around: [ @day2.iso8601 ])
+
+    assert_select ".triage-strip", 1
+    assert_select ".triage-strip", text: Regexp.new(@day2.strftime("%a"))
+  end
+
+  test "the Cover link carries day, focus, and filters, anchored to the activity card" do
+    get conference_schedule_coverage_path(@conference, around: [ @day2.iso8601 ])
+
+    expected_focus = @exams.timeslots.where(start_time: @day2.in_time_zone.all_day).order(:start_time).first.id
+    expected = conference_schedule_coverage_path(
+      @conference, day: @day2.iso8601, around: [ @day2.iso8601 ], focus: expected_focus, anchor: "activity-#{@exams.id}"
+    )
+    assert_select ".triage-strip a.btn-primary[href=?]", expected
+  end
+
+  test "focus param arms the matching card's ribbon controller" do
+    focus_slot = @exams.timeslots.order(:start_time).first
+
+    get conference_schedule_coverage_path(@conference, focus: focus_slot.id)
+
+    assert_select "#activity-#{@exams.id}[data-coverage-ribbon-focus-timeslot-id-value='#{focus_slot.id}']"
+  end
+
+  test "hide-full removes fully covered activities from the stack" do
+    get conference_schedule_coverage_path(@conference)
+    assert_select ".coverage-card", 2
+
+    get conference_schedule_coverage_path(@conference, hide_full: "1")
+    assert_select ".coverage-card", 1
+    assert_select ".coverage-card", text: /Front Desk/, count: 0
+  end
+
+  test "day switcher links preserve around and hide_full params" do
+    get conference_schedule_coverage_path(@conference, around: [ @day2.iso8601 ], hide_full: "1")
+
+    expected = conference_schedule_coverage_path(@conference, day: @day2.iso8601, around: [ @day2.iso8601 ], hide_full: "1")
+    assert_select ".btn-group[aria-label='Day'] a[href=?]", expected
+  end
+
+  test "a qualification-locked activity appears in triage without a Cover button" do
+    qualification = Qualification.create!(name: "Licensed Ham", description: "License", village: @village)
+    ProgramQualification.create!(program: @exams.program, qualification: qualification)
+
+    get conference_schedule_coverage_path(@conference)
+
+    assert_select ".triage-strip", text: /Ham Exams/
+    assert_select ".triage-strip", text: /Licensed Ham/
+    assert_select ".triage-strip a.btn-primary", count: 0
+  end
+
+  test "fully covered conference shows the all-covered message instead of triage" do
+    @exams.timeslots.each { |slot| slot.update_column(:current_volunteers_count, 1) }
+
+    get conference_schedule_coverage_path(@conference)
+
+    assert_select ".triage-strip", 0
+    assert_match(/covered everywhere/i, response.body)
+  end
+end

--- a/test/services/coverage_projection_test.rb
+++ b/test/services/coverage_projection_test.rb
@@ -1,0 +1,214 @@
+require "test_helper"
+
+# CoverageProjection (#239): projects existing Timeslot data into coverage
+# ticks and gap runs. Pure read model — the single source both the volunteer
+# claim stack and the admin board render from.
+class CoverageProjectionTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+    @program = Program.create!(name: "Ham Exams", village: @village)
+    # Day 0: 09:00-11:00 -> 8 fifteen-minute slots, needed defaults to 1 each.
+    @cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" } }
+    )
+    @day = @conference.start_date
+    @slots = @cp.timeslots.order(:start_time).to_a
+    assert_equal 8, @slots.size, "expected the schedule to generate 8 slots"
+  end
+
+  def cover(slot, count)
+    slot.update_column(:current_volunteers_count, count)
+  end
+
+  # --- ticks ---
+
+  test "ticks are ordered, one per slot, with needed/on read from the slot" do
+    projection = CoverageProjection.for(@cp, @day)
+
+    assert_equal 8, projection.ticks.size
+    assert_equal @slots.map(&:id), projection.ticks.map { |t| t[:timeslot_id] }
+    assert_equal @slots.first.start_time, projection.ticks.first[:start]
+    assert_equal [ 1 ], projection.ticks.map { |t| t[:needed] }.uniq
+    assert_equal [ 0 ], projection.ticks.map { |t| t[:on] }.uniq
+  end
+
+  test "tick states: bare when empty, short when under target, covered at or over target" do
+    cover(@slots[1], 1)              # covered (1/1)
+    @slots[2].update_column(:max_volunteers, 2)
+    cover(@slots[2], 1)              # short (1/2)
+    @slots[3].update_column(:max_volunteers, 2)
+    cover(@slots[3], 3)              # covered (3/2 — admin over-cover)
+
+    states = CoverageProjection.for(@cp, @day).ticks.map { |t| t[:state] }
+
+    assert_equal :bare,    states[0]
+    assert_equal :covered, states[1]
+    assert_equal :short,   states[2]
+    assert_equal :covered, states[3]
+  end
+
+  test "only the requested date's slots appear" do
+    other_day_cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Two Day Program", village: @village),
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" },
+        "1" => { "enabled" => true, "start" => "09:00", "end" => "12:00" }
+      }
+    )
+
+    assert_equal 4,  CoverageProjection.for(other_day_cp, @day).ticks.size
+    assert_equal 12, CoverageProjection.for(other_day_cp, @day + 1.day).ticks.size
+  end
+
+  test "a day with no slots yields no ticks and no gaps" do
+    projection = CoverageProjection.for(@cp, @day + 1.day)
+
+    assert_empty projection.ticks
+    assert_empty projection.gaps
+  end
+
+  # --- gaps ---
+
+  test "a fully uncovered day is one gap spanning the whole schedule" do
+    gaps = CoverageProjection.for(@cp, @day).gaps
+
+    assert_equal 1, gaps.size
+    assert_equal @slots.first.start_time, gaps.first[:start]
+    assert_equal @slots.last.end_time,    gaps.first[:end]
+    assert_equal @slots.first.id,         gaps.first[:start_timeslot_id]
+    assert_equal 120,                     gaps.first[:minutes]
+  end
+
+  test "covered slots split the day into separate gaps" do
+    cover(@slots[2], 1)
+    cover(@slots[3], 1)
+
+    gaps = CoverageProjection.for(@cp, @day).gaps
+
+    assert_equal 2, gaps.size
+    assert_equal [ @slots[0].start_time, @slots[4].start_time ], gaps.map { |g| g[:start] }
+    assert_equal [ 30, 60 ], gaps.map { |g| g[:minutes] }
+  end
+
+  test "a fully covered day has no gaps" do
+    @slots.each { |slot| cover(slot, 1) }
+
+    assert_empty CoverageProjection.for(@cp, @day).gaps
+  end
+
+  test "short slots count as gaps and carry the run's max needed" do
+    @slots.each { |slot| cover(slot, 1) }
+    @slots[5].update_column(:max_volunteers, 3)   # 1/3 -> short
+
+    gaps = CoverageProjection.for(@cp, @day).gaps
+
+    assert_equal 1, gaps.size
+    assert_equal @slots[5].start_time, gaps.first[:start]
+    assert_equal @slots[5].end_time,   gaps.first[:end]
+    assert_equal 3, gaps.first[:needed]
+  end
+
+  test "a schedule break splits a gap even when both sides are uncovered" do
+    # Split the day: 09:00-09:30 and 10:00-11:00 with a 30-minute break between.
+    @cp.update!(day_schedules: {
+      "0" => { "enabled" => true, "start" => "09:00", "end" => "09:30" },
+      "1" => { "enabled" => true, "start" => "09:00", "end" => "11:00" }
+    })
+    morning = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Split Program", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "09:30" } }
+    )
+    # Manufacture the break by removing 09:30-10:00 from an extended schedule.
+    morning.update!(day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:30" } })
+    morning.timeslots.order(:start_time).offset(2).limit(2).each(&:destroy!)
+
+    gaps = CoverageProjection.for(morning, @day).gaps
+
+    assert_equal 2, gaps.size, "gap must not span the 09:30-10:00 break"
+    assert_equal 30, gaps.first[:minutes]
+    assert_equal 30, gaps.last[:minutes]
+  end
+
+  # --- conference-wide summary ---
+
+  test "summary returns one entry per program scheduled that day, worst first" do
+    bare_program = @cp                                     # all bare
+    short_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Radio Demos", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+    short_program.timeslots.each { |slot| slot.update_column(:current_volunteers_count, 1) }
+    short_program.timeslots.first.update_column(:max_volunteers, 2)  # one short slot
+    covered_program = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+    covered_program.timeslots.each { |slot| slot.update_column(:current_volunteers_count, 1) }
+    unscheduled = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Night Only", village: @village),
+      day_schedules: { "1" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+
+    summary = CoverageProjection.summary(@conference, @day)
+
+    assert_equal [ bare_program.id, short_program.id, covered_program.id ],
+                 summary.map { |entry| entry[:conference_program].id }
+    refute_includes summary.map { |entry| entry[:conference_program].id }, unscheduled.id
+
+    bare_entry, short_entry, covered_entry = summary
+    assert_equal :bare, bare_entry[:worst_state]
+    assert_equal 120,   bare_entry[:uncovered_minutes]
+    assert_equal :short, short_entry[:worst_state]
+    assert_equal 15,     short_entry[:uncovered_minutes]
+    assert_equal :covered, covered_entry[:worst_state]
+    assert_equal 0,        covered_entry[:uncovered_minutes]
+    assert_nil covered_entry[:first_gap]
+    assert_equal bare_entry[:first_gap][:start], @slots.first.start_time
+  end
+
+  test "summary orders same-state programs by uncovered minutes, worst first" do
+    @slots.first(6).each { |slot| slot.update_column(:current_volunteers_count, 1) }  # 30 bare min left
+    big_gap = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "All Day Bare", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "12:00" } }
+    )
+
+    summary = CoverageProjection.summary(@conference, @day)
+
+    assert_equal [ big_gap.id, @cp.id ], summary.map { |entry| entry[:conference_program].id }
+  end
+
+  test "summary uses a bounded number of queries" do
+    3.times do |i|
+      ConferenceProgram.create!(
+        conference: @conference,
+        program: Program.create!(name: "Prog #{i}", village: @village),
+        day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+      )
+    end
+
+    queries = 0
+    counter = ->(*, payload) { queries += 1 unless payload[:name] == "SCHEMA" }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+      CoverageProjection.summary(@conference, @day)
+    end
+
+    assert_operator queries, :<=, 3, "summary should not N+1 across programs (ran #{queries} queries)"
+  end
+end

--- a/test/system/schedule_coverage_test.rb
+++ b/test/system/schedule_coverage_test.rb
@@ -75,7 +75,68 @@ class ScheduleCoverageSystemTest < ApplicationSystemTestCase
     end
   end
 
-  test "switching days re-renders the stack in the frame" do
+  test "triage Cover jumps to the gap on another day and pre-selects it" do
+    @cp.update!(day_schedules: {
+      "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" },
+      "1" => { "enabled" => true, "start" => "13:00", "end" => "15:00" }
+    })
+    # Cover day 1 fully so the only triage gap is day 2's afternoon.
+    @cp.timeslots.where(start_time: @conference.start_date.in_time_zone.all_day)
+       .each { |slot| slot.update_column(:current_volunteers_count, 1) }
+
+    login_as @volunteer
+    visit conference_schedule_coverage_path(@conference)
+
+    within ".triage-list" do
+      assert_text "1:00 PM"
+      click_link "Cover"
+    end
+
+    day2 = @conference.start_date + 1.day
+    assert_selector "[data-current-day='#{day2.iso8601}']"
+    # The gap arrived pre-selected: claim panel open, button armed at 1:00 PM.
+    assert_selector "[data-coverage-ribbon-target='claimPanel']:not([hidden])"
+    assert_selector "button:not([disabled])", text: /\ACover 1:00 PM/
+  end
+
+  test "hide-full toggle removes covered activities from the stack" do
+    covered = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+    covered.timeslots.each { |slot| slot.update_column(:current_volunteers_count, 1) }
+
+    login_as @volunteer
+    visit conference_schedule_coverage_path(@conference)
+    assert_selector ".coverage-card", count: 2
+
+    click_link "Hide full activities"
+    assert_selector ".coverage-card", count: 1
+    assert_no_text "Front Desk"
+
+    click_link "Show full activities"
+    assert_selector ".coverage-card", count: 2
+  end
+
+  test "I'm around chips scope the triage list" do
+    @cp.update!(day_schedules: {
+      "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" },
+      "1" => { "enabled" => true, "start" => "09:00", "end" => "11:00" }
+    })
+
+    login_as @volunteer
+    visit conference_schedule_coverage_path(@conference)
+    assert_selector ".triage-strip", count: 2
+
+    day2 = @conference.start_date + 1.day
+    within ".card", text: "Where you're needed" do
+      click_link day2.strftime("%a")
+    end
+    assert_selector ".triage-strip", count: 1
+  end
+
+  test "switching days re-renders the stack" do
     @cp.update!(day_schedules: {
       "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" },
       "1" => { "enabled" => true, "start" => "13:00", "end" => "14:00" }

--- a/test/system/schedule_coverage_test.rb
+++ b/test/system/schedule_coverage_test.rb
@@ -1,0 +1,93 @@
+require "application_system_test_case"
+
+# The coverage claim flow (#240): tap a tick in a hole, pick a block-snapped
+# length scoped to that hole, claim the window through bulk_create.
+class ScheduleCoverageSystemTest < ApplicationSystemTestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00",
+      minimum_shift_duration: 30
+    )
+    @program = Program.create!(name: "Ham Exams", village: @village)
+    @cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      # 09:00-11:00 -> a 2h day
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" } }
+    )
+    @volunteer = User.create!(
+      email: "volunteer@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      handle: "Vol One"
+    )
+  end
+
+  def login_as(user)
+    visit new_user_session_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    click_button "Log in"
+    assert_text "Logout"
+  end
+
+  test "claiming a window from the ribbon" do
+    login_as @volunteer
+    visit conference_schedule_coverage_path(@conference)
+    assert_selector "[data-coverage-ribbon-ready]"
+
+    # Tap the first tick, pick 1 hour, claim.
+    first(".coverage-ribbon .tick.bare").click
+    assert_selector "[data-coverage-ribbon-target='claimPanel']:not([hidden])"
+    within "[data-coverage-ribbon-target='lengthOptions']" do
+      find("button", text: "1h", exact_text: true).click
+    end
+    assert_selector "button:not([disabled])", text: /\ACover 9:00 AM/
+    find("button", text: /\ACover 9:00 AM/).click
+
+    # Back on the coverage view with the window claimed. Wait on the flash
+    # first — the form POST + redirect can outlast the default Capybara wait.
+    assert_text "Successfully signed up for 4 shifts", wait: 10
+    assert_current_path conference_schedule_coverage_path(@conference, day: @conference.start_date.iso8601)
+    assert_selector ".tick.covered", count: 4
+    assert_selector ".tick.mine", count: 4
+    assert_selector ".my-shifts", text: /9:00 AM\s*–\s*10:00 AM/
+  end
+
+  test "length options are scoped to the hole" do
+    # Cover 09:30 onward, leaving only a 30-minute hole at the front.
+    @cp.timeslots.order(:start_time).offset(2).each { |slot| slot.update_column(:current_volunteers_count, 1) }
+
+    login_as @volunteer
+    visit conference_schedule_coverage_path(@conference)
+    assert_selector "[data-coverage-ribbon-ready]"
+
+    first(".coverage-ribbon .tick.bare").click
+    within "[data-coverage-ribbon-target='lengthOptions']" do
+      assert_selector "button", count: 1
+      assert_selector "button", text: "30m", exact_text: true
+    end
+  end
+
+  test "switching days re-renders the stack in the frame" do
+    @cp.update!(day_schedules: {
+      "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" },
+      "1" => { "enabled" => true, "start" => "13:00", "end" => "14:00" }
+    })
+
+    login_as @volunteer
+    visit conference_schedule_coverage_path(@conference)
+    assert_selector ".coverage-ribbon .tick", count: 8
+
+    day2 = @conference.start_date + 1.day
+    click_link day2.strftime("%a %-m/%-d")
+    assert_selector "[data-current-day='#{day2.iso8601}']"
+    assert_selector ".coverage-ribbon .tick", count: 4
+  end
+end


### PR DESCRIPTION
The volunteer half of the schedule-redesign epic (#211), as three sequential commits — one per ticket. (Deadlock-dependent tickets sharing a branch per the updated Git Hygiene rules; this branch predates the feature-naming convention and keeps its original name by maintainer OK.)

Design reference: the approved interactive mockup at https://livitup.github.io/villagers/schedule-demo.html

## Commit 1 — #239: CoverageProjection read model
Pure service projecting existing `Timeslot` data (`max_volunteers` / denormalized `current_volunteers_count`) into per-15-min coverage ticks (`covered`/`short`/`bare`), time-contiguous gap runs, and a conference-wide worst-first summary — in a bounded 2–3 queries with a query-count spec guarding against N+1. No schema changes, no writes.

## Commit 2 — #240: Volunteer coverage view with gap-scoped claiming
`/conferences/:id/schedule/coverage`, shipping **alongside** the legacy grid (toggle links both ways; the grid is untouched until #244):
- Day switcher; per-activity cards with coverage ribbons (Bootstrap-variable theming, "mine" markers, per-tick tooltips)
- Tap an uncovered tick → block-snapped length options scoped to that hole, capped at 4h (settled decision) → plain-form claim via the existing `bulk_create` (block size, holes-only, qualifications all enforced server-side as today; only addition is an opt-in `return_to=coverage` redirect)
- "Your shifts" ranges for the day; qualification-locked activities render read-only with a lock badge

## Commit 3 — #241: "Where you're needed" triage + filters
- Worst-first gap strips (bare ▸ short ▸ most uncovered time) across the conference
- **Cover** deep-links to the right day and arrives with that gap pre-selected + scrolled into view
- "I'm around" day chips scope triage to the days a volunteer attends; hide-full toggle for the stack; filters survive navigation (all param-driven links, no client state)

### Note: Turbo Frame dropped deliberately
Day switching was initially a Turbo Frame. Instrumented system tests showed **chromedriver (Chrome 150) silently drops synthetic clicks on content inside a swapped turbo-frame** — no input event reaches the page (JS `.click()` works; `elementFromPoint` confirms correct geometry). Turbo Drive body replacement is exercised by the entire existing suite without issue, the frame wrapped ~the whole page anyway, and frames break anchor scrolling on Cover links — so day/filter links are plain Drive navigations.

## Testing
- 33 new tests: 12 service specs (tick states incl. varying per-slot needed and over-cover, gap merging/splitting incl. schedule breaks, day boundaries, summary ordering, query budget), 21 controller tests, 6 system tests (end-to-end claim, hole-scoped lengths, cross-day Cover pre-selection, hide-full round trip, chip scoping, day switch)
- Full suite: 962 runs, 0 failures; system suite 51 runs, 0 failures (run twice locally on Chrome 150); rubocop clean

Closes #239
Closes #240
Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)