### PR TITLE
Schedule redesign: admin coverage board + manage panel (part 5 of #211)

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -45,6 +45,7 @@ class ScheduleController < ApplicationController
     @days = (@conference.start_date..@conference.end_date).to_a
     @day = resolve_day
     @stack = CoverageProjection.stack(@conference, @day)
+    @can_manage_any = manageable_program_ids.any?
 
     @program_qualifications = build_program_qualifications
     @user_qualification_ids = build_user_qualification_ids
@@ -74,10 +75,87 @@ class ScheduleController < ApplicationController
     @my_shift_ranges = group_signups_into_ranges(day_signups)
   end
 
+  # Admin coverage board (#243): every manageable activity x every conference
+  # day at a glance, plus a manage panel (roster / add / remove / needed)
+  # wired to the #242 bulk endpoints. The panel opens via a plain Drive
+  # navigation (?manage=cp_id&day=) and closes via a link that drops the
+  # params — no Turbo Frames (see #241's chromedriver finding), no new JS.
+  def board
+    authorize @conference, :show?, policy_class: ConferencePolicy
+
+    @manageable_program_ids = manageable_program_ids
+    if @manageable_program_ids.empty?
+      redirect_to conference_schedule_coverage_path(@conference),
+                  alert: "You don't manage any activities at this conference."
+      return
+    end
+
+    @days = (@conference.start_date..@conference.end_date).to_a
+
+    # Rows: manageable activities x days, each cell a projection (or nil when
+    # not scheduled that day). Built from the same bounded per-day loads the
+    # volunteer stack uses.
+    per_day = @days.index_with { |day| CoverageProjection.stack(@conference, day) }
+    row_cps = per_day.values.flatten.map { |entry| entry[:conference_program] }.uniq
+                     .select { |cp| @manageable_program_ids.include?(cp.program_id) }
+                     .sort_by { |cp| cp.program.name }
+    @rows = row_cps.map do |cp|
+      cells = @days.index_with do |day|
+        per_day[day].find { |entry| entry[:conference_program].id == cp.id }&.fetch(:projection)
+      end
+      { conference_program: cp, cells: cells }
+    end
+
+    # The ribbon partial is shared with the volunteer view; the board renders
+    # it read-only, so there are no "mine" markers to compute.
+    @my_timeslot_ids = Set.new
+
+    load_manage_panel if params[:manage].present?
+  end
+
   private
 
   def set_conference
     @conference = Conference.find(params[:conference_id])
+  end
+
+  # Manage-panel data for one activity+day. Denies activity leads reaching for
+  # an activity that isn't theirs (same chokepoint as the #242 endpoints).
+  def load_manage_panel
+    @manage_cp = @conference.conference_programs.find(params[:manage])
+    authorize @manage_cp, :update?, policy_class: ConferenceProgramPolicy
+
+    @manage_day = begin
+      day = Date.iso8601(params[:day].to_s)
+      (@conference.start_date..@conference.end_date).cover?(day) ? day : @days.first
+    rescue Date::Error
+      @days.first
+    end
+    @manage_projection = CoverageProjection.for(@manage_cp, @manage_day)
+    @manage_roster = manage_roster(@manage_cp, @manage_day)
+    @users = User.order(:handle)
+  end
+
+  # The day's signups for one activity, grouped into contiguous ranges per
+  # user: [{ user:, starts_at:, ends_at:, start_timeslot_id:, minutes: }]
+  def manage_roster(conference_program, day)
+    signups = VolunteerSignup.joins(:timeslot)
+                             .where(timeslots: { conference_program_id: conference_program.id })
+                             .where(timeslots: { start_time: day.in_time_zone.all_day })
+                             .includes(:user, :timeslot)
+                             .sort_by { |signup| signup.timeslot.start_time }
+
+    signups.group_by(&:user).flat_map do |user, user_signups|
+      user_signups.chunk_while { |a, b| a.timeslot.end_time == b.timeslot.start_time }.map do |run|
+        {
+          user: user,
+          starts_at: run.first.timeslot.start_time,
+          ends_at: run.last.timeslot.end_time,
+          start_timeslot_id: run.first.timeslot.id,
+          minutes: run.size * 15
+        }
+      end
+    end.sort_by { |range| [ range[:starts_at], range[:user].display_name ] }
   end
 
   # The selected day: ?day= if it falls inside the conference, else today

--- a/app/views/schedule/_manage_panel.html.erb
+++ b/app/views/schedule/_manage_panel.html.erb
@@ -1,0 +1,86 @@
+<%# Statically-shown offcanvas (#243): opened by a plain Drive navigation
+    (?manage=cp&day=), closed by a link that drops the params. No backdrop,
+    body scroll allowed — the board stays visible and clickable behind it. %>
+<div class="offcanvas offcanvas-end show manage-panel" tabindex="-1" style="visibility: visible;" aria-modal="false" role="dialog">
+  <div class="offcanvas-header border-bottom">
+    <div>
+      <h2 class="h5 mb-0"><%= @manage_cp.program.name %></h2>
+      <small class="text-muted"><%= @manage_day.strftime("%A, %B %-d") %></small>
+    </div>
+    <%= link_to "", conference_schedule_board_path(@conference), class: "btn-close", "aria-label": "Close" %>
+  </div>
+  <div class="offcanvas-body">
+    <%= render "coverage_ribbon", projection: @manage_projection, interactive: false %>
+
+    <%# Needed today: one value per day (settled decision) -> #242 capacity path %>
+    <%= form_with url: bulk_update_capacity_conference_timeslots_path(@conference), method: :patch, data: { turbo: false }, class: "mt-3" do %>
+      <input type="hidden" name="conference_program_id" value="<%= @manage_cp.id %>">
+      <input type="hidden" name="date" value="<%= @manage_day.iso8601 %>">
+      <label class="form-label mb-1" for="manage-needed">Needed today</label>
+      <div class="input-group input-group-sm" style="max-width: 12rem;">
+        <input type="number" id="manage-needed" name="max_volunteers" min="1" class="form-control"
+               value="<%= @manage_projection.ticks.map { |tick| tick[:needed] }.max || 1 %>">
+        <button type="submit" class="btn btn-outline-primary">Save</button>
+      </div>
+    <% end %>
+
+    <hr>
+
+    <h3 class="h6">On the schedule</h3>
+    <% if @manage_roster.empty? %>
+      <p class="text-muted small">No one is signed up yet.</p>
+    <% else %>
+      <ul class="list-group list-group-flush mb-3">
+        <% @manage_roster.each do |range| %>
+          <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+            <div>
+              <div><%= display_name_with_callsign(range[:user]) %></div>
+              <small class="text-muted">
+                <%= range[:starts_at].strftime("%-l:%M %p") %> – <%= range[:ends_at].strftime("%-l:%M %p") %>
+              </small>
+            </div>
+            <%# Turbo-driven (not turbo:false) so data-turbo-confirm works. %>
+            <%= form_with url: bulk_remove_volunteer_conference_timeslots_path(@conference), method: :delete do %>
+              <input type="hidden" name="conference_program_id" value="<%= @manage_cp.id %>">
+              <input type="hidden" name="user_id" value="<%= range[:user].id %>">
+              <input type="hidden" name="start_timeslot_id" value="<%= range[:start_timeslot_id] %>">
+              <input type="hidden" name="duration_minutes" value="<%= range[:minutes] %>">
+              <button type="submit" class="btn btn-sm btn-outline-danger"
+                      data-turbo-confirm="Remove <%= range[:user].display_name %> from this window?">Remove</button>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <hr>
+
+    <h3 class="h6">Add a volunteer</h3>
+    <%= form_with url: bulk_add_volunteer_conference_timeslots_path(@conference), method: :post, data: { turbo: false } do %>
+      <input type="hidden" name="conference_program_id" value="<%= @manage_cp.id %>">
+      <div class="mb-2">
+        <label class="form-label small mb-0" for="manage-add-user">Who</label>
+        <%= select_tag :user_id,
+            options_for_select(@users.map { |user| [ display_name_with_callsign(user), user.id ] }),
+            id: "manage-add-user", class: "form-select form-select-sm" %>
+      </div>
+      <div class="row g-2 mb-2">
+        <div class="col">
+          <label class="form-label small mb-0" for="manage-add-start">From</label>
+          <%= select_tag :start_timeslot_id,
+              options_for_select(@manage_projection.ticks.map { |tick| [ tick[:start].strftime("%-l:%M %p"), tick[:timeslot_id] ] }),
+              id: "manage-add-start", class: "form-select form-select-sm" %>
+        </div>
+        <div class="col">
+          <label class="form-label small mb-0" for="manage-add-duration">For</label>
+          <%= select_tag :duration_minutes,
+              options_for_select([ [ "15m", 15 ], [ "30m", 30 ], [ "45m", 45 ], [ "1h", 60 ], [ "1.5h", 90 ],
+                                   [ "2h", 120 ], [ "3h", 180 ], [ "4h", 240 ] ], 60),
+              id: "manage-add-duration", class: "form-select form-select-sm" %>
+        </div>
+      </div>
+      <button type="submit" class="btn btn-primary btn-sm w-100">Add to schedule</button>
+      <p class="text-muted small mt-1 mb-0">Admin placements can exceed the needed count; overlap and qualification rules still apply.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schedule/board.html.erb
+++ b/app/views/schedule/board.html.erb
@@ -1,0 +1,56 @@
+<div class="container-fluid mt-4" style="max-width: 1440px;">
+  <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+    <h1 class="mb-0"><%= @conference.name %> - Coverage Board</h1>
+    <div class="d-flex gap-2">
+      <%= link_to "Coverage view", conference_schedule_coverage_path(@conference), class: "btn btn-outline-secondary btn-sm" %>
+      <%= link_to "Grid view", conference_schedule_path(@conference), class: "btn btn-outline-secondary btn-sm" %>
+    </div>
+  </div>
+  <p class="text-muted">Is every activity covered every day? Click a day to manage it.</p>
+
+  <div class="table-responsive">
+    <table class="table align-middle">
+      <thead class="table-light">
+        <tr>
+          <th>Activity</th>
+          <% @days.each do |day| %>
+            <th class="text-center"><%= day.strftime("%a %-m/%-d") %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% @rows.each do |row| %>
+          <tr class="board-row">
+            <th scope="row"><%= row[:conference_program].program.name %></th>
+            <% @days.each do |day| %>
+              <% projection = row[:cells][day] %>
+              <td class="board-cell text-center" style="min-width: 9rem;">
+                <% if projection %>
+                  <%
+                    state_badge = { bare: [ "text-bg-danger", "Bare" ], short: [ "text-bg-warning", "Short" ],
+                                    covered: [ "text-bg-success", "Covered" ] }[projection.worst_state]
+                  %>
+                  <%= link_to conference_schedule_board_path(@conference, manage: row[:conference_program].id, day: day.iso8601),
+                      class: "text-decoration-none d-block" do %>
+                    <span class="badge <%= state_badge[0] %> mb-1"><%= state_badge[1] %></span>
+                    <div class="coverage-ribbon">
+                      <% projection.ticks.each do |tick| %>
+                        <span class="tick <%= tick[:state] %>"></span>
+                      <% end %>
+                    </div>
+                  <% end %>
+                <% else %>
+                  <span class="text-muted small">Not scheduled</span>
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <% if @manage_cp %>
+    <%= render "manage_panel" %>
+  <% end %>
+</div>

--- a/app/views/schedule/coverage.html.erb
+++ b/app/views/schedule/coverage.html.erb
@@ -1,7 +1,12 @@
 <div class="container-fluid mt-4" style="max-width: 1440px;">
   <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
     <h1 class="mb-0"><%= @conference.name %> - Coverage</h1>
-    <%= link_to "Grid view", conference_schedule_path(@conference), class: "btn btn-outline-secondary btn-sm" %>
+    <div class="d-flex gap-2">
+      <% if @can_manage_any %>
+        <%= link_to "Coverage board", conference_schedule_board_path(@conference), class: "btn btn-outline-primary btn-sm" %>
+      <% end %>
+      <%= link_to "Grid view", conference_schedule_path(@conference), class: "btn btn-outline-secondary btn-sm" %>
+    </div>
   </div>
 
   <%# Day/filter links are plain Turbo Drive navigations, NOT a Turbo Frame.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
     resources :conference_roles, only: [ :create, :destroy ]
     get "schedule", to: "schedule#show", as: :schedule
     get "schedule/coverage", to: "schedule#coverage", as: :schedule_coverage
+    get "schedule/board", to: "schedule#board", as: :schedule_board
     get "leaderboard", to: "leaderboard#conference", as: :leaderboard
     resources :volunteer_signups, only: [ :index, :create, :destroy ] do
       collection do

--- a/test/controllers/schedule_board_test.rb
+++ b/test/controllers/schedule_board_test.rb
@@ -1,0 +1,136 @@
+require "test_helper"
+
+# Admin coverage board (#243): every manageable activity x every conference
+# day at a glance, with a manage panel (roster / add / remove / needed) wired
+# to the #242 bulk endpoints.
+class ScheduleBoardTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+    @day1 = @conference.start_date
+    @exams = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Ham Exams", village: @village),
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" },
+        "1" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+    @desk = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+    @desk.timeslots.each { |slot| slot.update_column(:current_volunteers_count, 1) }
+
+    @admin = create_user("admin@example.com", handle: "Admin")
+    UserRole.create!(user: @admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+    @volunteer = create_user("volunteer@example.com", handle: "Radio Ray")
+    @volunteer.update!(callsign: "W1AW")
+  end
+
+  def create_user(email, handle:)
+    User.create!(email: email, password: "password123", password_confirmation: "password123", handle: handle)
+  end
+
+  test "board shows a row per activity and a cell per day with coverage states" do
+    sign_in @admin
+    get conference_schedule_board_path(@conference)
+
+    assert_response :success
+    assert_select ".board-row", 2
+    assert_select ".board-row", text: /Ham Exams/
+    assert_select ".board-row", text: /Front Desk/
+    # Ham Exams: scheduled both days, bare both days. Front Desk: day 1 covered, day 2 not scheduled.
+    assert_select ".board-cell .badge.text-bg-danger", 2
+    assert_select ".board-cell .badge.text-bg-success", 1
+    assert_match(/not scheduled/i, response.body)
+  end
+
+  test "each scheduled cell links to the manage panel for that activity and day" do
+    sign_in @admin
+    get conference_schedule_board_path(@conference)
+
+    assert_select ".board-cell a[href=?]",
+                  conference_schedule_board_path(@conference, manage: @exams.id, day: @day1.iso8601)
+  end
+
+  test "an activity lead sees only their activity's row" do
+    lead = create_user("lead@example.com", handle: "Lead")
+    ConferenceProgramRole.create!(user: lead, conference_program: @exams, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in lead
+
+    get conference_schedule_board_path(@conference)
+
+    assert_response :success
+    assert_select ".board-row", 1
+    assert_select ".board-row", text: /Ham Exams/
+  end
+
+  test "a plain volunteer is turned away" do
+    sign_in @volunteer
+    get conference_schedule_board_path(@conference)
+
+    assert_response :redirect
+  end
+
+  test "the manage panel shows the roster as display names with ranged remove buttons" do
+    slots = @exams.timeslots.where(start_time: @day1.in_time_zone.all_day).order(:start_time).to_a
+    slots.first(3).each { |slot| VolunteerSignup.create!(user: @volunteer, timeslot: slot) }
+
+    sign_in @admin
+    get conference_schedule_board_path(@conference, manage: @exams.id, day: @day1.iso8601)
+
+    assert_select ".manage-panel", text: /Radio Ray \(W1AW\)/
+    assert_select ".manage-panel", text: /9:00 AM\s*–\s*9:45 AM/
+    # Remove form posts the exact window of the range.
+    assert_select ".manage-panel form input[name='start_timeslot_id'][value='#{slots.first.id}']"
+    assert_select ".manage-panel form input[name='duration_minutes'][value='45']"
+    refute_match @volunteer.email, css_select(".manage-panel").first.to_s
+  end
+
+  test "the manage panel's add form lists users by display name and offers the day's start times" do
+    sign_in @admin
+    get conference_schedule_board_path(@conference, manage: @exams.id, day: @day1.iso8601)
+
+    assert_select ".manage-panel form[action=?]", bulk_add_volunteer_conference_timeslots_path(@conference)
+    assert_select ".manage-panel select[name='user_id'] option", text: "Radio Ray (W1AW)"
+    first_slot = @exams.timeslots.where(start_time: @day1.in_time_zone.all_day).order(:start_time).first
+    assert_select ".manage-panel select[name='start_timeslot_id'] option[value='#{first_slot.id}']", text: /9:00 AM/
+  end
+
+  test "the manage panel carries the needed-today editor with the current value" do
+    sign_in @admin
+    get conference_schedule_board_path(@conference, manage: @exams.id, day: @day1.iso8601)
+
+    assert_select ".manage-panel form[action=?]", bulk_update_capacity_conference_timeslots_path(@conference)
+    assert_select ".manage-panel input[name='max_volunteers'][value='1']"
+  end
+
+  test "an activity lead cannot open the manage panel for someone else's activity" do
+    lead = create_user("lead@example.com", handle: "Lead")
+    ConferenceProgramRole.create!(user: lead, conference_program: @exams, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in lead
+
+    get conference_schedule_board_path(@conference, manage: @desk.id, day: @day1.iso8601)
+
+    assert_response :redirect
+  end
+
+  test "managers get a board link on the coverage view; volunteers do not" do
+    sign_in @admin
+    get conference_schedule_coverage_path(@conference)
+    assert_select "a[href=?]", conference_schedule_board_path(@conference)
+
+    sign_in @volunteer
+    get conference_schedule_coverage_path(@conference)
+    assert_select "a[href=?]", conference_schedule_board_path(@conference), count: 0
+  end
+end

--- a/test/system/schedule_board_test.rb
+++ b/test/system/schedule_board_test.rb
@@ -1,0 +1,82 @@
+require "application_system_test_case"
+
+# Admin coverage board end-to-end (#243): open a day's manage panel, set
+# needed, add and remove a volunteer over a window.
+class ScheduleBoardSystemTest < ApplicationSystemTestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+    @cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Ham Exams", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" } }
+    )
+    @admin = User.create!(email: "admin@example.com", password: "password123",
+                          password_confirmation: "password123", handle: "Admin")
+    UserRole.create!(user: @admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+    @volunteer = User.create!(email: "ray@example.com", password: "password123",
+                              password_confirmation: "password123", handle: "Radio Ray", callsign: "W1AW")
+  end
+
+  def login_as(user)
+    visit new_user_session_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    click_button "Log in"
+    assert_text "Logout"
+  end
+
+  test "managing a day from the board: needed, add, remove" do
+    login_as @admin
+    visit conference_schedule_board_path(@conference)
+    assert_selector ".board-row", count: 1
+
+    # Open the day's manage panel.
+    first(".board-cell a").click
+    assert_selector ".manage-panel", text: "Ham Exams"
+
+    # Raise needed to 2 for the day.
+    fill_in "Needed today", with: 2
+    click_button "Save"
+    assert_text "Needed set to 2 for 8 slots"
+
+    # Add Radio Ray 9:00-10:00.
+    within ".manage-panel" do
+      select "Radio Ray (W1AW)", from: "Who"
+      select "9:00 AM", from: "From"
+      select "1h", from: "For"
+      click_button "Add to schedule"
+    end
+    assert_text "Radio Ray (W1AW) added 9:00 AM – 10:00 AM"
+    within ".manage-panel" do
+      assert_text "Radio Ray (W1AW)"
+      assert_text(/9:00 AM\s*–\s*10:00 AM/)
+    end
+
+    # Remove the window again.
+    within ".manage-panel" do
+      accept_confirm { click_button "Remove" }
+    end
+    assert_text "Radio Ray (W1AW) removed from 4 slots"
+    within ".manage-panel" do
+      assert_text "No one is signed up yet"
+    end
+  end
+
+  test "board reflects coverage states after management" do
+    @cp.timeslots.each { |slot| slot.update_column(:current_volunteers_count, 1) }
+
+    login_as @admin
+    visit conference_schedule_board_path(@conference)
+
+    assert_selector ".board-cell .badge.text-bg-success", count: 1
+    assert_selector ".board-cell .tick.covered", count: 8
+  end
+end


### PR DESCRIPTION
The admin half of the schedule redesign (#211), built on the CoverageProjection read model (#247) and the bulk write endpoints (#248).

**`/conferences/:id/schedule/board`** — "is every activity covered every day?" at a glance: one row per manageable activity, one cell per conference day showing a worst-state badge (Bare/Short/Covered) over a mini coverage ribbon, or "Not scheduled". Linked as **Coverage board** from the volunteer coverage view (managers only).

**Clicking a day opens the manage panel** for that activity+day — a statically-shown Bootstrap offcanvas (no backdrop, body scroll on) opened by a plain Drive navigation (`?manage=cp&day=`) and closed by a link that drops the params. No Turbo Frames (per the chromedriver finding documented in #247) and **zero new JavaScript**. It wires the #242 endpoints:

- **Needed today** — the one-value-per-day capacity editor (settled decision) → `bulk_update_capacity`
- **Roster** grouped into contiguous ranges per volunteer, shown as Display Name (callsign) — never emails — each with a windowed, turbo-confirmed **Remove** → `bulk_remove_volunteer`
- **Add a volunteer** over a window (who / from / for), user picker in display names → `bulk_add_volunteer` (admin placements may over-cover; overlap + qualification rules still apply)

**Scoping:** conference managers see every activity; an activity lead (#185) sees only their own row and cannot open another activity's panel (same `ConferenceProgramPolicy#update?` chokepoint as the endpoints); plain volunteers are redirected away.

## Testing
- 9 controller tests: rows/cells/states, cell links, lead scoping, volunteer turned away, roster display names + windowed remove params, add-form contents, needed editor, cross-activity lead denial, board-link visibility
- 2 system tests: the full manage flow end-to-end (raise needed → add a window → remove it) and board state rendering
- Full suite: 983 runs, 0 failures; system suite 53 runs, 0 failures (run twice locally on Chrome 150); rubocop clean

With this, parts 1–5 of the epic are complete; #244 (retire the legacy grid) remains gated on real-world use of the new views.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)