### PR TITLE
Separate minimum and maximum shift coverage (#259)

### DIFF
--- a/app/assets/stylesheets/schedule.scss
+++ b/app/assets/stylesheets/schedule.scss
@@ -19,6 +19,8 @@
     &.bare { background: var(--bs-danger); }
     &.short { background: var(--bs-warning); }
     &.covered { background: var(--bs-success); }
+    // Over the minimum (#259): healthy surplus up to the signup cap.
+    &.surplus { background: var(--bs-primary); }
 
     // My own shifts: an info underline on top of whatever state color.
     &.mine { box-shadow: inset 0 -4px 0 var(--bs-info); }

--- a/app/controllers/conference_programs_controller.rb
+++ b/app/controllers/conference_programs_controller.rb
@@ -83,7 +83,7 @@ class ConferenceProgramsController < ApplicationController
   end
 
   def conference_program_params
-    params.require(:conference_program).permit(:program_id, :public_description, :max_volunteers)
+    params.require(:conference_program).permit(:program_id, :public_description, :min_volunteers, :max_volunteers)
   end
 
   def process_day_schedules

--- a/app/controllers/conference_reports_controller.rb
+++ b/app/controllers/conference_reports_controller.rb
@@ -22,10 +22,12 @@ class ConferenceReportsController < ApplicationController
     end
   end
 
+  # Under-covered = below the coverage target (min_volunteers, #259); slots
+  # between min and max are adequately staffed and not reported.
   def unmanned_shifts
     @timeslots = filtered_timeslots
                  .includes(conference_program: :program)
-                 .where("timeslots.current_volunteers_count < timeslots.max_volunteers")
+                 .where("timeslots.current_volunteers_count < timeslots.min_volunteers")
                  .order(:start_time)
 
     respond_to do |format|
@@ -84,7 +86,7 @@ class ConferenceReportsController < ApplicationController
 
   def send_unmanned_shifts_csv
     csv_data = CSV.generate(headers: true) do |csv|
-      csv << [ "Date", "Time", "Program", "Current Volunteers", "Max Volunteers", "Spots Available" ]
+      csv << [ "Date", "Time", "Program", "Current Volunteers", "Min Volunteers", "Max Volunteers", "Needed to Cover" ]
 
       @timeslots.each do |timeslot|
         csv << [
@@ -92,8 +94,9 @@ class ConferenceReportsController < ApplicationController
           "#{timeslot.start_time.strftime('%H:%M')} - #{timeslot.end_time.strftime('%H:%M')}",
           timeslot.conference_program.program.name,
           timeslot.current_volunteers_count,
+          timeslot.min_volunteers,
           timeslot.max_volunteers,
-          timeslot.max_volunteers - timeslot.current_volunteers_count
+          timeslot.min_volunteers - timeslot.current_volunteers_count
         ]
       end
     end

--- a/app/controllers/custom_programs_controller.rb
+++ b/app/controllers/custom_programs_controller.rb
@@ -60,6 +60,6 @@ class CustomProgramsController < ApplicationController
   end
 
   def program_params
-    params.require(:program).permit(:name, :description, :max_volunteers)
+    params.require(:program).permit(:name, :description, :min_volunteers, :max_volunteers)
   end
 end

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -64,6 +64,7 @@ class ProgramsController < ApplicationController
         {
           conference_program_id: cp.id,
           conference_name: cp.conference.name,
+          current_min_volunteers: cp.effective_min_volunteers,
           current_max_volunteers: cp.effective_max_volunteers,
           timeslots_count: timeslots_count,
           over_capacity_count: over_capacity_count,
@@ -78,10 +79,11 @@ class ProgramsController < ApplicationController
   def bulk_update_capacity
     authorize @program, :update?, policy_class: ProgramPolicy
     new_max_volunteers = params[:new_max_volunteers].to_i
+    new_min_volunteers = params[:new_min_volunteers].presence&.to_i
     conference_program_ids = params[:conference_program_ids] || []
 
     conference_program_ids.each do |cp_id|
-      UpdateTimeslotCapacityJob.perform_later(cp_id.to_i, new_max_volunteers)
+      UpdateTimeslotCapacityJob.perform_later(cp_id.to_i, new_max_volunteers, new_min_volunteers)
     end
 
     render json: {
@@ -102,6 +104,6 @@ class ProgramsController < ApplicationController
   end
 
   def program_params
-    params.require(:program).permit(:name, :description, :max_volunteers)
+    params.require(:program).permit(:name, :description, :min_volunteers, :max_volunteers)
   end
 end

--- a/app/controllers/timeslots_controller.rb
+++ b/app/controllers/timeslots_controller.rb
@@ -49,24 +49,30 @@ class TimeslotsController < ApplicationController
                   notice: "#{helpers.display_name_with_callsign(user)} removed from #{removed} slot#{'s' unless removed == 1}."
   end
 
-  # Set needed (max_volunteers) for every slot of the activity on one date —
-  # one value per day (settled decision).
+  # Set the coverage band (min needed / max cap, #259) for every slot of the
+  # activity on one date — one value pair per day (settled decision).
   def bulk_update_capacity
     authorize @conference_program, :update?, policy_class: ConferenceProgramPolicy
 
+    new_min = params[:min_volunteers].to_i
     new_max = params[:max_volunteers].to_i
-    if new_max < 1
+    if new_min < 1
       redirect_back fallback_location: conference_schedule_path(@conference),
                     alert: "Needed volunteers must be at least 1."
+      return
+    end
+    if new_max < new_min
+      redirect_back fallback_location: conference_schedule_path(@conference),
+                    alert: "Maximum volunteers must be at least the minimum."
       return
     end
 
     date = Date.iso8601(params[:date].to_s)
     updated = @conference_program.timeslots.where(start_time: date.in_time_zone.all_day)
-                                 .update_all(max_volunteers: new_max)
+                                 .update_all(min_volunteers: new_min, max_volunteers: new_max)
 
     redirect_back fallback_location: conference_schedule_path(@conference),
-                  notice: "Needed set to #{new_max} for #{updated} slot#{'s' unless updated == 1} on #{date.strftime('%A, %B %-d')}."
+                  notice: "Coverage set to #{new_min}–#{new_max} for #{updated} slot#{'s' unless updated == 1} on #{date.strftime('%A, %B %-d')}."
   rescue Date::Error
     redirect_back fallback_location: conference_schedule_path(@conference), alert: "Invalid date."
   end

--- a/app/javascript/controllers/bulk_capacity_update_controller.js
+++ b/app/javascript/controllers/bulk_capacity_update_controller.js
@@ -2,34 +2,41 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="bulk-capacity-update"
 export default class extends Controller {
-  static targets = ["maxVolunteers", "modal", "conferenceList", "selectAll", "submitBtn", "loading"]
+  static targets = ["minVolunteers", "maxVolunteers", "modal", "conferenceList", "selectAll", "submitBtn", "loading"]
   static values = {
     programId: Number,
     originalValue: Number,
+    originalMinValue: Number,
     affectedConferencesUrl: String,
     bulkUpdateUrl: String
   }
 
   connect() {
     this.originalValueValue = parseInt(this.maxVolunteersTarget.value) || 1
+    this.originalMinValueValue = this.currentMin()
+  }
+
+  currentMin() {
+    return this.hasMinVolunteersTarget ? (parseInt(this.minVolunteersTarget.value) || 1) : 1
   }
 
   async checkForChanges(event) {
-    const newValue = parseInt(this.maxVolunteersTarget.value)
+    const newMax = parseInt(this.maxVolunteersTarget.value)
+    const newMin = this.currentMin()
+    const changed = newMax !== this.originalValueValue || newMin !== this.originalMinValueValue
 
-    // If value changed, check for affected conferences
-    if (newValue !== this.originalValueValue && newValue > 0) {
-      await this.loadAffectedConferences(newValue)
+    if (changed && newMax > 0 && newMin > 0 && newMin <= newMax) {
+      await this.loadAffectedConferences(newMin, newMax)
     }
   }
 
-  async loadAffectedConferences(newMaxVolunteers) {
+  async loadAffectedConferences(newMinVolunteers, newMaxVolunteers) {
     try {
       const response = await fetch(`${this.affectedConferencesUrlValue}?new_max_volunteers=${newMaxVolunteers}`)
       const data = await response.json()
 
       if (data.conferences && data.conferences.length > 0) {
-        this.renderConferenceList(data.conferences, newMaxVolunteers)
+        this.renderConferenceList(data.conferences, newMinVolunteers, newMaxVolunteers)
         this.showModal()
       }
     } catch (error) {
@@ -37,7 +44,7 @@ export default class extends Controller {
     }
   }
 
-  renderConferenceList(conferences, newMaxVolunteers) {
+  renderConferenceList(conferences, newMinVolunteers, newMaxVolunteers) {
     let html = ""
     conferences.forEach(conf => {
       const warningBadge = conf.over_capacity_count > 0
@@ -60,12 +67,12 @@ export default class extends Controller {
                 ${warningBadge}
                 <br>
                 <small class="text-muted">
-                  Current: ${conf.current_max_volunteers} volunteers/shift |
+                  Current: ${conf.current_min_volunteers}–${conf.current_max_volunteers} volunteers/shift |
                   ${conf.timeslots_count} timeslots
                 </small>
               </div>
               <div class="text-end">
-                <span class="badge bg-primary">${conf.current_max_volunteers} → ${newMaxVolunteers}</span>
+                <span class="badge bg-primary">${conf.current_min_volunteers}–${conf.current_max_volunteers} → ${newMinVolunteers}–${newMaxVolunteers}</span>
               </div>
             </div>
           </label>
@@ -97,6 +104,7 @@ export default class extends Controller {
     const checkboxes = this.conferenceListTarget.querySelectorAll(".conference-checkbox:checked")
     const conferenceProgrmIds = Array.from(checkboxes).map(cb => cb.value)
     const newMaxVolunteers = parseInt(this.maxVolunteersTarget.value)
+    const newMinVolunteers = this.currentMin()
 
     if (conferenceProgrmIds.length === 0) {
       this.hideModal()
@@ -114,6 +122,7 @@ export default class extends Controller {
           "X-CSRF-Token": document.querySelector("[name='csrf-token']").content
         },
         body: JSON.stringify({
+          new_min_volunteers: newMinVolunteers,
           new_max_volunteers: newMaxVolunteers,
           conference_program_ids: conferenceProgrmIds
         })
@@ -122,8 +131,9 @@ export default class extends Controller {
       const data = await response.json()
       if (data.success) {
         this.hideModal()
-        // Update original value to prevent modal showing again
+        // Update original values to prevent modal showing again
         this.originalValueValue = newMaxVolunteers
+        this.originalMinValueValue = newMinVolunteers
       }
     } catch (error) {
       console.error("Error updating capacity:", error)
@@ -135,7 +145,8 @@ export default class extends Controller {
 
   skipUpdate() {
     this.hideModal()
-    // Update original value to prevent modal showing again on re-save
+    // Update original values to prevent modal showing again on re-save
     this.originalValueValue = parseInt(this.maxVolunteersTarget.value)
+    this.originalMinValueValue = this.currentMin()
   }
 }

--- a/app/jobs/update_timeslot_capacity_job.rb
+++ b/app/jobs/update_timeslot_capacity_job.rb
@@ -1,7 +1,10 @@
 class UpdateTimeslotCapacityJob < ApplicationJob
   queue_as :default
 
-  def perform(conference_program_id, new_max_volunteers)
+  # new_min_volunteers is optional so jobs queued before the coverage band
+  # existed (#259) still run; without it, each slot keeps its min, clamped
+  # down to the new max.
+  def perform(conference_program_id, new_max_volunteers, new_min_volunteers = nil)
     conference_program = ConferenceProgram.find_by(id: conference_program_id)
     return { updated: 0, skipped: 0 } unless conference_program
 
@@ -15,7 +18,8 @@ class UpdateTimeslotCapacityJob < ApplicationJob
         next
       end
 
-      timeslot.update!(max_volunteers: new_max_volunteers)
+      new_min = [ new_min_volunteers || timeslot.min_volunteers, new_max_volunteers ].min
+      timeslot.update!(min_volunteers: new_min, max_volunteers: new_max_volunteers)
       updated_count += 1
     end
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -45,12 +45,14 @@ class Conference < ApplicationRecord
     timeslots.count
   end
 
+  # "Filled" means the coverage target is met (min_volunteers, #259), not that
+  # the slot is at its signup cap.
   def filled_timeslots
-    timeslots.where("timeslots.current_volunteers_count >= timeslots.max_volunteers").count
+    timeslots.where("timeslots.current_volunteers_count >= timeslots.min_volunteers").count
   end
 
   def unfilled_timeslots
-    timeslots.where("timeslots.current_volunteers_count < timeslots.max_volunteers").count
+    timeslots.where("timeslots.current_volunteers_count < timeslots.min_volunteers").count
   end
 
   def volunteer_count

--- a/app/models/conference_program.rb
+++ b/app/models/conference_program.rb
@@ -18,10 +18,18 @@ class ConferenceProgram < ApplicationRecord
   validates :conference, presence: true
   validates :program, presence: true, uniqueness: { scope: :conference_id }
   validates :max_volunteers, numericality: { greater_than: 0 }, allow_nil: true
+  validates :min_volunteers, numericality: { greater_than: 0 }, allow_nil: true
+  validate :min_not_above_max
 
   # Returns the effective max_volunteers (override or program default)
   def effective_max_volunteers
     max_volunteers || program&.max_volunteers || 1
+  end
+
+  # Coverage target (#259): override or program default, but never above the
+  # effective cap — a max override may undercut the program's min default.
+  def effective_min_volunteers
+    [ min_volunteers || program&.min_volunteers || 1, effective_max_volunteers ].min
   end
 
   after_create :generate_timeslots
@@ -33,6 +41,14 @@ class ConferenceProgram < ApplicationRecord
   end
 
   private
+
+  def min_not_above_max
+    return unless min_volunteers && max_volunteers
+
+    if min_volunteers > max_volunteers
+      errors.add(:min_volunteers, "must be less than or equal to max volunteers")
+    end
+  end
 
   # day_schedules are keyed by calendar date (ISO "YYYY-MM-DD") so a
   # conference date change never re-assigns a day's hours to a different

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -13,6 +13,8 @@ class Program < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: { scope: [ :village_id, :conference_id ], message: "must be unique within the village" }
   validates :max_volunteers, presence: true, numericality: { greater_than: 0 }
+  validates :min_volunteers, presence: true,
+            numericality: { greater_than: 0, less_than_or_equal_to: ->(program) { program.max_volunteers || 1 } }
 
   # Scopes
   scope :village_level, -> { where(conference_id: nil) }

--- a/app/models/timeslot.rb
+++ b/app/models/timeslot.rb
@@ -9,6 +9,10 @@ class Timeslot < ApplicationRecord
   validates :start_time, presence: true
   validates :end_time, presence: true
   validates :max_volunteers, presence: true, numericality: { greater_than: 0 }
+  # Coverage band (#259): min_volunteers is the coverage target (green at min),
+  # max_volunteers the hard signup cap (blue band up to max).
+  validates :min_volunteers, presence: true,
+            numericality: { greater_than: 0, less_than_or_equal_to: ->(slot) { slot.max_volunteers || 1 } }
   validates :current_volunteers_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :start_time, uniqueness: { scope: :conference_program_id }
 

--- a/app/services/coverage_projection.rb
+++ b/app/services/coverage_projection.rb
@@ -3,21 +3,24 @@
 # An activity is a position staffed continuously while the village is open;
 # this read model answers "how covered is it, and where are the holes?" for
 # one activity-day (.for) or a whole conference-day (.summary). It reads only
-# what Timeslot already stores — max_volunteers ("needed") and the
-# denormalized current_volunteers_count ("on") — so there are no counting
-# queries and no schema changes.
+# what Timeslot already stores — the [min_volunteers, max_volunteers] coverage
+# band (#259) and the denormalized current_volunteers_count ("on") — so there
+# are no counting queries.
 #
 #   projection = CoverageProjection.for(conference_program, date)
-#   projection.ticks # => [{ timeslot_id:, start:, end:, needed:, on:, state: }, ...]
+#   projection.ticks # => [{ timeslot_id:, start:, end:, needed:, max:, on:, state: }, ...]
 #   projection.gaps  # => [{ start:, end:, needed:, start_timeslot_id:, minutes: }, ...]
 #
-# States: on >= needed -> :covered, on == 0 -> :bare, otherwise :short.
-# A gap is a time-contiguous run of ticks where on < needed — exactly the
-# windows a volunteer may claim (the server already restricts self-signup to
-# non-full slots, so gaps and claimable windows coincide).
+# In ticks/gaps, needed: is min_volunteers (the coverage target) and max: the
+# signup cap. States: on == 0 -> :bare, on < min -> :short, on == min ->
+# :covered (minimum met, green), on > min -> :surplus (extra cushion, blue).
+# A gap is a time-contiguous run of ticks where on < min — the coverage holes
+# the claim stack advertises. Gaps close at min: slots between min and max are
+# still claimable via self-signup (the server blocks only full slots) but are
+# no longer advertised as needed.
 class CoverageProjection
   TICK_MINUTES = 15
-  STATE_RANK = { bare: 0, short: 1, covered: 2 }.freeze
+  STATE_RANK = { bare: 0, short: 1, covered: 2, surplus: 3 }.freeze
 
   attr_reader :ticks, :gaps
 
@@ -83,17 +86,20 @@ class CoverageProjection
       timeslot_id: slot.id,
       start: slot.start_time,
       end: slot.end_time,
-      needed: slot.max_volunteers,
+      needed: slot.min_volunteers,
+      max: slot.max_volunteers,
       on: slot.current_volunteers_count,
       state: state_of(slot)
     }
   end
 
   def state_of(slot)
-    return :covered if slot.current_volunteers_count >= slot.max_volunteers
-    return :bare if slot.current_volunteers_count.zero?
+    on = slot.current_volunteers_count
+    return :bare if on.zero?
+    return :short if on < slot.min_volunteers
+    return :covered if on == slot.min_volunteers
 
-    :short
+    :surplus
   end
 
   # Merge consecutive under-covered ticks into runs. "Consecutive" is by time,

--- a/app/services/timeslot_generator.rb
+++ b/app/services/timeslot_generator.rb
@@ -103,6 +103,7 @@ class TimeslotGenerator
       Timeslot.create!(
         conference_program: @conference_program,
         start_time: start_time,
+        min_volunteers: @conference_program.effective_min_volunteers,
         max_volunteers: @conference_program.effective_max_volunteers
       )
     end

--- a/app/views/conference_programs/edit.html.erb
+++ b/app/views/conference_programs/edit.html.erb
@@ -29,10 +29,18 @@
             </div>
 
             <div class="mb-3">
-              <%= form.label :max_volunteers, "Volunteers Needed Per Shift (Override)", class: "form-label" %>
+              <%= form.label :min_volunteers, "Minimum Volunteers Per Shift (Override)", class: "form-label" %>
+              <%= form.number_field :min_volunteers, min: 1, class: "form-control", style: "max-width: 150px;", placeholder: "Use program default (#{@conference_program.program.min_volunteers})" %>
+              <small class="form-text text-muted">
+                Volunteers needed for a shift to count as covered. Program default: <%= @conference_program.program.min_volunteers %>. Leave blank to use default. Changing this will NOT update existing timeslots.
+              </small>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :max_volunteers, "Maximum Volunteers Per Shift (Override)", class: "form-label" %>
               <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;", placeholder: "Use program default (#{@conference_program.program.max_volunteers})" %>
               <small class="form-text text-muted">
-                Program default: <%= @conference_program.program.max_volunteers %>. Leave blank to use default, or set a value to override. Changing this will NOT update existing timeslots.
+                Hard cap — signups close once a shift reaches this. Program default: <%= @conference_program.program.max_volunteers %>. Leave blank to use default. Changing this will NOT update existing timeslots.
               </small>
             </div>
 

--- a/app/views/conference_programs/new.html.erb
+++ b/app/views/conference_programs/new.html.erb
@@ -36,10 +36,18 @@
             </div>
 
             <div class="mb-3">
-              <%= form.label :max_volunteers, "Volunteers Needed Per Shift (Override)", class: "form-label" %>
+              <%= form.label :min_volunteers, "Minimum Volunteers Per Shift (Override)", class: "form-label" %>
+              <%= form.number_field :min_volunteers, min: 1, class: "form-control", style: "max-width: 150px;", placeholder: "Use program default" %>
+              <small class="form-text text-muted">
+                Volunteers needed for a shift to count as covered. Leave blank to use the program's default.
+              </small>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :max_volunteers, "Maximum Volunteers Per Shift (Override)", class: "form-label" %>
               <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;", placeholder: "Use program default" %>
               <small class="form-text text-muted">
-                Leave blank to use the program's default. Set a value to override for this conference only.
+                Hard cap — signups close once a shift reaches this. Leave blank to use the program's default.
               </small>
             </div>
 

--- a/app/views/conference_reports/unmanned_shifts.html.erb
+++ b/app/views/conference_reports/unmanned_shifts.html.erb
@@ -44,21 +44,22 @@
               <th>Time</th>
               <th>Program</th>
               <th>Current</th>
+              <th>Min</th>
               <th>Max</th>
-              <th>Spots Available</th>
+              <th>Needed to Cover</th>
               <th>Status</th>
             </tr>
           </thead>
           <tbody>
             <% @timeslots.each do |timeslot| %>
-              <% spots_available = timeslot.max_volunteers - timeslot.current_volunteers_count %>
               <tr class="<%= timeslot.current_volunteers_count == 0 ? 'table-danger' : 'table-warning' %>">
                 <td><%= timeslot.start_time.strftime("%A, %B %d") %></td>
                 <td><%= timeslot.start_time.strftime("%l:%M %p") %> - <%= timeslot.end_time.strftime("%l:%M %p") %></td>
                 <td><%= timeslot.conference_program.program.name %></td>
                 <td><%= timeslot.current_volunteers_count %></td>
+                <td><%= timeslot.min_volunteers %></td>
                 <td><%= timeslot.max_volunteers %></td>
-                <td><%= spots_available %></td>
+                <td><%= timeslot.min_volunteers - timeslot.current_volunteers_count %></td>
                 <td>
                   <% if timeslot.current_volunteers_count == 0 %>
                     <span class="badge bg-danger">Unmanned</span>
@@ -74,7 +75,7 @@
     </div>
     <p class="text-muted mt-3">
       Showing <%= @timeslots.size %> shifts that need volunteers.
-      Total spots available: <%= @timeslots.sum { |t| t.max_volunteers - t.current_volunteers_count } %>
+      Total volunteers needed to cover: <%= @timeslots.sum { |t| t.min_volunteers - t.current_volunteers_count } %>
     </p>
   <% else %>
     <div class="alert alert-success">

--- a/app/views/custom_programs/edit.html.erb
+++ b/app/views/custom_programs/edit.html.erb
@@ -29,8 +29,15 @@
             </div>
 
             <div class="mb-3">
-              <%= form.label :max_volunteers, "Volunteers Needed Per Shift", class: "form-label" %>
+              <%= form.label :min_volunteers, "Minimum Volunteers Per Shift", class: "form-label" %>
+              <%= form.number_field :min_volunteers, min: 1, class: "form-control", style: "max-width: 150px;" %>
+              <div class="form-text">Volunteers needed for a shift to count as covered.</div>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :max_volunteers, "Maximum Volunteers Per Shift", class: "form-label" %>
               <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;" %>
+              <div class="form-text">Hard cap — signups close once a shift reaches this.</div>
             </div>
 
             <div class="d-grid gap-2 d-md-flex justify-content-md-end">

--- a/app/views/custom_programs/new.html.erb
+++ b/app/views/custom_programs/new.html.erb
@@ -35,8 +35,15 @@
             </div>
 
             <div class="mb-3">
-              <%= form.label :max_volunteers, "Volunteers Needed Per Shift", class: "form-label" %>
+              <%= form.label :min_volunteers, "Minimum Volunteers Per Shift", class: "form-label" %>
+              <%= form.number_field :min_volunteers, min: 1, class: "form-control", style: "max-width: 150px;", value: @program.min_volunteers || 1 %>
+              <div class="form-text">Volunteers needed for a shift to count as covered.</div>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :max_volunteers, "Maximum Volunteers Per Shift", class: "form-label" %>
               <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;", value: @program.max_volunteers || 1 %>
+              <div class="form-text">Hard cap — signups close once a shift reaches this.</div>
             </div>
 
             <div class="d-grid gap-2 d-md-flex justify-content-md-end">

--- a/app/views/programs/edit.html.erb
+++ b/app/views/programs/edit.html.erb
@@ -34,10 +34,17 @@
             </div>
 
             <div class="mb-3">
-              <%= form.label :max_volunteers, "Default Volunteers Per Shift", class: "form-label" %>
+              <%= form.label :min_volunteers, "Default Minimum Volunteers Per Shift", class: "form-label" %>
+              <%= form.number_field :min_volunteers, min: 1, class: "form-control", style: "max-width: 150px;",
+                  data: { bulk_capacity_update_target: "minVolunteers", action: "blur->bulk-capacity-update#checkForChanges" } %>
+              <div class="form-text">Volunteers needed for a shift to count as covered. Can be overridden per conference.</div>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :max_volunteers, "Default Maximum Volunteers Per Shift", class: "form-label" %>
               <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;",
                   data: { bulk_capacity_update_target: "maxVolunteers", action: "blur->bulk-capacity-update#checkForChanges" } %>
-              <div class="form-text">Default number of volunteers needed per 15-minute shift. Can be overridden per conference.</div>
+              <div class="form-text">Hard cap — signups close once a shift reaches this. Can be overridden per conference.</div>
             </div>
 
             <div class="d-grid gap-2 d-md-flex justify-content-md-end">

--- a/app/views/programs/new.html.erb
+++ b/app/views/programs/new.html.erb
@@ -31,9 +31,15 @@
             </div>
 
             <div class="mb-3">
-              <%= form.label :max_volunteers, "Default Volunteers Per Shift", class: "form-label" %>
+              <%= form.label :min_volunteers, "Default Minimum Volunteers Per Shift", class: "form-label" %>
+              <%= form.number_field :min_volunteers, min: 1, class: "form-control", style: "max-width: 150px;" %>
+              <div class="form-text">Volunteers needed for a shift to count as covered. Can be overridden per conference.</div>
+            </div>
+
+            <div class="mb-3">
+              <%= form.label :max_volunteers, "Default Maximum Volunteers Per Shift", class: "form-label" %>
               <%= form.number_field :max_volunteers, min: 1, class: "form-control", style: "max-width: 150px;" %>
-              <div class="form-text">Default number of volunteers needed per 15-minute shift. Can be overridden per conference.</div>
+              <div class="form-text">Hard cap — signups close once a shift reaches this. Can be overridden per conference.</div>
             </div>
 
             <div class="d-grid gap-2 d-md-flex justify-content-md-end">

--- a/app/views/schedule/_coverage_card.html.erb
+++ b/app/views/schedule/_coverage_card.html.erb
@@ -3,7 +3,8 @@
   qualifications = @program_qualifications[program.id] || []
   locked = qualifications.any? { |qualification| !@user_qualification_ids.include?(qualification.id) }
   worst = projection.worst_state
-  state_badge = { bare: [ "text-bg-danger", "Bare" ], short: [ "text-bg-warning", "Short" ], covered: [ "text-bg-success", "Covered" ] }[worst]
+  state_badge = { bare: [ "text-bg-danger", "Bare" ], short: [ "text-bg-warning", "Short" ],
+                  covered: [ "text-bg-success", "Covered" ], surplus: [ "text-bg-primary", "Extra" ] }[worst]
 %>
 <div class="card coverage-card" id="activity-<%= conference_program.id %>"
      <% unless locked %>

--- a/app/views/schedule/_coverage_ribbon.html.erb
+++ b/app/views/schedule/_coverage_ribbon.html.erb
@@ -8,7 +8,7 @@
 <div class="coverage-ribbon <%= "claimable" if interactive %>" <% if interactive %>data-coverage-ribbon-target="ribbon"<% end %>>
   <% projection.ticks.each do |tick| %>
     <span class="tick <%= tick[:state] %> <%= "mine" if @my_timeslot_ids.include?(tick[:timeslot_id]) %>"
-          title="<%= tick[:start].strftime("%-l:%M %p") %> — <%= tick[:on] %> of <%= tick[:needed] %> covered"
+          title="<%= tick[:start].strftime("%-l:%M %p") %> — <%= tick[:on] %> on, needs <%= tick[:needed] %> (max <%= tick[:max] %>)"
           data-timeslot-id="<%= tick[:timeslot_id] %>"
           data-start="<%= tick[:start].iso8601 %>"
           data-label="<%= tick[:start].strftime("%-l:%M %p") %>"

--- a/app/views/schedule/_manage_panel.html.erb
+++ b/app/views/schedule/_manage_panel.html.erb
@@ -12,16 +12,22 @@
   <div class="offcanvas-body">
     <%= render "coverage_ribbon", projection: @manage_projection, interactive: false %>
 
-    <%# Needed today: one value per day (settled decision) -> #242 capacity path %>
+    <%# Coverage band today (#259): min = covered (green), max = signup cap.
+        One value pair per day (settled decision) -> #242 capacity path %>
     <%= form_with url: bulk_update_capacity_conference_timeslots_path(@conference), method: :patch, data: { turbo: false }, class: "mt-3" do %>
       <input type="hidden" name="conference_program_id" value="<%= @manage_cp.id %>">
       <input type="hidden" name="date" value="<%= @manage_day.iso8601 %>">
-      <label class="form-label mb-1" for="manage-needed">Needed today</label>
-      <div class="input-group input-group-sm" style="max-width: 12rem;">
-        <input type="number" id="manage-needed" name="max_volunteers" min="1" class="form-control"
+      <label class="form-label mb-1" for="manage-min">Coverage today</label>
+      <div class="input-group input-group-sm" style="max-width: 18rem;">
+        <span class="input-group-text">Min</span>
+        <input type="number" id="manage-min" name="min_volunteers" min="1" class="form-control"
                value="<%= @manage_projection.ticks.map { |tick| tick[:needed] }.max || 1 %>">
+        <span class="input-group-text">Max</span>
+        <input type="number" id="manage-max" name="max_volunteers" min="1" class="form-control" aria-label="Max"
+               value="<%= @manage_projection.ticks.map { |tick| tick[:max] }.max || 1 %>">
         <button type="submit" class="btn btn-outline-primary">Save</button>
       </div>
+      <p class="text-muted small mt-1 mb-0">Min met shows green; extra volunteers up to Max show blue. Signups close at Max.</p>
     <% end %>
 
     <hr>

--- a/app/views/schedule/board.html.erb
+++ b/app/views/schedule/board.html.erb
@@ -25,7 +25,8 @@
                 <% if projection %>
                   <%
                     state_badge = { bare: [ "text-bg-danger", "Bare" ], short: [ "text-bg-warning", "Short" ],
-                                    covered: [ "text-bg-success", "Covered" ] }[projection.worst_state]
+                                    covered: [ "text-bg-success", "Covered" ],
+                                    surplus: [ "text-bg-primary", "Extra" ] }[projection.worst_state]
                   %>
                   <%= link_to conference_schedule_board_path(@conference, manage: row[:conference_program].id, day: day.iso8601),
                       class: "text-decoration-none d-block" do %>

--- a/db/migrate/20260727120000_add_min_volunteers_for_coverage_band.rb
+++ b/db/migrate/20260727120000_add_min_volunteers_for_coverage_band.rb
@@ -1,0 +1,20 @@
+class AddMinVolunteersForCoverageBand < ActiveRecord::Migration[8.1]
+  # Coverage band (#259): min_volunteers is the coverage target ("green at
+  # min"), max_volunteers stays the hard signup cap. Backfilling min = max
+  # preserves today's behavior exactly (covered used to mean full).
+  def up
+    add_column :timeslots, :min_volunteers, :integer, default: 1, null: false
+    add_column :programs, :min_volunteers, :integer, default: 1, null: false
+    add_column :conference_programs, :min_volunteers, :integer
+
+    execute "UPDATE timeslots SET min_volunteers = max_volunteers"
+    execute "UPDATE programs SET min_volunteers = max_volunteers"
+    execute "UPDATE conference_programs SET min_volunteers = max_volunteers WHERE max_volunteers IS NOT NULL"
+  end
+
+  def down
+    remove_column :timeslots, :min_volunteers
+    remove_column :programs, :min_volunteers
+    remove_column :conference_programs, :min_volunteers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_20_043541) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_27_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -42,6 +42,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_043541) do
     t.datetime "created_at", null: false
     t.json "day_schedules"
     t.integer "max_volunteers"
+    t.integer "min_volunteers"
     t.bigint "program_id", null: false
     t.text "public_description"
     t.datetime "updated_at", null: false
@@ -138,6 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_043541) do
     t.datetime "created_at", null: false
     t.text "description"
     t.integer "max_volunteers", default: 1, null: false
+    t.integer "min_volunteers", default: 1, null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.bigint "village_id", null: false
@@ -193,6 +195,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_043541) do
     t.integer "current_volunteers_count", default: 0, null: false
     t.datetime "end_time", null: false
     t.integer "max_volunteers", default: 1, null: false
+    t.integer "min_volunteers", default: 1, null: false
     t.datetime "start_time", null: false
     t.datetime "updated_at", null: false
     t.index ["conference_program_id", "start_time"], name: "index_timeslots_on_conference_program_id_and_start_time", unique: true

--- a/test/controllers/conference_reports_controller_test.rb
+++ b/test/controllers/conference_reports_controller_test.rb
@@ -98,6 +98,22 @@ class ConferenceReportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "unmanned shifts keys off min_volunteers, not max" do
+    at_min   = @conference_program.timeslots.order(:start_time).first
+    below    = @conference_program.timeslots.order(:start_time).second
+    at_min.update!(min_volunteers: 1, max_volunteers: 2, current_volunteers_count: 1)
+    below.update!(min_volunteers: 2, max_volunteers: 2, current_volunteers_count: 1)
+    @conference_program.timeslots.where.not(id: [ at_min.id, below.id ])
+                       .update_all(min_volunteers: 1, current_volunteers_count: 1)
+
+    sign_in @village_admin
+    get unmanned_shifts_conference_reports_path(@conference, format: :csv)
+
+    lines = response.body.lines
+    assert_equal 2, lines.size, "only the below-min shift should be listed:\n#{response.body}"
+    assert_includes lines.last, below.start_time.strftime("%H:%M")
+  end
+
   test "unmanned shifts report can be exported as CSV" do
     sign_in @village_admin
     get unmanned_shifts_conference_reports_path(@conference, format: :csv)

--- a/test/controllers/timeslot_bulk_actions_test.rb
+++ b/test/controllers/timeslot_bulk_actions_test.rb
@@ -124,21 +124,34 @@ class TimeslotBulkActionsTest < ActionDispatch::IntegrationTest
     )
 
     patch bulk_update_capacity_conference_timeslots_path(@conference),
-          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601, max_volunteers: 3 }
+          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601,
+                    min_volunteers: 2, max_volunteers: 3 }
 
     assert_response :redirect
-    assert_equal [ 3 ], @day1_slots.map { |slot| slot.reload.max_volunteers }.uniq
+    assert_equal [ 2 ], @day1_slots.map { |slot| slot.reload.min_volunteers }.uniq
+    assert_equal [ 3 ], @day1_slots.map(&:max_volunteers).uniq
     day2_slots = @cp.timeslots.where(start_time: (@conference.start_date + 1.day).in_time_zone.all_day)
     assert_equal [ 1 ], day2_slots.map(&:max_volunteers).uniq, "other day untouched"
     assert_equal [ 1 ], other_cp.timeslots.map(&:max_volunteers).uniq, "other activity untouched"
   end
 
-  test "rejects a capacity below 1" do
+  test "rejects a minimum below 1" do
     patch bulk_update_capacity_conference_timeslots_path(@conference),
-          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601, max_volunteers: 0 }
+          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601,
+                    min_volunteers: 0, max_volunteers: 3 }
 
     assert_match(/at least 1/i, flash[:alert])
     assert_equal [ 1 ], @day1_slots.map { |slot| slot.reload.max_volunteers }.uniq
+  end
+
+  test "rejects a maximum below the minimum" do
+    patch bulk_update_capacity_conference_timeslots_path(@conference),
+          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601,
+                    min_volunteers: 3, max_volunteers: 2 }
+
+    assert_match(/at least the minimum/i, flash[:alert])
+    assert_equal [ 1 ], @day1_slots.map { |slot| slot.reload.min_volunteers }.uniq
+    assert_equal [ 1 ], @day1_slots.map(&:max_volunteers).uniq
   end
 
   # --- authorization ---
@@ -152,7 +165,8 @@ class TimeslotBulkActionsTest < ActionDispatch::IntegrationTest
     assert_equal 1, @target.volunteer_signups.count
 
     patch bulk_update_capacity_conference_timeslots_path(@conference),
-          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601, max_volunteers: 2 }
+          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601,
+                    min_volunteers: 2, max_volunteers: 2 }
     assert_equal [ 2 ], @day1_slots.map { |slot| slot.reload.max_volunteers }.uniq
   end
 
@@ -178,7 +192,8 @@ class TimeslotBulkActionsTest < ActionDispatch::IntegrationTest
     assert_equal 0, @target.volunteer_signups.count
 
     patch bulk_update_capacity_conference_timeslots_path(@conference),
-          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601, max_volunteers: 5 }
+          params: { conference_program_id: @cp.id, date: @conference.start_date.iso8601,
+                    min_volunteers: 5, max_volunteers: 5 }
     assert_equal [ 1 ], @day1_slots.map { |slot| slot.reload.max_volunteers }.uniq
   end
 

--- a/test/jobs/update_timeslot_capacity_job_test.rb
+++ b/test/jobs/update_timeslot_capacity_job_test.rb
@@ -54,6 +54,26 @@ class UpdateTimeslotCapacityJobTest < ActiveJob::TestCase
     assert_equal 2, timeslot.max_volunteers
   end
 
+  test "updates min_volunteers alongside max when given" do
+    UpdateTimeslotCapacityJob.perform_now(@conference_program.id, 5, 3)
+
+    @conference_program.timeslots.reload.each do |timeslot|
+      assert_equal 3, timeslot.min_volunteers
+      assert_equal 5, timeslot.max_volunteers
+    end
+  end
+
+  test "clamps existing min down when only max is lowered past it" do
+    @conference_program.timeslots.each { |ts| ts.update!(min_volunteers: 2, max_volunteers: 2) }
+
+    UpdateTimeslotCapacityJob.perform_now(@conference_program.id, 1)
+
+    @conference_program.timeslots.reload.each do |timeslot|
+      assert_equal 1, timeslot.min_volunteers
+      assert_equal 1, timeslot.max_volunteers
+    end
+  end
+
   test "handles missing conference_program gracefully" do
     # Should not raise an error for non-existent conference_program
     assert_nothing_raised do

--- a/test/models/conference_program_test.rb
+++ b/test/models/conference_program_test.rb
@@ -150,6 +150,64 @@ class ConferenceProgramTest < ActiveSupport::TestCase
     assert_equal 3, cp.effective_max_volunteers
   end
 
+  test "effective_min_volunteers returns override when set" do
+    cp = ConferenceProgram.new(
+      conference: @conference,
+      program: @program,
+      min_volunteers: 2,
+      max_volunteers: 5
+    )
+    assert_equal 2, cp.effective_min_volunteers
+  end
+
+  test "effective_min_volunteers falls back to program default" do
+    @program.update!(min_volunteers: 2, max_volunteers: 3)
+    cp = ConferenceProgram.new(
+      conference: @conference,
+      program: @program,
+      min_volunteers: nil
+    )
+    assert_equal 2, cp.effective_min_volunteers
+  end
+
+  test "effective_min_volunteers never exceeds effective_max_volunteers" do
+    @program.update!(min_volunteers: 3, max_volunteers: 3)
+    cp = ConferenceProgram.new(
+      conference: @conference,
+      program: @program,
+      min_volunteers: nil,
+      max_volunteers: 2   # override cap below the program's min default
+    )
+    assert_equal 2, cp.effective_min_volunteers
+  end
+
+  test "rejects a min override above the max override" do
+    cp = ConferenceProgram.new(
+      conference: @conference,
+      program: @program,
+      min_volunteers: 5,
+      max_volunteers: 2
+    )
+    assert_not cp.valid?
+    assert cp.errors[:min_volunteers].any?
+  end
+
+  test "timeslots inherit effective_min_volunteers" do
+    @program.update!(min_volunteers: 2, max_volunteers: 3)
+    cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: @program,
+      day_schedules: {
+        "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" }
+      }
+    )
+    assert cp.timeslots.any?
+    cp.timeslots.each do |timeslot|
+      assert_equal 2, timeslot.min_volunteers
+      assert_equal 3, timeslot.max_volunteers
+    end
+  end
+
   test "timeslots inherit effective_max_volunteers" do
     @program.update!(max_volunteers: 3)
     cp = ConferenceProgram.create!(

--- a/test/models/program_test.rb
+++ b/test/models/program_test.rb
@@ -14,6 +14,26 @@ class ProgramTest < ActiveSupport::TestCase
     assert program.valid?
   end
 
+  test "should default min_volunteers to 1 and reject values below 1" do
+    program = Program.new(name: "Ham Test", village: @village)
+    assert_equal 1, program.min_volunteers
+
+    program.min_volunteers = 0
+    assert_not program.valid?
+    assert program.errors[:min_volunteers].any?
+  end
+
+  test "should reject min_volunteers above max_volunteers" do
+    program = Program.new(
+      name: "Ham Test",
+      village: @village,
+      min_volunteers: 4,
+      max_volunteers: 2
+    )
+    assert_not program.valid?
+    assert program.errors[:min_volunteers].any?
+  end
+
   test "should require name" do
     program = Program.new(
       description: "Amateur radio license testing",

--- a/test/models/timeslot_test.rb
+++ b/test/models/timeslot_test.rb
@@ -95,6 +95,48 @@ class TimeslotTest < ActiveSupport::TestCase
     assert_equal @conference, timeslot.conference
   end
 
+  # --- coverage band (#259): min_volunteers target vs max_volunteers cap ---
+
+  test "should default min_volunteers to 1" do
+    timeslot = Timeslot.new(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00")
+    )
+    assert_equal 1, timeslot.min_volunteers
+  end
+
+  test "should require min_volunteers of at least 1" do
+    timeslot = Timeslot.new(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00"),
+      min_volunteers: 0,
+      max_volunteers: 5
+    )
+    assert_not timeslot.valid?
+    assert timeslot.errors[:min_volunteers].any?
+  end
+
+  test "should reject min_volunteers above max_volunteers" do
+    timeslot = Timeslot.new(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00"),
+      min_volunteers: 6,
+      max_volunteers: 5
+    )
+    assert_not timeslot.valid?
+    assert timeslot.errors[:min_volunteers].any?
+  end
+
+  test "should allow min_volunteers equal to max_volunteers" do
+    timeslot = Timeslot.new(
+      conference_program: @conference_program,
+      start_time: Time.zone.parse("#{@conference.start_date} 09:00"),
+      min_volunteers: 5,
+      max_volunteers: 5
+    )
+    assert timeslot.valid?
+  end
+
   test "should belong to program through conference_program" do
     timeslot = Timeslot.create!(
       conference_program: @conference_program,

--- a/test/services/coverage_projection_test.rb
+++ b/test/services/coverage_projection_test.rb
@@ -30,6 +30,10 @@ class CoverageProjectionTest < ActiveSupport::TestCase
     slot.update_column(:current_volunteers_count, count)
   end
 
+  def band(slot, min, max)
+    slot.update_columns(min_volunteers: min, max_volunteers: max)
+  end
+
   # --- ticks ---
 
   test "ticks are ordered, one per slot, with needed/on read from the slot" do
@@ -39,15 +43,20 @@ class CoverageProjectionTest < ActiveSupport::TestCase
     assert_equal @slots.map(&:id), projection.ticks.map { |t| t[:timeslot_id] }
     assert_equal @slots.first.start_time, projection.ticks.first[:start]
     assert_equal [ 1 ], projection.ticks.map { |t| t[:needed] }.uniq
+    assert_equal [ 1 ], projection.ticks.map { |t| t[:max] }.uniq
     assert_equal [ 0 ], projection.ticks.map { |t| t[:on] }.uniq
   end
 
-  test "tick states: bare when empty, short when under target, covered at or over target" do
-    cover(@slots[1], 1)              # covered (1/1)
-    @slots[2].update_column(:max_volunteers, 2)
-    cover(@slots[2], 1)              # short (1/2)
-    @slots[3].update_column(:max_volunteers, 2)
-    cover(@slots[3], 3)              # covered (3/2 — admin over-cover)
+  test "tick states: bare when empty, short below min, covered at min, surplus above min" do
+    cover(@slots[1], 1)              # covered (1 == min 1)
+    band(@slots[2], 2, 3)
+    cover(@slots[2], 1)              # short (1 < min 2)
+    band(@slots[3], 2, 3)
+    cover(@slots[3], 2)              # covered (2 == min 2)
+    band(@slots[4], 2, 4)
+    cover(@slots[4], 3)              # surplus (min 2 < 3 <= max 4)
+    band(@slots[5], 2, 3)
+    cover(@slots[5], 4)              # surplus (admin over-cover past max)
 
     states = CoverageProjection.for(@cp, @day).ticks.map { |t| t[:state] }
 
@@ -55,6 +64,8 @@ class CoverageProjectionTest < ActiveSupport::TestCase
     assert_equal :covered, states[1]
     assert_equal :short,   states[2]
     assert_equal :covered, states[3]
+    assert_equal :surplus, states[4]
+    assert_equal :surplus, states[5]
   end
 
   test "only the requested date's slots appear" do
@@ -109,7 +120,7 @@ class CoverageProjectionTest < ActiveSupport::TestCase
 
   test "short slots count as gaps and carry the run's max needed" do
     @slots.each { |slot| cover(slot, 1) }
-    @slots[5].update_column(:max_volunteers, 3)   # 1/3 -> short
+    band(@slots[5], 3, 3)   # 1/3 -> short
 
     gaps = CoverageProjection.for(@cp, @day).gaps
 
@@ -117,6 +128,13 @@ class CoverageProjectionTest < ActiveSupport::TestCase
     assert_equal @slots[5].start_time, gaps.first[:start]
     assert_equal @slots[5].end_time,   gaps.first[:end]
     assert_equal 3, gaps.first[:needed]
+  end
+
+  test "gaps close at min: a slot at min but below max is not a gap" do
+    @slots.each { |slot| band(slot, 1, 3) }
+    @slots.each { |slot| cover(slot, 1) }
+
+    assert_empty CoverageProjection.for(@cp, @day).gaps
   end
 
   test "a schedule break splits a gap even when both sides are uncovered" do
@@ -151,7 +169,7 @@ class CoverageProjectionTest < ActiveSupport::TestCase
       day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
     )
     short_program.timeslots.each { |slot| slot.update_column(:current_volunteers_count, 1) }
-    short_program.timeslots.first.update_column(:max_volunteers, 2)  # one short slot
+    band(short_program.timeslots.first, 2, 2)  # one short slot
     covered_program = ConferenceProgram.create!(
       conference: @conference,
       program: Program.create!(name: "Front Desk", village: @village),
@@ -179,6 +197,15 @@ class CoverageProjectionTest < ActiveSupport::TestCase
     assert_equal 0,        covered_entry[:uncovered_minutes]
     assert_nil covered_entry[:first_gap]
     assert_equal bare_entry[:first_gap][:start], @slots.first.start_time
+  end
+
+  test "worst_state treats surplus as healthier than covered" do
+    @slots.each { |slot| band(slot, 1, 3) }
+    @slots.each { |slot| cover(slot, 2) }   # all above min
+    assert_equal :surplus, CoverageProjection.for(@cp, @day).worst_state
+
+    cover(@slots[0], 1)                     # one slot exactly at min
+    assert_equal :covered, CoverageProjection.for(@cp, @day).worst_state
   end
 
   test "summary orders same-state programs by uncovered minutes, worst first" do

--- a/test/system/schedule_board_test.rb
+++ b/test/system/schedule_board_test.rb
@@ -42,10 +42,11 @@ class ScheduleBoardSystemTest < ApplicationSystemTestCase
     first(".board-cell a").click
     assert_selector ".manage-panel", text: "Ham Exams"
 
-    # Raise needed to 2 for the day.
-    fill_in "Needed today", with: 2
+    # Raise the coverage band to 2–3 for the day (#259: min covered, max cap).
+    fill_in "manage-min", with: 2
+    fill_in "manage-max", with: 3
     click_button "Save"
-    assert_text "Needed set to 2 for 8 slots"
+    assert_text "Coverage set to 2–3 for 8 slots"
 
     # Add Radio Ray 9:00-10:00.
     within ".manage-panel" do
@@ -78,5 +79,12 @@ class ScheduleBoardSystemTest < ApplicationSystemTestCase
 
     assert_selector ".board-cell .badge.text-bg-success", count: 1
     assert_selector ".board-cell .tick.covered", count: 8
+
+    # Over the minimum (#259): a min..max band with extra volunteers shows blue.
+    @cp.timeslots.each { |slot| slot.update_columns(min_volunteers: 1, max_volunteers: 2, current_volunteers_count: 2) }
+    visit conference_schedule_board_path(@conference)
+
+    assert_selector ".board-cell .badge.text-bg-primary", count: 1
+    assert_selector ".board-cell .tick.surplus", count: 8
   end
 end


### PR DESCRIPTION
## Summary

Splits the overloaded `max_volunteers` into a `[min, max]` coverage band (#259):

- **`min_volunteers`** is the new coverage target — a shift is **covered (green) exactly at min**
- **`max_volunteers`** stays the hard signup cap — volunteers **above min render blue (`:surplus`)**, and self-signup still closes at max

| Condition (`on` = current volunteers) | State | Color |
|---|---|---|
| `on == 0` | bare | red (unchanged) |
| `0 < on < min` | short | amber (unchanged) |
| `on == min` | covered | **green** |
| `on > min` | surplus | **blue** |

## Changes

- **Schema**: `min_volunteers` added to `timeslots`, `programs`, and `conference_programs` (nullable override), validated `1 <= min <= max`. Migration backfills `min = max`, so existing conferences keep today's behavior exactly. Plain-SQL `UPDATE` backfill for adapter portability; `schema.rb` stays PostgreSQL dialect.
- **`CoverageProjection`**: new `:surplus` state ranked healthiest; ticks expose both `needed:` (min) and `max:`; gaps key off min. Gaps close at min — the claim stack only advertises under-covered windows, while the min→max band stays claimable through normal signup.
- **UI**: blue "Extra" badge + blue ribbon ticks on the board and coverage cards; manage panel's "Needed today" became a Min/Max "Coverage today" pair; program / custom program / conference-program forms take min+max; cross-conference bulk update modal and `UpdateTimeslotCapacityJob` propagate both (job clamps stale mins when max drops below them, and stays compatible with pre-band queued jobs).
- **Reports/metrics**: unmanned-shifts report and dashboard filled/unfilled counts key off min; CSV gains Min Volunteers / Needed to Cover columns.

## Open questions from the issue — decisions taken

1. **Backfill**: `min = max` (behavior-preserving, the issue's safe choice)
2. **Green boundary**: green only exactly at min, blue above (as the request phrasing implies)
3. **Gap semantics**: gaps close at min; the surplus band is still claimable via self-signup but not advertised as needed
4. **Bulk editing**: band is settable per activity-day in the manage panel, and via program defaults/overrides + the bulk modal

## Testing

- TDD: red suite first (19 failing), then implementation
- `bin/rails test` — 983 runs, 0 failures
- `bin/rails test:system` — 33 runs, 0 failures (run with `CHROME_BINARY` escape hatch due to a stale local Chrome for Testing install)
- `bin/rubocop` — no offenses

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)