### PR TITLE
Schedule redesign: window/day-scoped admin write paths (part 4 of #211)

### DIFF
--- a/app/controllers/timeslots_controller.rb
+++ b/app/controllers/timeslots_controller.rb
@@ -1,7 +1,8 @@
 class TimeslotsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_conference
-  before_action :set_timeslot
+  before_action :set_timeslot, only: [ :update, :add_volunteer, :remove_volunteer ]
+  before_action :set_conference_program, only: [ :bulk_add_volunteer, :bulk_remove_volunteer, :bulk_update_capacity ]
 
   def update
     authorize @timeslot.conference_program, :update?, policy_class: ConferenceProgramPolicy
@@ -36,10 +37,97 @@ class TimeslotsController < ApplicationController
     redirect_to conference_schedule_path(@conference), notice: "#{user_email} removed from shift."
   end
 
+  # --- Window/day-scoped admin operations (#242) ---
+  # A "window" is start_timeslot_id + duration_minutes, mirroring the volunteer
+  # bulk_create contract. All three are gated by ConferenceProgramPolicy#update?
+  # (conference managers + this activity's lead).
+
+  # Add a user to every slot in the window. Skips slots they're already on.
+  # Admin placements may over-cover (exceed needed) — that's the settled
+  # decision — but overlap and qualification rules still apply, and one bad
+  # slot rolls back the whole window.
+  def bulk_add_volunteer
+    authorize @conference_program, :update?, policy_class: ConferenceProgramPolicy
+
+    user = User.find(params[:user_id])
+    slots = window_timeslots
+    already_on = user.volunteer_signups.where(timeslot_id: slots.map(&:id)).pluck(:timeslot_id).to_set
+
+    begin
+      ActiveRecord::Base.transaction do
+        slots.reject { |slot| already_on.include?(slot.id) }.each do |slot|
+          VolunteerSignup.create!(user: user, timeslot: slot, allow_over_capacity: true)
+        end
+      end
+      redirect_back fallback_location: conference_schedule_path(@conference),
+                    notice: "#{helpers.display_name_with_callsign(user)} added #{window_label(slots)}."
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_back fallback_location: conference_schedule_path(@conference),
+                    alert: "Could not add #{user.display_name}: #{e.record.errors.full_messages.to_sentence}"
+    end
+  end
+
+  # Remove a user from every slot in the window they're signed up for.
+  def bulk_remove_volunteer
+    authorize @conference_program, :update?, policy_class: ConferenceProgramPolicy
+
+    user = User.find(params[:user_id])
+    slots = window_timeslots
+    signups = user.volunteer_signups.where(timeslot_id: slots.map(&:id))
+    removed = signups.size
+
+    ActiveRecord::Base.transaction { signups.destroy_all }
+
+    redirect_back fallback_location: conference_schedule_path(@conference),
+                  notice: "#{helpers.display_name_with_callsign(user)} removed from #{removed} slot#{'s' unless removed == 1}."
+  end
+
+  # Set needed (max_volunteers) for every slot of the activity on one date —
+  # one value per day (settled decision).
+  def bulk_update_capacity
+    authorize @conference_program, :update?, policy_class: ConferenceProgramPolicy
+
+    new_max = params[:max_volunteers].to_i
+    if new_max < 1
+      redirect_back fallback_location: conference_schedule_path(@conference),
+                    alert: "Needed volunteers must be at least 1."
+      return
+    end
+
+    date = Date.iso8601(params[:date].to_s)
+    updated = @conference_program.timeslots.where(start_time: date.in_time_zone.all_day)
+                                 .update_all(max_volunteers: new_max)
+
+    redirect_back fallback_location: conference_schedule_path(@conference),
+                  notice: "Needed set to #{new_max} for #{updated} slot#{'s' unless updated == 1} on #{date.strftime('%A, %B %-d')}."
+  rescue Date::Error
+    redirect_back fallback_location: conference_schedule_path(@conference), alert: "Invalid date."
+  end
+
   private
 
   def set_conference
     @conference = Conference.find(params[:conference_id])
+  end
+
+  def set_conference_program
+    @conference_program = @conference.conference_programs.find(params[:conference_program_id])
+  end
+
+  # Ordered slots of the window [start, start + duration) for this activity.
+  def window_timeslots
+    start_slot = @conference_program.timeslots.find(params[:start_timeslot_id])
+    end_time = start_slot.start_time + params[:duration_minutes].to_i.minutes
+    @conference_program.timeslots
+                       .where("start_time >= ? AND start_time < ?", start_slot.start_time, end_time)
+                       .order(:start_time)
+                       .to_a
+  end
+
+  def window_label(slots)
+    return "to 0 slots" if slots.empty?
+
+    "#{slots.first.start_time.strftime('%-l:%M %p')} – #{slots.last.end_time.strftime('%-l:%M %p')}"
   end
 
   def set_timeslot

--- a/app/models/volunteer_signup.rb
+++ b/app/models/volunteer_signup.rb
@@ -4,6 +4,12 @@ class VolunteerSignup < ApplicationRecord
   has_one :conference, through: :timeslot
   has_one :program, through: :timeslot
 
+  # Admin placements may exceed a slot's needed count (#242 settled decision:
+  # admins can place anyone anywhere, including over-covering). Volunteer
+  # self-signup never sets this, so the fullness check still protects it.
+  # Overlap and qualification validations apply to everyone regardless.
+  attr_accessor :allow_over_capacity
+
   validates :user, presence: true
   validates :timeslot, presence: true, uniqueness: { scope: :user_id }
   validate :no_overlapping_signups
@@ -31,6 +37,7 @@ class VolunteerSignup < ApplicationRecord
 
   def timeslot_not_full
     return unless timeslot
+    return if allow_over_capacity
 
     if timeslot.current_volunteers_count >= timeslot.max_volunteers
       errors.add(:base, "This timeslot is full")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,13 @@ Rails.application.routes.draw do
         post :add_volunteer
         delete :remove_volunteer
       end
+      # Window/day-scoped admin operations (#242): act on a run of slots for
+      # one activity instead of a single 15-minute cell.
+      collection do
+        post :bulk_add_volunteer
+        delete :bulk_remove_volunteer
+        patch :bulk_update_capacity
+      end
     end
     resources :reports, controller: "conference_reports", only: [ :index ] do
       collection do

--- a/test/controllers/timeslot_bulk_actions_test.rb
+++ b/test/controllers/timeslot_bulk_actions_test.rb
@@ -1,0 +1,193 @@
+require "test_helper"
+
+# Window/day-scoped admin write paths (#242): bulk add/remove a volunteer
+# across a window and day-scoped capacity. Settled decisions: admins may
+# over-cover (exceed needed); capacity is one value per activity per day.
+class TimeslotBulkActionsTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+    @program = Program.create!(name: "Ham Exams", village: @village)
+    @cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" },
+        "1" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+    @day1_slots = @cp.timeslots.where(start_time: @conference.start_date.in_time_zone.all_day).order(:start_time).to_a
+
+    @admin = create_user("admin@example.com", handle: "Admin")
+    UserRole.create!(user: @admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+    @target = create_user("target@example.com", handle: "Radio Ray")
+    sign_in @admin
+  end
+
+  def create_user(email, handle:)
+    User.create!(email: email, password: "password123", password_confirmation: "password123", handle: handle)
+  end
+
+  def bulk_add(start_slot: @day1_slots.first, duration: 60, user: @target)
+    post bulk_add_volunteer_conference_timeslots_path(@conference),
+         params: { conference_program_id: @cp.id, user_id: user.id,
+                   start_timeslot_id: start_slot.id, duration_minutes: duration }
+  end
+
+  # --- bulk add ---
+
+  test "adds the volunteer to every slot in the window and keeps counters correct" do
+    bulk_add(duration: 60)
+
+    assert_response :redirect
+    assert_equal 4, @target.volunteer_signups.count
+    assert_equal @day1_slots.first(4).map(&:id).sort, @target.volunteer_signups.map(&:timeslot_id).sort
+    assert_equal [ 1, 1, 1, 1, 0, 0, 0, 0 ], @day1_slots.map { |slot| slot.reload.current_volunteers_count }
+    assert_match "Radio Ray", flash[:notice]
+  end
+
+  test "skips slots the volunteer is already on" do
+    VolunteerSignup.create!(user: @target, timeslot: @day1_slots[1])
+
+    bulk_add(duration: 60)
+
+    assert_equal 4, @target.volunteer_signups.count
+    assert_equal 1, @day1_slots[1].reload.current_volunteers_count, "no duplicate signup"
+  end
+
+  test "admin placement may over-cover a full slot" do
+    other = create_user("other@example.com", handle: "Other Vol")
+    VolunteerSignup.create!(user: other, timeslot: @day1_slots.first)   # 1/1 -> full
+
+    bulk_add(duration: 15)
+
+    assert_equal 1, @target.volunteer_signups.count
+    assert_equal 2, @day1_slots.first.reload.current_volunteers_count
+    assert_operator @day1_slots.first.current_volunteers_count, :>, @day1_slots.first.max_volunteers
+  end
+
+  test "rolls back the whole window when one slot fails validation" do
+    # Overlapping signup on another program mid-window -> that slot fails.
+    other_cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:30", "end" => "09:45" } }
+    )
+    VolunteerSignup.create!(user: @target, timeslot: other_cp.timeslots.first)
+
+    bulk_add(duration: 60)
+
+    assert_equal 1, @target.volunteer_signups.count, "only the pre-existing signup remains"
+    assert_equal [ 0, 0, 0, 0 ], @day1_slots.first(4).map { |slot| slot.reload.current_volunteers_count }
+    assert_match(/overlapping/i, flash[:alert])
+  end
+
+  test "still enforces qualifications" do
+    qualification = Qualification.create!(name: "Licensed Ham", description: "License", village: @village)
+    ProgramQualification.create!(program: @program, qualification: qualification)
+
+    bulk_add(duration: 30)
+
+    assert_equal 0, @target.volunteer_signups.count
+    assert_match(/qualifications/i, flash[:alert])
+  end
+
+  # --- bulk remove ---
+
+  test "removes the volunteer from only the window's slots" do
+    @day1_slots.each { |slot| VolunteerSignup.create!(user: @target, timeslot: slot) }
+
+    delete bulk_remove_volunteer_conference_timeslots_path(@conference),
+           params: { conference_program_id: @cp.id, user_id: @target.id,
+                     start_timeslot_id: @day1_slots[2].id, duration_minutes: 60 }
+
+    assert_response :redirect
+    remaining = @target.volunteer_signups.map(&:timeslot_id).sort
+    assert_equal (@day1_slots.first(2) + @day1_slots.last(2)).map(&:id).sort, remaining
+    assert_equal [ 1, 1, 0, 0, 0, 0, 1, 1 ], @day1_slots.map { |slot| slot.reload.current_volunteers_count }
+  end
+
+  # --- day-scoped capacity ---
+
+  test "sets capacity for every slot of the activity on the date and nothing else" do
+    other_cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+
+    patch bulk_update_capacity_conference_timeslots_path(@conference),
+          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601, max_volunteers: 3 }
+
+    assert_response :redirect
+    assert_equal [ 3 ], @day1_slots.map { |slot| slot.reload.max_volunteers }.uniq
+    day2_slots = @cp.timeslots.where(start_time: (@conference.start_date + 1.day).in_time_zone.all_day)
+    assert_equal [ 1 ], day2_slots.map(&:max_volunteers).uniq, "other day untouched"
+    assert_equal [ 1 ], other_cp.timeslots.map(&:max_volunteers).uniq, "other activity untouched"
+  end
+
+  test "rejects a capacity below 1" do
+    patch bulk_update_capacity_conference_timeslots_path(@conference),
+          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601, max_volunteers: 0 }
+
+    assert_match(/at least 1/i, flash[:alert])
+    assert_equal [ 1 ], @day1_slots.map { |slot| slot.reload.max_volunteers }.uniq
+  end
+
+  # --- authorization ---
+
+  test "the activity lead of this activity may use all three actions" do
+    lead = create_user("lead@example.com", handle: "Lead")
+    ConferenceProgramRole.create!(user: lead, conference_program: @cp, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in lead
+
+    bulk_add(duration: 15)
+    assert_equal 1, @target.volunteer_signups.count
+
+    patch bulk_update_capacity_conference_timeslots_path(@conference),
+          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601, max_volunteers: 2 }
+    assert_equal [ 2 ], @day1_slots.map { |slot| slot.reload.max_volunteers }.uniq
+  end
+
+  test "an activity lead of a different activity is denied" do
+    other_cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+    outsider = create_user("outsider@example.com", handle: "Outsider")
+    ConferenceProgramRole.create!(user: outsider, conference_program: other_cp, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in outsider
+
+    bulk_add(duration: 15)
+
+    assert_equal 0, @target.volunteer_signups.count
+  end
+
+  test "a plain volunteer is denied" do
+    sign_in @target
+
+    bulk_add(duration: 15, user: @target)
+    assert_equal 0, @target.volunteer_signups.count
+
+    patch bulk_update_capacity_conference_timeslots_path(@conference),
+          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601, max_volunteers: 5 }
+    assert_equal [ 1 ], @day1_slots.map { |slot| slot.reload.max_volunteers }.uniq
+  end
+
+  test "volunteer self-signup still cannot enter a full slot (over-cover is admin-only)" do
+    other = create_user("other@example.com", handle: "Other Vol")
+    VolunteerSignup.create!(user: other, timeslot: @day1_slots.first)   # full
+
+    signup = VolunteerSignup.new(user: @target, timeslot: @day1_slots.first)
+    assert_not signup.valid?
+    assert_match(/full/i, signup.errors.full_messages.to_sentence)
+  end
+end


### PR DESCRIPTION
Backend for the admin coverage board (#243) — manage runs of slots instead of single 15-minute cells. No UI in this PR; independent of the coverage views in #247 (branches from main cleanly either way).

Three collection actions on `TimeslotsController`, all gated by the existing `ConferenceProgramPolicy#update?` chokepoint (conference managers + that activity's lead, #185), using the same window contract as the volunteer `bulk_create` (`start_timeslot_id` + `duration_minutes`):

- **`bulk_add_volunteer`** — one user across a whole window, transactional: one invalid slot rolls back the window; idempotent over slots they're already on. **Admin placements may over-cover** (settled decision: admins place anyone anywhere) via a new `VolunteerSignup#allow_over_capacity` virtual attribute that bypasses *only* the fullness validation — overlap and qualification rules still bind everyone, and volunteer self-signup never sets the flag, so holes-only self-service is unchanged (regression-tested).
- **`bulk_remove_volunteer`** — removes a user from the window's slots.
- **`bulk_update_capacity`** — sets needed (`max_volunteers`) for every slot of one activity on one date — one value per day (settled decision), minimum 1.

Counter caches stay correct via the existing signup callbacks; flash messages use Display Names (#219); `redirect_back` so both the future board and the legacy schedule work as callers.

## Testing
12 controller tests (TDD): window math + counters, idempotent re-add, admin over-cover, whole-window rollback on an overlap failure, qualification enforcement, windowed removal, day-scoped capacity isolation (other days/activities untouched), minimum capacity, and the Pundit matrix (village admin ✓ / this activity's lead ✓ / other activity's lead ✗ / volunteer ✗) plus the volunteer fullness regression guard.

Full suite: 941 runs, 0 failures; rubocop clean.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)