### PR TITLE
Fix ConvertDayScheduleKeysToDates migration on MySQL/MariaDB

### DIFF
--- a/db/migrate/20260720042923_convert_day_schedule_keys_to_dates.rb
+++ b/db/migrate/20260720042923_convert_day_schedule_keys_to_dates.rb
@@ -8,7 +8,7 @@ class ConvertDayScheduleKeysToDates < ActiveRecord::Migration[8.1]
   # code. Idempotent: date-looking keys pass through untouched.
   def up
     say_with_time "re-keying conference_programs.day_schedules by calendar date" do
-      execute(<<~SQL.squish).each do |row|
+      select_all(<<~SQL.squish).each do |row|
         SELECT cp.id, cp.day_schedules, c.start_date
         FROM conference_programs cp
         JOIN conferences c ON c.id = cp.conference_id


### PR DESCRIPTION
## What

`db/migrate/20260720042923_convert_day_schedule_keys_to_dates.rb` used `execute(sql).each` and accessed result columns by name (`row["day_schedules"]`). That works on PostgreSQL (rows are hashes) but fails on MySQL/MariaDB, where result rows are positional arrays — raising `no implicit conversion of String into Integer` and blocking all migrations.

This swaps `execute` for `select_all`, which returns an adapter-agnostic `ActiveRecord::Result` whose `.each` yields string-keyed hashes on every adapter. The existing `row["..."]` access then works on both Postgres and MySQL/MariaDB. One-line change; behavior on Postgres is unchanged.

## Testing

- Ran `bin/rails db:migrate` on MariaDB: the migration now completes, re-keying `conference_programs.day_schedules` from positional day indices to ISO calendar dates as intended, and the subsequent `AddTimeZoneToConferences` migration applies.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)