### PR TITLE
Date-keyed schedules + per-conference time zones (#226, #252)

### DIFF
--- a/app/controllers/calendar_exports_controller.rb
+++ b/app/controllers/calendar_exports_controller.rb
@@ -2,6 +2,7 @@ require "icalendar"
 
 class CalendarExportsController < ApplicationController
   before_action :authenticate_user!
+  include ConferenceTimeZone
   before_action :set_conference
 
   def show
@@ -16,8 +17,11 @@ class CalendarExportsController < ApplicationController
       program = timeslot.conference_program.program
 
       calendar.event do |event|
-        event.dtstart = Icalendar::Values::DateTime.new(timeslot.start_time)
-        event.dtend = Icalendar::Values::DateTime.new(timeslot.end_time)
+        # Export in the conference's zone with an explicit TZID (#252) so
+        # subscribers' calendars show shifts at the event's local time.
+        tzid = @conference.tz.tzinfo.identifier
+        event.dtstart = Icalendar::Values::DateTime.new(timeslot.start_time.in_time_zone(@conference.tz), "tzid" => tzid)
+        event.dtend = Icalendar::Values::DateTime.new(timeslot.end_time.in_time_zone(@conference.tz), "tzid" => tzid)
         event.summary = "Volunteer: #{program.name}"
         event.description = "Volunteer shift for #{program.name} at #{@conference.name}"
         event.location = @conference.display_location

--- a/app/controllers/concerns/conference_time_zone.rb
+++ b/app/controllers/concerns/conference_time_zone.rb
@@ -1,0 +1,21 @@
+# Renders conference-scoped requests in the conference's time zone (#252):
+# every server-formatted time (schedule labels, flash messages, reports,
+# exports) comes out in conference-local wall clock. Client code never
+# formats times itself (#250), so this is the single display chokepoint.
+module ConferenceTimeZone
+  extend ActiveSupport::Concern
+
+  included do
+    around_action :use_conference_time_zone
+  end
+
+  private
+
+  def use_conference_time_zone(&block)
+    conference = @conference
+    conference ||= Conference.find_by(id: params[:conference_id]) if params[:conference_id]
+    return yield unless conference
+
+    Time.use_zone(conference.time_zone, &block)
+  end
+end

--- a/app/controllers/conference_dashboard_controller.rb
+++ b/app/controllers/conference_dashboard_controller.rb
@@ -1,5 +1,6 @@
 class ConferenceDashboardController < ApplicationController
   before_action :authenticate_user!
+  include ConferenceTimeZone
   before_action :set_conference
 
   def show

--- a/app/controllers/conference_reports_controller.rb
+++ b/app/controllers/conference_reports_controller.rb
@@ -2,6 +2,7 @@ require "csv"
 
 class ConferenceReportsController < ApplicationController
   before_action :authenticate_user!
+  include ConferenceTimeZone
   before_action :set_conference
   before_action :authorize_reports
 

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -135,6 +135,6 @@ class ConferencesController < ApplicationController
   end
 
   def conference_params
-    params.require(:conference).permit(:name, :country, :state, :city, :start_date, :end_date, :conference_hours_start, :conference_hours_end, :reminder_hours_before, :minimum_shift_duration)
+    params.require(:conference).permit(:name, :country, :state, :city, :time_zone, :start_date, :end_date, :conference_hours_start, :conference_hours_end, :reminder_hours_before, :minimum_shift_duration)
   end
 end

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -1,5 +1,6 @@
 class ScheduleController < ApplicationController
   before_action :authenticate_user!
+  include ConferenceTimeZone
   before_action :set_conference
 
   # The schedule IS the coverage view (#244): per-activity claim stack

--- a/app/controllers/timeslots_controller.rb
+++ b/app/controllers/timeslots_controller.rb
@@ -1,5 +1,6 @@
 class TimeslotsController < ApplicationController
   before_action :authenticate_user!
+  include ConferenceTimeZone
   before_action :set_conference
   before_action :set_conference_program
 

--- a/app/controllers/volunteer_signups_controller.rb
+++ b/app/controllers/volunteer_signups_controller.rb
@@ -1,5 +1,6 @@
 class VolunteerSignupsController < ApplicationController
   before_action :authenticate_user!
+  include ConferenceTimeZone
   before_action :set_conference
   before_action :set_timeslot, only: [ :create ]
   before_action :set_volunteer_signup, only: [ :destroy ]

--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -58,6 +58,15 @@ class VolunteerMailer < ApplicationMailer
     )
   end
 
+  # Render every shift email in the conference's time zone (#252) so the
+  # times volunteers read match the clock at the event. mail() renders the
+  # templates synchronously, so wrapping it wraps the views too.
+  def mail(**)
+    return super unless @conference
+
+    Time.use_zone(@conference.time_zone) { super }
+  end
+
   private
 
   def group_signups_by_program(signups)

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -12,6 +12,8 @@ class Conference < ApplicationRecord
   validates :name, presence: true
   validates :start_date, presence: true
   validates :end_date, presence: true
+  # The zone all schedule wall-clock times are interpreted in (#252).
+  validates :time_zone, presence: true, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name), message: "is not a known time zone" }
   validate :end_date_after_start_date
 
   after_update :regenerate_timeslots_if_schedule_changed
@@ -136,6 +138,10 @@ class Conference < ApplicationRecord
     minimum_shift_duration || 15
   end
 
+  def tz
+    ActiveSupport::TimeZone[time_zone] || ActiveSupport::TimeZone["UTC"]
+  end
+
   private
 
   def end_date_after_start_date
@@ -146,13 +152,16 @@ class Conference < ApplicationRecord
 
   def regenerate_timeslots_if_schedule_changed
     return unless saved_change_to_start_date? || saved_change_to_end_date? ||
-                  saved_change_to_conference_hours_start? || saved_change_to_conference_hours_end?
+                  saved_change_to_conference_hours_start? || saved_change_to_conference_hours_end? ||
+                  saved_change_to_time_zone?
 
     # Reconcile timeslots for all conference programs. TimeslotGenerator keeps
-    # timeslots (and signups) whose start time still fits the new dates/hours
-    # instead of destroying and recreating everything (issue #225).
+    # timeslots (and signups) whose date + wall-clock identity survives
+    # (#225/#252): a pure zone change slides every slot's instant in place
+    # with no destruction and no notifications.
+    previous_zone = saved_change_to_time_zone? ? saved_change_to_time_zone.first : time_zone
     conference_programs.find_each do |cp|
-      TimeslotGenerator.new(cp).generate
+      TimeslotGenerator.new(cp, previous_time_zone: previous_zone).generate
     end
   end
 end

--- a/app/models/conference_program.rb
+++ b/app/models/conference_program.rb
@@ -26,12 +26,27 @@ class ConferenceProgram < ApplicationRecord
 
   after_create :generate_timeslots
   after_update :regenerate_timeslots_if_needed
+  before_validation :normalize_day_schedule_keys
 
   def day_schedules
     super || {}
   end
 
   private
+
+  # day_schedules are keyed by calendar date (ISO "YYYY-MM-DD") so a
+  # conference date change never re-assigns a day's hours to a different
+  # date (#226). Legacy positional index keys ("0", "1", ...) — old stored
+  # data, old callers, seeds — are converted here using the conference's
+  # current start_date at write time.
+  def normalize_day_schedule_keys
+    return if day_schedules.blank? || conference.nil?
+
+    normalized = day_schedules.transform_keys do |key|
+      key.to_s.match?(/\A\d+\z/) ? (conference.start_date + key.to_i).iso8601 : key.to_s
+    end
+    self.day_schedules = normalized if normalized != day_schedules
+  end
 
   def generate_timeslots
     TimeslotGenerator.new(self).generate

--- a/app/services/timeslot_generator.rb
+++ b/app/services/timeslot_generator.rb
@@ -26,8 +26,10 @@ class TimeslotGenerator
     return [] if @day_schedules.empty?
 
     start_times = []
-    (@conference.start_date..@conference.end_date).each_with_index do |date, day_index|
-      day_schedule = @day_schedules[day_index.to_s]
+    # day_schedules are keyed by calendar date (#226); dates outside the
+    # conference range are retained in the config but generate nothing.
+    (@conference.start_date..@conference.end_date).each do |date|
+      day_schedule = @day_schedules[date.iso8601]
       next unless day_schedule && day_schedule["enabled"] == true
 
       start_times.concat(start_times_for_day(date, day_schedule))

--- a/app/services/timeslot_generator.rb
+++ b/app/services/timeslot_generator.rb
@@ -1,40 +1,54 @@
 class TimeslotGenerator
-  def initialize(conference_program)
+  def initialize(conference_program, previous_time_zone: nil)
     @conference_program = conference_program
     @conference = conference_program.conference
     @day_schedules = conference_program.day_schedules
+    # The zone the EXISTING timeslots' wall clock was written in. Callers pass
+    # this when the conference's zone just changed (#252); defaults to the
+    # current zone, which makes reconciliation instant-equivalent otherwise.
+    @previous_time_zone = previous_time_zone.presence || @conference.time_zone
   end
 
   # Reconciles the conference program's timeslots against its current schedule.
   #
-  # Rather than destroying every timeslot and recreating from scratch (which
-  # would cascade-delete all volunteer signups), this keeps timeslots whose
-  # start time still exists in the schedule, creates any newly-scheduled slots,
-  # and removes only the slots that no longer belong. Volunteers signed up for a
-  # removed slot are notified that their shift was cancelled (issue #225).
+  # A slot's identity is its calendar date + wall-clock time in the
+  # conference's zone (#226/#252), not its absolute instant. So:
+  # - identity unchanged, instant unchanged -> untouched;
+  # - identity unchanged, instant moved (the conference's time zone changed)
+  #   -> the slot slides in place, keeping its id and volunteer signups, with
+  #   no notifications;
+  # - identity gone (day dropped, hours narrowed) -> destroyed, and its
+  #   volunteers are notified their shift was cancelled (issue #225);
+  # - new identity -> created.
   def generate
-    desired_start_times = compute_desired_start_times
-
-    remove_obsolete_timeslots(desired_start_times)
-    create_missing_timeslots(desired_start_times)
+    # use_zone so cancellation notifications (and any other formatting done
+    # during reconciliation) render times in the conference's zone.
+    Time.use_zone(@conference.tz) do
+      reconcile(compute_desired_slots)
+    end
   end
 
   private
 
-  # Every start time the current schedule calls for, as Time objects.
-  def compute_desired_start_times
-    return [] if @day_schedules.empty?
+  # { [iso_date, "HH:MM"] => Time } for every 15-minute tick the current
+  # schedule calls for, with instants computed in the conference's zone.
+  def compute_desired_slots
+    return {} if @day_schedules.empty?
 
-    start_times = []
-    # day_schedules are keyed by calendar date (#226); dates outside the
-    # conference range are retained in the config but generate nothing.
-    (@conference.start_date..@conference.end_date).each do |date|
-      day_schedule = @day_schedules[date.iso8601]
-      next unless day_schedule && day_schedule["enabled"] == true
+    Time.use_zone(@conference.tz) do
+      desired = {}
+      (@conference.start_date..@conference.end_date).each do |date|
+        # day_schedules are keyed by calendar date (#226); dates outside the
+        # conference range are retained in the config but generate nothing.
+        day_schedule = @day_schedules[date.iso8601]
+        next unless day_schedule && day_schedule["enabled"] == true
 
-      start_times.concat(start_times_for_day(date, day_schedule))
+        start_times_for_day(date, day_schedule).each do |time|
+          desired[[ date.iso8601, time.strftime("%H:%M") ]] = time
+        end
+      end
+      desired
     end
-    start_times
   end
 
   def start_times_for_day(date, day_schedule)
@@ -43,14 +57,11 @@ class TimeslotGenerator
 
     # Use day-specific times if provided, otherwise use conference defaults
     if start_time_str.nil? && @conference.conference_hours_start
-      # conference_hours_start is stored as a time, format it as HH:MM
-      time_obj = @conference.conference_hours_start
-      # For time columns, use strftime with UTC to avoid timezone issues
-      start_time_str = time_obj.utc.strftime("%H:%M")
+      # conference_hours_start is stored as a time column; format it as HH:MM
+      start_time_str = @conference.conference_hours_start.utc.strftime("%H:%M")
     end
     if end_time_str.nil? && @conference.conference_hours_end
-      time_obj = @conference.conference_hours_end
-      end_time_str = time_obj.utc.strftime("%H:%M")
+      end_time_str = @conference.conference_hours_end.utc.strftime("%H:%M")
     end
 
     return [] unless start_time_str && end_time_str
@@ -67,26 +78,28 @@ class TimeslotGenerator
     times
   end
 
-  # Remove timeslots that no longer belong to the schedule. Compare by epoch
-  # seconds so persisted (DB-loaded) and freshly-parsed times match regardless
-  # of adapter or timezone representation.
-  def remove_obsolete_timeslots(desired_start_times)
-    desired_keys = desired_start_times.map(&:to_i).to_set
+  def reconcile(desired)
+    remaining = desired.dup
+    previous_zone = ActiveSupport::TimeZone[@previous_time_zone] || @conference.tz
 
     @conference_program.timeslots.includes(volunteer_signups: :user).find_each do |timeslot|
-      next if desired_keys.include?(timeslot.start_time.to_i)
+      # The slot's identity, read back in the zone its wall clock was written in.
+      local = timeslot.start_time.in_time_zone(previous_zone)
+      key = [ local.to_date.iso8601, local.strftime("%H:%M") ]
+      new_start = remaining.delete(key)
 
-      notify_affected_volunteers(timeslot)
-      timeslot.destroy!
+      if new_start.nil?
+        notify_affected_volunteers(timeslot)
+        timeslot.destroy!
+      elsif timeslot.start_time.to_i != new_start.to_i
+        # Same wall-clock identity, new instant (zone change): slide in place.
+        # update_columns skips callbacks/validations — transient uniqueness
+        # collisions mid-slide are fine because the mapping is one-to-one.
+        timeslot.update_columns(start_time: new_start, end_time: new_start + 15.minutes)
+      end
     end
-  end
 
-  def create_missing_timeslots(desired_start_times)
-    existing_keys = @conference_program.timeslots.pluck(:start_time).map(&:to_i).to_set
-
-    desired_start_times.each do |start_time|
-      next if existing_keys.include?(start_time.to_i)
-
+    remaining.each_value do |start_time|
       Timeslot.create!(
         conference_program: @conference_program,
         start_time: start_time,

--- a/app/views/conference_programs/edit.html.erb
+++ b/app/views/conference_programs/edit.html.erb
@@ -44,26 +44,26 @@
               </p>
               <div id="day-schedules">
                 <% (@conference.start_date..@conference.end_date).each_with_index do |date, index| %>
-                  <% day_schedule = @conference_program.day_schedules[index.to_s] || {} %>
+                  <% day_schedule = @conference_program.day_schedules[date.iso8601] || {} %>
                   <% enabled = day_schedule["enabled"] == true || day_schedule["enabled"] == "1" %>
                   <div class="card mb-2">
                     <div class="card-body">
                       <div class="form-check mb-2">
-                        <%= check_box_tag "conference_program[day_schedules][#{index}][enabled]", "1", enabled, 
+                        <%= check_box_tag "conference_program[day_schedules][#{date.iso8601}][enabled]", "1", enabled, 
                             class: "form-check-input day-enabled", id: "day_#{index}_enabled",
                             data: { day: index } %>
                         <%= label_tag "day_#{index}_enabled", "Day #{index + 1}: #{date.strftime('%A, %B %d')}", class: "form-check-label fw-bold" %>
                       </div>
                       <div class="row day-schedule-fields" style="display: <%= enabled ? 'block' : 'none' %>;">
                         <div class="col-md-6">
-                          <%= label_tag "conference_program[day_schedules][#{index}][start]", "Start Time", class: "form-label" %>
-                          <%= time_field_tag "conference_program[day_schedules][#{index}][start]", 
+                          <%= label_tag "conference_program[day_schedules][#{date.iso8601}][start]", "Start Time", class: "form-label" %>
+                          <%= time_field_tag "conference_program[day_schedules][#{date.iso8601}][start]", 
                               day_schedule["start"] || @conference.conference_hours_start&.strftime("%H:%M"), 
                               class: "form-control" %>
                         </div>
                         <div class="col-md-6">
-                          <%= label_tag "conference_program[day_schedules][#{index}][end]", "End Time", class: "form-label" %>
-                          <%= time_field_tag "conference_program[day_schedules][#{index}][end]", 
+                          <%= label_tag "conference_program[day_schedules][#{date.iso8601}][end]", "End Time", class: "form-label" %>
+                          <%= time_field_tag "conference_program[day_schedules][#{date.iso8601}][end]", 
                               day_schedule["end"] || @conference.conference_hours_end&.strftime("%H:%M"), 
                               class: "form-control" %>
                         </div>

--- a/app/views/conference_programs/new.html.erb
+++ b/app/views/conference_programs/new.html.erb
@@ -54,21 +54,21 @@
                   <div class="card mb-2">
                     <div class="card-body">
                       <div class="form-check mb-2">
-                        <%= check_box_tag "conference_program[day_schedules][#{index}][enabled]", "1", false, 
+                        <%= check_box_tag "conference_program[day_schedules][#{date.iso8601}][enabled]", "1", false, 
                             class: "form-check-input day-enabled", id: "day_#{index}_enabled",
                             data: { day: index } %>
                         <%= label_tag "day_#{index}_enabled", "Day #{index + 1}: #{date.strftime('%A, %B %d')}", class: "form-check-label fw-bold" %>
                       </div>
                       <div class="row day-schedule-fields" style="display: none;">
                         <div class="col-md-6">
-                          <%= label_tag "conference_program[day_schedules][#{index}][start]", "Start Time", class: "form-label" %>
-                          <%= time_field_tag "conference_program[day_schedules][#{index}][start]", 
+                          <%= label_tag "conference_program[day_schedules][#{date.iso8601}][start]", "Start Time", class: "form-label" %>
+                          <%= time_field_tag "conference_program[day_schedules][#{date.iso8601}][start]", 
                               @conference.conference_hours_start&.strftime("%H:%M"), 
                               class: "form-control" %>
                         </div>
                         <div class="col-md-6">
-                          <%= label_tag "conference_program[day_schedules][#{index}][end]", "End Time", class: "form-label" %>
-                          <%= time_field_tag "conference_program[day_schedules][#{index}][end]", 
+                          <%= label_tag "conference_program[day_schedules][#{date.iso8601}][end]", "End Time", class: "form-label" %>
+                          <%= time_field_tag "conference_program[day_schedules][#{date.iso8601}][end]", 
                               @conference.conference_hours_end&.strftime("%H:%M"), 
                               class: "form-control" %>
                         </div>

--- a/app/views/conferences/edit.html.erb
+++ b/app/views/conferences/edit.html.erb
@@ -36,6 +36,12 @@
               </div>
             </div>
 
+            <div class="mb-3">
+              <%= form.label :time_zone, "Time Zone", class: "form-label" %>
+              <%= form.time_zone_select :time_zone, ActiveSupport::TimeZone.us_zones, {}, { class: "form-select" } %>
+              <div class="form-text">All schedule times, reminders, and calendar exports use this zone.</div>
+            </div>
+
             <div class="row">
               <div class="col-md-6 mb-3">
                 <%= form.label :conference_hours_start, "Conference Hours Start", class: "form-label" %>

--- a/app/views/conferences/new.html.erb
+++ b/app/views/conferences/new.html.erb
@@ -36,6 +36,12 @@
               </div>
             </div>
 
+            <div class="mb-3">
+              <%= form.label :time_zone, "Time Zone", class: "form-label" %>
+              <%= form.time_zone_select :time_zone, ActiveSupport::TimeZone.us_zones, {}, { class: "form-select" } %>
+              <div class="form-text">All schedule times, reminders, and calendar exports use this zone.</div>
+            </div>
+
             <div class="row">
               <div class="col-md-6 mb-3">
                 <%= form.label :conference_hours_start, "Conference Hours Start", class: "form-label" %>

--- a/db/migrate/20260720042923_convert_day_schedule_keys_to_dates.rb
+++ b/db/migrate/20260720042923_convert_day_schedule_keys_to_dates.rb
@@ -1,0 +1,40 @@
+class ConvertDayScheduleKeysToDates < ActiveRecord::Migration[8.1]
+  # day_schedules were keyed by positional day index ("0", "1", ...) anchored
+  # at the conference start_date, so moving start_date silently re-assigned
+  # every day's hours to different dates (#226). Re-key by calendar date
+  # (ISO "YYYY-MM-DD") using each conference's start_date as of now.
+  #
+  # Data-only migration; raw SQL/JSON handling so it doesn't depend on model
+  # code. Idempotent: date-looking keys pass through untouched.
+  def up
+    say_with_time "re-keying conference_programs.day_schedules by calendar date" do
+      execute(<<~SQL.squish).each do |row|
+        SELECT cp.id, cp.day_schedules, c.start_date
+        FROM conference_programs cp
+        JOIN conferences c ON c.id = cp.conference_id
+        WHERE cp.day_schedules IS NOT NULL
+      SQL
+        schedules = row["day_schedules"].is_a?(String) ? JSON.parse(row["day_schedules"]) : row["day_schedules"]
+        next if schedules.blank?
+
+        start_date = row["start_date"].is_a?(String) ? Date.parse(row["start_date"]) : row["start_date"]
+        converted = schedules.transform_keys do |key|
+          key.to_s.match?(/\A\d+\z/) ? (start_date + key.to_i).iso8601 : key.to_s
+        end
+        next if converted == schedules
+
+        execute(<<~SQL.squish)
+          UPDATE conference_programs
+          SET day_schedules = #{connection.quote(converted.to_json)}
+          WHERE id = #{row['id'].to_i}
+        SQL
+      end
+    end
+  end
+
+  def down
+    # Irreversible in general (index keys are lossy relative to dates), and
+    # date keys are also understood by no prior code paths worth restoring.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260720043541_add_time_zone_to_conferences.rb
+++ b/db/migrate/20260720043541_add_time_zone_to_conferences.rb
@@ -1,0 +1,9 @@
+class AddTimeZoneToConferences < ActiveRecord::Migration[8.1]
+  # Backfilling "UTC" preserves current behavior exactly: every stored
+  # timeslot instant was generated as UTC wall clock, so no data moves at
+  # migrate time. Assigning a real zone afterward slides slots in place
+  # (see TimeslotGenerator, #252).
+  def change
+    add_column :conferences, :time_zone, :string, null: false, default: "UTC"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_20_042923) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_20_043541) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -94,6 +94,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_042923) do
     t.integer "reminder_hours_before"
     t.date "start_date"
     t.string "state"
+    t.string "time_zone", default: "UTC", null: false
     t.datetime "updated_at", null: false
     t.bigint "village_id", null: false
     t.index ["village_id"], name: "index_conferences_on_village_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_19_163926) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_20_042923) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/test/controllers/calendar_exports_controller_test.rb
+++ b/test/controllers/calendar_exports_controller_test.rb
@@ -114,4 +114,18 @@ class CalendarExportsControllerTest < ActionDispatch::IntegrationTest
     # Should have no events
     assert_equal 0, response.body.scan("BEGIN:VEVENT").count
   end
+  test "export uses the conference's TZID and local wall clock (#252)" do
+    @conference.update!(time_zone: "Pacific Time (US & Canada)")
+    # Regeneration on zone change slid the slots; re-find the user's slot.
+    slot = @conference.timeslots.order(:start_time).first
+    VolunteerSignup.find_or_create_by!(user: @user, timeslot: slot)
+
+    sign_in @user
+    get conference_calendar_export_url(@conference)
+
+    assert_response :success
+    assert_match "TZID=America/Los_Angeles", response.body
+    local = slot.start_time.in_time_zone("Pacific Time (US & Canada)").strftime("%Y%m%dT%H%M%S")
+    assert_match local, response.body
+  end
 end

--- a/test/controllers/schedule_coverage_test.rb
+++ b/test/controllers/schedule_coverage_test.rb
@@ -115,6 +115,17 @@ class ScheduleCoverageTest < ActionDispatch::IntegrationTest
     assert_select "[data-coverage-ribbon-cap-minutes-value='240']"
   end
 
+  test "labels render in the conference's time zone, not the server default (#252)" do
+    @conference.update!(time_zone: "Pacific Time (US & Canada)")
+
+    get conference_schedule_path(@conference)
+
+    assert_response :success
+    # 09:00 wall clock in PDT is 16:00 UTC; labels must still read 9:00 AM.
+    assert_match "9:00 AM", response.body
+    refute_match "4:00 PM", response.body
+  end
+
   test "requires authentication" do
     sign_out @volunteer
     get conference_schedule_path(@conference)

--- a/test/models/conference_program_test.rb
+++ b/test/models/conference_program_test.rb
@@ -73,7 +73,7 @@ class ConferenceProgramTest < ActiveSupport::TestCase
     assert_equal @program, cp.program
   end
 
-  test "should store day schedules in jsonb" do
+  test "should store day schedules keyed by calendar date, normalizing legacy index keys" do
     schedules = {
       "0" => { "enabled" => true, "start" => "09:00", "end" => "17:00" },
       "1" => { "enabled" => true, "start" => "10:00", "end" => "18:00" },
@@ -85,7 +85,12 @@ class ConferenceProgramTest < ActiveSupport::TestCase
       public_description: "Test",
       day_schedules: schedules
     )
-    assert_equal schedules, cp.day_schedules
+    expected = {
+      @conference.start_date.iso8601 => { "enabled" => true, "start" => "09:00", "end" => "17:00" },
+      (@conference.start_date + 1.day).iso8601 => { "enabled" => true, "start" => "10:00", "end" => "18:00" },
+      (@conference.start_date + 2.days).iso8601 => { "enabled" => false }
+    }
+    assert_equal expected, cp.day_schedules
   end
 
   test "day_schedules should default to empty hash" do

--- a/test/models/conference_time_zone_test.rb
+++ b/test/models/conference_time_zone_test.rb
@@ -1,0 +1,129 @@
+require "test_helper"
+
+# Per-conference time zones (#252). Wall-clock schedules are interpreted in
+# the conference's zone, and changing the zone on a live conference slides
+# every slot's instant while keeping ids, signups, and wall-clock times —
+# with zero cancellation notifications.
+class ConferenceTimeZoneTest < ActiveSupport::TestCase
+  PACIFIC = "Pacific Time (US & Canada)".freeze
+
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @day = Date.new(2026, 8, 5)   # summer: PDT (-07:00)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: @day,
+      end_date: @day + 1.day,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+    @program = Program.create!(name: "Ham Exams", village: @village)
+  end
+
+  def create_cp(conference = @conference)
+    ConferenceProgram.create!(
+      conference: conference,
+      program: @program,
+      day_schedules: { @day.iso8601 => { "enabled" => true, "start" => "09:00", "end" => "11:00" } }
+    )
+  end
+
+  test "time_zone defaults to UTC and validates against known zones" do
+    assert_equal "UTC", @conference.time_zone
+    assert_equal "Etc/UTC", @conference.tz.tzinfo.identifier
+
+    @conference.time_zone = "Not A Zone"
+    assert_not @conference.valid?
+    assert @conference.errors[:time_zone].any?
+  end
+
+  test "schedule wall times are interpreted in the conference's zone" do
+    @conference.update!(time_zone: PACIFIC)
+    cp = create_cp
+
+    first = cp.timeslots.order(:start_time).first
+    assert_equal "2026-08-05T09:00:00-07:00", first.start_time.in_time_zone(PACIFIC).iso8601
+    assert_equal "2026-08-05T16:00:00Z", first.start_time.utc.iso8601, "09:00 PDT is 16:00 UTC"
+  end
+
+  test "DST is honored per date" do
+    winter_day = Date.new(2026, 12, 5)
+    conference = Conference.create!(
+      village: @village, name: "Winter Conference", time_zone: PACIFIC,
+      start_date: winter_day, end_date: winter_day,
+      conference_hours_start: "09:00", conference_hours_end: "17:00"
+    )
+    cp = ConferenceProgram.create!(
+      conference: conference,
+      program: Program.create!(name: "Winter Program", village: @village),
+      day_schedules: { winter_day.iso8601 => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+
+    assert_equal "2026-12-05T17:00:00Z", cp.timeslots.order(:start_time).first.start_time.utc.iso8601,
+                 "09:00 PST (winter) is 17:00 UTC"
+  end
+
+  test "setting the zone on a live conference slides slots in place: ids, signups, wall clock all preserved, no notifications" do
+    cp = create_cp   # generated under UTC
+    volunteer = User.create!(email: "vol@example.com", password: "password123",
+                             password_confirmation: "password123", handle: "Vol One")
+    slots_before = cp.timeslots.order(:start_time).to_a
+    signup = VolunteerSignup.create!(user: volunteer, timeslot: slots_before[2])
+    utc_instants = slots_before.map { |slot| slot.start_time.utc.iso8601 }
+
+    assert_no_difference [ "Notification.count", "VolunteerSignup.count" ] do
+      @conference.update!(time_zone: PACIFIC)
+    end
+
+    slots_after = cp.timeslots.order(:start_time).to_a
+    assert_equal slots_before.map(&:id), slots_after.map(&:id), "same rows, slid in place"
+    assert VolunteerSignup.exists?(id: signup.id)
+    assert_equal [ "09:00" ] + [ nil ] * 0, [ slots_after.first.start_time.in_time_zone(PACIFIC).strftime("%H:%M") ],
+                 "wall clock preserved in the new zone"
+    assert_not_equal utc_instants, slots_after.map { |slot| slot.start_time.utc.iso8601 },
+                     "absolute instants shifted"
+    assert_equal 7 * 3600, slots_after.first.start_time.utc.to_i - Time.utc(2026, 8, 5, 9).to_i,
+                 "shifted by exactly the PDT offset"
+    assert_equal slots_after.first.start_time + 15.minutes, slots_after.first.end_time, "end_time slid too"
+  end
+
+  test "reminder windows key off the true instant in the conference's zone" do
+    @village.update!(email_enabled: true, mailgun_api_key: "test-key", mailgun_domain: "test.mailgun.org")
+    @conference.update!(time_zone: PACIFIC, reminder_hours_before: 24)
+    cp = create_cp
+    volunteer = User.create!(email: "vol@example.com", password: "password123",
+                             password_confirmation: "password123", handle: "Vol One")
+    slot = cp.timeslots.order(:start_time).first   # 2026-08-05 09:00 PDT = 16:00 UTC
+    signup = VolunteerSignup.create!(user: volunteer, timeslot: slot)
+
+    # 25h before the true instant: outside the 24h window — no reminder.
+    travel_to Time.utc(2026, 8, 4, 15, 0) do
+      ShiftReminderJob.perform_now
+      assert_nil signup.reload.reminder_sent_at
+    end
+
+    # Under UTC-wall-clock interpretation the shift would "start" at 09:00 UTC
+    # and a reminder would already have fired by 23:00 UTC the day before.
+    # With the zone honored, 23h before the real 16:00 UTC start is inside
+    # the window — the reminder fires exactly relative to the true instant.
+    travel_to Time.utc(2026, 8, 4, 17, 0) do
+      ShiftReminderJob.perform_now
+      assert_not_nil signup.reload.reminder_sent_at
+    end
+  end
+
+  test "changing between two non-UTC zones also slides in place" do
+    @conference.update!(time_zone: PACIFIC)
+    cp = create_cp
+    ids = cp.timeslots.order(:start_time).pluck(:id)
+
+    assert_no_difference "Notification.count" do
+      @conference.update!(time_zone: "Eastern Time (US & Canada)")
+    end
+
+    slots = cp.timeslots.order(:start_time).to_a
+    assert_equal ids, slots.map(&:id)
+    assert_equal "09:00", slots.first.start_time.in_time_zone("Eastern Time (US & Canada)").strftime("%H:%M")
+  end
+end

--- a/test/models/conference_timeslot_regeneration_test.rb
+++ b/test/models/conference_timeslot_regeneration_test.rb
@@ -26,17 +26,21 @@ class ConferenceTimeslotRegenerationTest < ActiveSupport::TestCase
     )
   end
 
-  test "should regenerate timeslots when conference start_date changes" do
+  test "start_date changes drop out-of-range days but never re-assign schedules (#226)" do
     initial_count = @conference_program.timeslots.count
     assert initial_count > 0
+    scheduled_date = @conference.start_date
 
-    new_start_date = @conference.start_date + 1.day
-    @conference.update!(start_date: new_start_date)
+    # Moving start past the scheduled date: its slots go away, but the
+    # schedule stays bound to its calendar date (retained in config)...
+    @conference.update!(start_date: scheduled_date + 1.day)
+    assert_equal 0, @conference_program.timeslots.count
+    assert @conference_program.reload.day_schedules.key?(scheduled_date.iso8601)
 
-    # Timeslots should be regenerated with new dates
+    # ...and comes back when the range covers that date again.
+    @conference.update!(start_date: scheduled_date)
     assert_equal initial_count, @conference_program.timeslots.count
-    first_timeslot = @conference_program.timeslots.order(:start_time).first
-    assert_equal new_start_date, first_timeslot.start_time.to_date
+    assert_equal scheduled_date, @conference_program.timeslots.order(:start_time).first.start_time.to_date
   end
 
   test "should regenerate timeslots when conference end_date changes" do

--- a/test/services/timeslot_realignment_test.rb
+++ b/test/services/timeslot_realignment_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+# #226: day_schedules are keyed by calendar date (ISO), not positional index,
+# so a start_date change never silently re-assigns a day's hours to a
+# different date — and volunteers signed up on surviving days keep their
+# shifts. Uses the repro from the ticket.
+class TimeslotRealignmentTest < ActiveSupport::TestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @day1 = Date.tomorrow
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: @day1,
+      end_date: @day1 + 2.days,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+    @program = Program.create!(name: "Ham Exams", village: @village)
+    # short / FULL / short — stored by calendar date.
+    @cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        @day1.iso8601 => { "enabled" => true, "start" => "09:00", "end" => "10:45" },
+        (@day1 + 1.day).iso8601 => { "enabled" => true, "start" => "09:00", "end" => "16:45" },
+        (@day1 + 2.days).iso8601 => { "enabled" => true, "start" => "09:00", "end" => "10:45" }
+      }
+    )
+    @volunteer = User.create!(email: "vol@example.com", password: "password123",
+                              password_confirmation: "password123", handle: "Vol One")
+  end
+
+  def slots_on(date)
+    @cp.timeslots.where(start_time: date.in_time_zone.all_day).order(:start_time)
+  end
+
+  test "schedules are generated per calendar date" do
+    assert_equal 7, slots_on(@day1).count           # 09:00-10:45
+    assert_equal 31, slots_on(@day1 + 1.day).count  # 09:00-16:45
+    assert_equal 7, slots_on(@day1 + 2.days).count
+  end
+
+  test "dropping the first day does not re-assign the full day's hours (the #226 repro)" do
+    full_day = @day1 + 1.day
+    thirteen_hundred = slots_on(full_day).find { |slot| slot.start_time.strftime("%H:%M") == "13:00" }
+    VolunteerSignup.create!(user: @volunteer, timeslot: thirteen_hundred)
+
+    @conference.update!(start_date: @day1 + 1.day)
+
+    assert_equal 0, slots_on(@day1).count, "dropped day's slots removed"
+    assert_equal 31, slots_on(full_day).count, "the full day KEEPS its full hours"
+    assert VolunteerSignup.exists?(user: @volunteer, timeslot: thirteen_hundred),
+           "the 13:00 signup on the surviving day survives"
+  end
+
+  test "dropping a day cancels (and notifies) only that day's signups" do
+    first_day_slot = slots_on(@day1).first
+    VolunteerSignup.create!(user: @volunteer, timeslot: first_day_slot)
+    survivor_slot = slots_on(@day1 + 1.day).first
+    VolunteerSignup.create!(user: @volunteer, timeslot: survivor_slot)
+
+    assert_difference "Notification.count", 1 do
+      @conference.update!(start_date: @day1 + 1.day)
+    end
+    assert_not VolunteerSignup.exists?(timeslot_id: first_day_slot.id)
+    assert VolunteerSignup.exists?(timeslot_id: survivor_slot.id)
+  end
+
+  test "extending the conference a day earlier changes nothing on existing days" do
+    signup = VolunteerSignup.create!(user: @volunteer, timeslot: slots_on(@day1).first)
+    before_ids = @cp.timeslots.order(:start_time).pluck(:id)
+
+    assert_no_difference "Notification.count" do
+      @conference.update!(start_date: @day1 - 1.day)
+    end
+
+    assert_equal before_ids, @cp.timeslots.order(:start_time).pluck(:id), "no slot churn at all"
+    assert VolunteerSignup.exists?(id: signup.id)
+    assert_equal 0, slots_on(@day1 - 1.day).count, "the new day starts unscheduled"
+  end
+
+  test "a schedule for a date outside the range is retained and comes back when the range returns" do
+    @conference.update!(end_date: @day1 + 1.day)   # drop the third day
+    assert_equal 0, slots_on(@day1 + 2.days).count
+    assert @cp.reload.day_schedules.key?((@day1 + 2.days).iso8601), "config retained"
+
+    @conference.update!(end_date: @day1 + 2.days)  # bring it back
+    assert_equal 7, slots_on(@day1 + 2.days).count, "slots regenerate from the retained config"
+  end
+
+  test "legacy positional index keys normalize to date keys on write" do
+    legacy = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Legacy Program", village: @village),
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "10:00", "end" => "11:00" },
+        "2" => { "enabled" => true, "start" => "12:00", "end" => "13:00" }
+      }
+    )
+
+    assert_equal [ @day1.iso8601, (@day1 + 2.days).iso8601 ], legacy.day_schedules.keys.sort
+    assert_equal 4, legacy.timeslots.where(start_time: @day1.in_time_zone.all_day).count
+  end
+end


### PR DESCRIPTION
Two deadlock-dependent tickets on one feature-named branch (per the Git Hygiene rules), one commit each. Built explicitly for **live-conference safety**: the app is in production with dozens of volunteers signed up, so both changes are designed so that existing data never moves unexpectedly and no signup is ever silently destroyed.

## Commit 1 — #226: `day_schedules` keyed by calendar date
The old positional-index keys ("0", "1"…) were anchored at `start_date`, so moving it silently re-assigned every day's hours to different dates — and the regeneration destroyed signups whose instants moved. Now:
- Keys are ISO dates; a data migration re-keys existing rows (verified against real dev data); legacy index keys still normalize on write so old callers/seeds/tests keep working.
- **The ticket's exact repro is the test**: drop the first day of a 3-day conference → only that day's slots go (with the #225 cancellation notice); every other day keeps its exact hours **and all of its signups**. Extending the conference produces zero slot churn.
- Out-of-range dates are retained in config and regenerate when the range covers them again.

## Commit 2 — #252: per-conference time zones
`conferences.time_zone` (NOT NULL, **backfilled "UTC"** = a by-construction no-op for stored instants), `time_zone_select` on the conference forms, and everything keys off it:
- **TimeslotGenerator identifies slots by date + wall-clock in the conference's zone.** Assigning or changing the zone on a scheduled conference **slides every slot's instant in place** — same rows, same ids, every signup intact, zero notifications (asserted UTC→PDT and PDT→EST, DST honored per date). This is the path the live conference will take when its real zone is set.
- Display: a `ConferenceTimeZone` around_action renders all conference-scoped controllers in the conference zone (the client never formats times itself per #250, so labels follow for free). Shift emails render in-zone via a `mail()` override.
- **Reminders needed zero logic changes** — the absolute-time window math becomes correct once instants are true; a travel_to regression test proves the old UTC interpretation would have fired hours off.
- iCal exports emit `TZID` (e.g. `America/Los_Angeles`) with local wall clock.

## Testing
- 6 realignment specs (the #226 repro, notification scoping, zero-churn extension, retained out-of-range config, legacy-key normalization)
- 6 zone specs (validation, PDT/PST instants, the live-conference slide ×2, reminder window)
- iCal TZID + conference-zone display controller tests
- Full suite: 966 runs, 0 failures; system 33 runs, 0 failures; rubocop clean; migrations exercised against real dev data

## Operator note for the live conference
After deploy: nothing changes until you set the conference's zone (it stays "UTC" = today's behavior). When you set the real zone in the conference edit form, all slots slide to their true instants with signups riding along — that's the moment reminders and calendar exports become correct.

Closes #226
Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)