### PR TITLE
Fix Cover button end time rendering in the browser's time zone

### DIFF
--- a/app/javascript/controllers/coverage_ribbon_controller.js
+++ b/app/javascript/controllers/coverage_ribbon_controller.js
@@ -73,22 +73,28 @@ export default class extends Controller {
     this.lengthOptionsTarget.querySelectorAll("button").forEach(button => {
       button.classList.toggle("active", Number(button.dataset.minutes) === minutes)
     })
-    this.highlightSelection(minutes)
+    const lastTick = this.highlightSelection(minutes)
 
-    const start = new Date(this.startTick.dataset.start)
-    const end = new Date(start.getTime() + minutes * 60000)
+    // Display times come exclusively from server-rendered labels (#250):
+    // formatting a Date client-side would use the BROWSER's time zone, which
+    // may differ from the conference's and skew the end time.
     this.submitButtonTarget.disabled = false
     this.submitButtonTarget.textContent =
-      `Cover ${this.startTick.dataset.label} – ${this.formatTime(end)}`
+      `Cover ${this.startTick.dataset.label} – ${lastTick.dataset.endLabel}`
   }
 
+  // Marks the selected ticks and returns the last one.
   highlightSelection(minutes) {
     const startIso = this.startTick.dataset.start
     const endMs = new Date(startIso).getTime() + minutes * 60000
+    let lastSelected = this.startTick
     this.ribbonTarget.querySelectorAll(".tick").forEach(tick => {
       const tickMs = new Date(tick.dataset.start).getTime()
-      tick.classList.toggle("selected", tick.dataset.start >= startIso && tickMs < endMs)
+      const selected = tick.dataset.start >= startIso && tickMs < endMs
+      tick.classList.toggle("selected", selected)
+      if (selected) lastSelected = tick
     })
+    return lastSelected
   }
 
   formatDuration(minutes) {
@@ -97,9 +103,5 @@ export default class extends Controller {
     if (hours === 0) return `${mins}m`
     if (mins === 0) return `${hours}h`
     return `${hours}h ${mins}m`
-  }
-
-  formatTime(date) {
-    return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
   }
 }

--- a/app/views/schedule/_coverage_ribbon.html.erb
+++ b/app/views/schedule/_coverage_ribbon.html.erb
@@ -12,6 +12,7 @@
           data-timeslot-id="<%= tick[:timeslot_id] %>"
           data-start="<%= tick[:start].iso8601 %>"
           data-label="<%= tick[:start].strftime("%-l:%M %p") %>"
+          data-end-label="<%= tick[:end].strftime("%-l:%M %p") %>"
           <% if interactive && tick[:on] < tick[:needed] %>
           data-action="click->coverage-ribbon#pickStart"
           role="button"

--- a/test/system/coverage_timezone_test.rb
+++ b/test/system/coverage_timezone_test.rb
@@ -1,0 +1,50 @@
+require "application_system_test_case"
+
+# Regression for #250: the Cover button's end label must be in the
+# conference's (server) time zone, not the browser's. We force the browser
+# into a far-away zone via CDP and assert the label still matches the
+# server-rendered tick labels around it.
+class CoverageTimezoneTest < ApplicationSystemTestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00",
+      minimum_shift_duration: 30
+    )
+    ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Ham Exams", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" } }
+    )
+    @volunteer = User.create!(email: "volunteer@example.com", password: "password123",
+                              password_confirmation: "password123", handle: "Vol One")
+  end
+
+  test "the Cover label's end time matches the server zone regardless of the browser zone" do
+    visit new_user_session_path
+    # Put the browser 10 hours away from the app's UTC clock.
+    page.driver.browser.execute_cdp("Emulation.setTimezoneOverride", timezoneId: "Pacific/Honolulu")
+
+    fill_in "Email", with: @volunteer.email
+    fill_in "Password", with: "password123"
+    click_button "Log in"
+    assert_text "Logout"
+
+    visit conference_schedule_coverage_path(@conference)
+    assert_selector "[data-coverage-ribbon-ready]"
+
+    first(".coverage-ribbon .tick.bare").click
+    within "[data-coverage-ribbon-target='lengthOptions']" do
+      find("button", text: "1h", exact_text: true).click
+    end
+
+    # 9:00 AM + 1h = 10:00 AM in the conference's zone — never 11:00 PM
+    # (Honolulu's rendering of 10:00 UTC).
+    assert_selector "button:not([disabled])", text: "Cover 9:00 AM – 10:00 AM"
+  end
+end


### PR DESCRIPTION
Bug found in manual testing of the coverage view (#240/#247): picking 11:00 AM + 1h showed **"Cover 11:00 AM – 8:00 AM"** in an EDT browser against the UTC app clock.

Everything on the page is server-rendered in the conference's zone except that one string — the claim's end label was computed client-side (`new Date(start + minutes)` + `toLocaleTimeString`), which formats in the **browser's** zone.

**Fix:** every tick now carries a server-formatted `data-end-label`; the ribbon controller reads the last selected tick's label instead of doing Date math for display. Client-side time formatting is deleted entirely, so the mismatch is structurally impossible.

**Regression test:** forces the browser into `Pacific/Honolulu` (−10) via CDP `Emulation.setTimezoneOverride` and asserts the Cover label matches the server-zone times — red against the old code, green now.

Full suite 983 runs / system 54 runs, 0 failures; rubocop clean.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)