### PR TITLE
Swap-or-keep modal for conflicting shift signups (#267)

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -40,6 +40,8 @@ class ScheduleController < ApplicationController
                               .sort_by { |signup| signup.timeslot.start_time }
     @my_timeslot_ids = day_signups.map(&:timeslot_id).to_set
     @my_shift_ranges = group_signups_into_ranges(day_signups)
+
+    load_swap_confirmation if params[:confirm_swap].present?
   end
 
   # The coverage view moved to the main schedule URL when the grid retired
@@ -93,6 +95,30 @@ class ScheduleController < ApplicationController
 
   def set_conference
     @conference = Conference.find(params[:conference_id])
+  end
+
+  # Swap-or-keep confirmation (#267): a conflicting claim redirects here with
+  # ?confirm_swap=<start timeslot>&swap_minutes=. The conflicts are re-derived
+  # server-side rather than trusted from the URL; a stale or hand-edited link
+  # with no real conflict renders no modal.
+  def load_swap_confirmation
+    start_slot = Timeslot.joins(:conference_program)
+                         .where(conference_programs: { conference_id: @conference.id })
+                         .find_by(id: params[:confirm_swap])
+    minutes = params[:swap_minutes].to_i
+    return if start_slot.nil? || minutes <= 0
+
+    end_time = start_slot.start_time + minutes.minutes
+    conflicts = VolunteerSignup.conflicting_for(
+      current_user, start_slot.conference_program, start_slot.start_time, end_time
+    ).to_a
+    return if conflicts.empty?
+
+    @swap_start_slot = start_slot
+    @swap_minutes = minutes
+    @swap_end_time = end_time
+    @swap_program_name = start_slot.conference_program.program.name
+    @swap_conflict_ranges = group_signups_into_ranges(conflicts)
   end
 
   # Manage-panel data for one activity+day. Denies activity leads reaching for

--- a/app/controllers/volunteer_signups_controller.rb
+++ b/app/controllers/volunteer_signups_controller.rb
@@ -62,6 +62,29 @@ class VolunteerSignupsController < ApplicationController
     # Filter to timeslots user isn't already signed up for
     timeslots_to_signup = timeslots.reject { |ts| existing_signup_ids.include?(ts.id) }
 
+    # Time conflicts with other shifts (#267): don't silently fail — send the
+    # volunteer to the schedule's swap-or-keep confirmation modal. The modal
+    # posts back here with replace_conflicts=1 to swap.
+    conflicting_signups = VolunteerSignup.conflicting_for(
+      current_user, conference_program, start_timeslot.start_time, end_time
+    ).to_a
+    if conflicting_signups.any? && params[:replace_conflicts] != "1"
+      redirect_to conference_schedule_path(
+        @conference,
+        day: params[:return_day].presence || start_timeslot.start_time.to_date.iso8601,
+        confirm_swap: start_timeslot.id, swap_minutes: requested_minutes
+      )
+      return
+    end
+
+    # Everything requested is already theirs: say so instead of celebrating a
+    # zero-shift signup (#267).
+    if timeslots_to_signup.empty?
+      redirect_to signup_return_path(conference_schedule_path(@conference)),
+                  alert: "You're already signed up for this window — nothing was changed."
+      return
+    end
+
     # Check if any timeslot is full
     full_timeslots = timeslots_to_signup.select(&:full?)
     if full_timeslots.any?
@@ -70,21 +93,34 @@ class VolunteerSignupsController < ApplicationController
       return
     end
 
-    # Create signups in a transaction
+    # Swap atomically: cancel the conflicting shifts and create the new ones in
+    # one transaction, so a failed signup leaves the old shifts untouched.
+    # (ActiveRecord::Rollback is swallowed by the transaction block, so the
+    # failure must be carried out via a local — previously it fell through to
+    # the success notice, the "signed up for 0 shifts" bug.)
     created_signups = []
+    failure_message = nil
     ActiveRecord::Base.transaction do
+      conflicting_signups.each(&:destroy!)
       timeslots_to_signup.each do |timeslot|
         signup = VolunteerSignup.new(user: current_user, timeslot: timeslot)
         if signup.save
           created_signups << signup
         else
-          raise ActiveRecord::Rollback, signup.errors.full_messages.join(", ")
+          failure_message = signup.errors.full_messages.join(", ")
+          raise ActiveRecord::Rollback
         end
       end
     end
 
+    if failure_message
+      redirect_to signup_return_path(conference_schedule_path(@conference)),
+                  alert: "Could not sign up: #{failure_message}. Your existing shifts are unchanged."
+      return
+    end
+
     # Send single consolidated notification for all signups
-    NotificationService.notify_shift_signups(user: current_user, signups: created_signups) if created_signups.any?
+    NotificationService.notify_shift_signups(user: current_user, signups: created_signups)
 
     created_count = created_signups.size
     total_minutes = created_count * 15
@@ -93,8 +129,12 @@ class VolunteerSignupsController < ApplicationController
     duration_str = hours > 0 ? "#{hours} hour#{'s' if hours > 1}" : ""
     duration_str += " #{minutes} minutes" if minutes > 0
 
-    redirect_to signup_return_path(conference_volunteer_signups_path(@conference)),
-                notice: "Successfully signed up for #{created_count} shifts (#{duration_str.strip})."
+    notice = "Successfully signed up for #{created_count} shifts (#{duration_str.strip})."
+    if conflicting_signups.any?
+      notice = "Cancelled #{conflicting_signups.size} conflicting shift#{'s' if conflicting_signups.size != 1}. #{notice}"
+    end
+
+    redirect_to signup_return_path(conference_volunteer_signups_path(@conference)), notice: notice
   end
 
   def destroy

--- a/app/models/volunteer_signup.rb
+++ b/app/models/volunteer_signup.rb
@@ -19,6 +19,23 @@ class VolunteerSignup < ApplicationRecord
   after_create :increment_timeslot_count
   after_destroy :decrement_timeslot_count
 
+  # The user's signups that clash in time with a requested window (#267):
+  # anything overlapping [start_time, end_time) except signups on the window's
+  # own slots — those are extensions of an existing shift, not conflicts.
+  # Ordered by start time for display. Shared by the bulk-claim path and the
+  # swap-confirmation modal so both always agree on what conflicts.
+  def self.conflicting_for(user, conference_program, start_time, end_time)
+    window_slot_ids = conference_program.timeslots
+                                        .where("start_time >= ? AND start_time < ?", start_time, end_time)
+                                        .select(:id)
+    user.volunteer_signups
+        .joins(:timeslot)
+        .where("timeslots.start_time < ? AND timeslots.end_time > ?", end_time, start_time)
+        .where.not(timeslot_id: window_slot_ids)
+        .includes(timeslot: { conference_program: :program })
+        .order("timeslots.start_time")
+  end
+
   private
 
   def no_overlapping_signups

--- a/app/views/schedule/_swap_conflict_modal.html.erb
+++ b/app/views/schedule/_swap_conflict_modal.html.erb
@@ -1,0 +1,49 @@
+<%# Swap-or-keep conflict modal (#267): statically shown, opened by a plain
+    redirect carrying ?confirm_swap&swap_minutes (same pattern as the board's
+    manage panel). "Keep" and the close button are links that drop the params;
+    "Swap" re-posts the claim with replace_conflicts=1. %>
+<% plural = @swap_conflict_ranges.size > 1 %>
+<div class="modal fade show d-block swap-conflict-modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="swap-conflict-title">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 class="modal-title h5" id="swap-conflict-title">You're already scheduled then</h2>
+        <%= link_to "", conference_schedule_path(@conference, day: @day.iso8601), class: "btn-close", "aria-label": "Close" %>
+      </div>
+      <div class="modal-body">
+        <p>
+          You asked to cover <strong><%= @swap_program_name %></strong> on
+          <%= @swap_start_slot.start_time.strftime("%A, %B %-d") %> from
+          <%= @swap_start_slot.start_time.strftime("%-l:%M %p") %> to <%= @swap_end_time.strftime("%-l:%M %p") %>,
+          but that overlaps <%= plural ? "shifts" : "a shift" %> you're already signed up for:
+        </p>
+        <ul class="list-group mb-3">
+          <% @swap_conflict_ranges.each do |range| %>
+            <li class="list-group-item d-flex justify-content-between">
+              <span><%= range[:program_name] %></span>
+              <span class="text-muted"><%= range[:starts_at].strftime("%-l:%M %p") %> – <%= range[:ends_at].strftime("%-l:%M %p") %></span>
+            </li>
+          <% end %>
+        </ul>
+        <p class="mb-0">
+          You can cancel the conflicting shift<%= "s" if plural %> and take the new one instead,
+          or keep your schedule exactly as it is.
+        </p>
+      </div>
+      <div class="modal-footer">
+        <%= link_to "Keep my current shifts", conference_schedule_path(@conference, day: @day.iso8601),
+            class: "btn btn-outline-secondary" %>
+        <%= form_with url: bulk_create_conference_volunteer_signups_path(@conference), method: :post,
+                      data: { turbo: false }, class: "d-inline" do %>
+          <input type="hidden" name="timeslot_id" value="<%= @swap_start_slot.id %>">
+          <input type="hidden" name="duration_minutes" value="<%= @swap_minutes %>">
+          <input type="hidden" name="replace_conflicts" value="1">
+          <input type="hidden" name="return_to" value="coverage">
+          <input type="hidden" name="return_day" value="<%= @day.iso8601 %>">
+          <button type="submit" class="btn btn-primary">Cancel conflicting shift<%= "s" if plural %> and sign up</button>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal-backdrop fade show"></div>

--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -119,4 +119,6 @@
       </div>
     <% end %>
   </div>
+
+  <%= render "swap_conflict_modal" if @swap_conflict_ranges.present? %>
 </div>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -28,6 +28,38 @@ end
 Selenium::WebDriver::Remote::Response.prepend(RetryableStaleInspectorNode)
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  # Chrome 150's other click hazard (sibling of the stale-inspector race
+  # above, see #241): after the first Turbo Drive body swap of a session,
+  # chromedriver's native click dispatch goes dead — every further click is
+  # silently dropped (no error, no event) even though the element is visible
+  # and correctly positioned. JS-dispatched clicks are unaffected. So: click
+  # natively once, and if the expected effect doesn't appear, re-dispatch the
+  # click through JS and wait again. Keep `wait` generous for clicks that
+  # submit forms, so a slow in-flight POST isn't double-submitted.
+  def click_expecting(element, effect_selector = nil, text: nil, count: nil, gone: nil, wait: 3)
+    element.click
+    return if click_effect?(effect_selector, text: text, count: count, gone: gone, wait: wait)
+
+    page.execute_script("arguments[0].click()", element)
+    return if click_effect?(effect_selector, text: text, count: count, gone: gone, wait: wait)
+
+    flunk "expected #{(effect_selector || text || "#{gone} to disappear").inspect} after clicking #{element.inspect}"
+  end
+
+  private
+
+  def click_effect?(effect_selector, text:, count:, gone:, wait:)
+    if effect_selector
+      options = { wait: wait }
+      options[:count] = count if count
+      page.has_selector?(effect_selector, **options)
+    elsif gone
+      page.has_no_selector?(gone, wait: wait)
+    else
+      page.has_text?(text, wait: wait)
+    end
+  end
+
   # Use Chrome's modern headless mode. The legacy `:headless_chrome` mode
   # (--headless) has DOM/CDP inconsistencies on recent Chrome that intermittently
   # raise "Node with given id does not belong to the document" during Capybara
@@ -37,6 +69,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")
     options.add_argument("--disable-gpu")
+    options.add_argument("--force-device-scale-factor=1")
     # Escape hatch when selenium-manager picks the wrong local browser (e.g. a
     # stale "Chrome for Testing" install shadowing the real Chrome):
     #   CHROME_BINARY="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" bin/rails test:system

--- a/test/controllers/health_controller_test.rb
+++ b/test/controllers/health_controller_test.rb
@@ -3,19 +3,22 @@ require "test_helper"
 class HealthControllerTest < ActionDispatch::IntegrationTest
   setup do
     @original_demo_mode = ENV["DEMO_MODE"]
-    @timestamp_file = Rails.root.join("tmp", "demo_last_reset.txt")
-    @original_timestamp = File.read(@timestamp_file) if File.exist?(@timestamp_file)
+
+    # Parallel test workers share the filesystem, so the real
+    # tmp/demo_last_reset.txt would race across processes. Point DemoMode at a
+    # per-process file for the duration of each test.
+    @timestamp_file = Rails.root.join("tmp", "demo_last_reset_test_#{Process.pid}.txt")
+    DemoMode.singleton_class.alias_method :original_timestamp_file_path, :timestamp_file_path
+    file = @timestamp_file
+    DemoMode.define_singleton_method(:timestamp_file_path) { file }
   end
 
   teardown do
     ENV["DEMO_MODE"] = @original_demo_mode
 
-    # Restore or clean up timestamp file
-    if @original_timestamp
-      File.write(@timestamp_file, @original_timestamp)
-    elsif File.exist?(@timestamp_file)
-      File.delete(@timestamp_file)
-    end
+    DemoMode.singleton_class.alias_method :timestamp_file_path, :original_timestamp_file_path
+    DemoMode.singleton_class.remove_method :original_timestamp_file_path
+    File.delete(@timestamp_file) if File.exist?(@timestamp_file)
   end
 
   test "health check returns 200" do

--- a/test/controllers/schedule_coverage_test.rb
+++ b/test/controllers/schedule_coverage_test.rb
@@ -165,4 +165,66 @@ class ScheduleCoverageTest < ActionDispatch::IntegrationTest
     assert_redirected_to conference_schedule_path(@conference, day: @conference.start_date.iso8601)
     assert_match(/blocks/, flash[:alert])
   end
+
+  # --- swap confirmation modal (#267) ---
+
+  def swap_conflict_setup
+    @other_cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" } }
+    )
+    # I'm on Front Desk 9:00–9:30; the swap target is Ham Exams 9:00–10:00.
+    @other_cp.timeslots.order(:start_time).first(2).each do |slot|
+      VolunteerSignup.create!(user: @volunteer, timeslot: slot)
+    end
+    @target_start = @cp.timeslots.order(:start_time).first
+  end
+
+  test "confirm_swap renders the conflict modal with swap and keep choices" do
+    swap_conflict_setup
+
+    get conference_schedule_path(@conference, day: @conference.start_date.iso8601,
+                                              confirm_swap: @target_start.id, swap_minutes: 60)
+
+    assert_response :success
+    assert_select ".swap-conflict-modal" do
+      assert_select "*", text: /Front Desk/
+      assert_select "*", text: /Ham Exams/
+      assert_select "*", text: /9:00 AM\s*–\s*9:30 AM/
+      assert_select "form input[name=replace_conflicts][value='1']"
+      assert_select "form input[name=timeslot_id][value='#{@target_start.id}']"
+      assert_select "form input[name=duration_minutes][value='60']"
+      assert_select "a", text: /keep/i
+    end
+  end
+
+  test "confirm_swap without an actual conflict renders no modal" do
+    get conference_schedule_path(@conference, day: @conference.start_date.iso8601,
+                                              confirm_swap: @cp.timeslots.order(:start_time).first.id,
+                                              swap_minutes: 60)
+
+    assert_response :success
+    assert_select ".swap-conflict-modal", 0
+  end
+
+  test "confirm_swap ignores a timeslot from another conference" do
+    swap_conflict_setup
+    foreign_conference = Conference.create!(
+      village: @village, name: "Other Con",
+      start_date: Date.tomorrow, end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00", conference_hours_end: "17:00"
+    )
+    foreign_cp = ConferenceProgram.create!(
+      conference: foreign_conference,
+      program: Program.create!(name: "Foreign", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+
+    get conference_schedule_path(@conference, day: @conference.start_date.iso8601,
+                                              confirm_swap: foreign_cp.timeslots.first.id, swap_minutes: 60)
+
+    assert_response :success
+    assert_select ".swap-conflict-modal", 0
+  end
 end

--- a/test/controllers/volunteer_signups_controller_test.rb
+++ b/test/controllers/volunteer_signups_controller_test.rb
@@ -322,6 +322,115 @@ class VolunteerSignupsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # --- conflicting signups (#267): swap-or-keep instead of a green "0 shifts" ---
+
+  def build_run(conference_program, hour, count: 4, max: 2)
+    count.times.map do |i|
+      Timeslot.create!(
+        conference_program: conference_program,
+        start_time: Date.tomorrow.to_datetime + hour.hours + (i * 15).minutes,
+        max_volunteers: max
+      )
+    end
+  end
+
+  def conflict_setup
+    other_cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village)
+    )
+    @my_slots = build_run(other_cp, 11, count: 2)             # Front Desk 11:00–11:30
+    @my_signups = @my_slots.map { |slot| VolunteerSignup.create!(user: @volunteer, timeslot: slot) }
+    @target_slots = build_run(@conference_program, 11)        # Test Program 11:00–12:00
+  end
+
+  test "bulk create with the whole window already claimed alerts instead of a green zero-shift notice" do
+    slots = build_run(@conference_program, 11)
+    slots.each { |slot| VolunteerSignup.create!(user: @volunteer, timeslot: slot) }
+
+    sign_in @volunteer
+    assert_no_difference("VolunteerSignup.count") do
+      post bulk_create_conference_volunteer_signups_url(@conference), params: {
+        timeslot_id: slots.first.id,
+        duration_minutes: 60
+      }
+    end
+    assert_nil flash[:notice]
+    assert_match(/already signed up/i, flash[:alert])
+  end
+
+  test "bulk create with a cross-activity conflict redirects to swap confirmation instead of silently failing" do
+    conflict_setup
+
+    sign_in @volunteer
+    assert_no_difference([ "VolunteerSignup.count", "Notification.count" ]) do
+      post bulk_create_conference_volunteer_signups_url(@conference), params: {
+        timeslot_id: @target_slots.first.id,
+        duration_minutes: 60,
+        return_to: "coverage",
+        return_day: Date.tomorrow.iso8601
+      }
+    end
+    assert_redirected_to conference_schedule_path(
+      @conference, day: Date.tomorrow.iso8601,
+      confirm_swap: @target_slots.first.id, swap_minutes: 60
+    )
+  end
+
+  test "bulk create with replace_conflicts cancels the conflicting shifts and books the window" do
+    conflict_setup
+
+    sign_in @volunteer
+    assert_difference("VolunteerSignup.count", 2) do  # -2 old, +4 new
+      post bulk_create_conference_volunteer_signups_url(@conference), params: {
+        timeslot_id: @target_slots.first.id,
+        duration_minutes: 60,
+        replace_conflicts: "1"
+      }
+    end
+    assert_empty @volunteer.volunteer_signups.where(timeslot_id: @my_slots.map(&:id))
+    assert_equal @target_slots.map(&:id).sort, @volunteer.volunteer_signups.pluck(:timeslot_id).sort
+    assert_equal [ 0, 0 ], @my_slots.map { |slot| slot.reload.current_volunteers_count }
+    assert_equal [ 1, 1, 1, 1 ], @target_slots.map { |slot| slot.reload.current_volunteers_count }
+    assert_match(/4 shifts/, flash[:notice])
+  end
+
+  test "a failed swap keeps the existing shifts and sends no notification" do
+    conflict_setup
+    qualification = Qualification.create!(name: "Radio License", description: "FCC license", village: @village)
+    ProgramQualification.create!(program: @program, qualification: qualification)
+
+    sign_in @volunteer
+    assert_no_difference([ "VolunteerSignup.count", "Notification.count" ]) do
+      post bulk_create_conference_volunteer_signups_url(@conference), params: {
+        timeslot_id: @target_slots.first.id,
+        duration_minutes: 60,
+        replace_conflicts: "1"
+      }
+    end
+    assert_equal @my_slots.map(&:id).sort, @volunteer.volunteer_signups.pluck(:timeslot_id).sort,
+                 "the conflicting shifts must survive a failed swap"
+    assert_equal [ 1, 1 ], @my_slots.map { |slot| slot.reload.current_volunteers_count }
+    assert_nil flash[:notice]
+    assert_match(/qualification/i, flash[:alert])
+  end
+
+  test "bulk create surfaces validation failures instead of a green zero-shift notice" do
+    qualification = Qualification.create!(name: "Radio License", description: "FCC license", village: @village)
+    ProgramQualification.create!(program: @program, qualification: qualification)
+    slots = build_run(@conference_program, 11)
+
+    sign_in @volunteer
+    assert_no_difference([ "VolunteerSignup.count", "Notification.count" ]) do
+      post bulk_create_conference_volunteer_signups_url(@conference), params: {
+        timeslot_id: slots.first.id,
+        duration_minutes: 60
+      }
+    end
+    assert_nil flash[:notice]
+    assert_match(/qualification/i, flash[:alert])
+  end
+
   test "bulk create requires authentication" do
     timeslots = []
     2.times do |i|

--- a/test/models/demo_mode_test.rb
+++ b/test/models/demo_mode_test.rb
@@ -4,20 +4,23 @@ class DemoModeTest < ActiveSupport::TestCase
   setup do
     @original_demo_mode = ENV["DEMO_MODE"]
     @original_banner_text = ENV["DEMO_BANNER_TEXT"]
-    @timestamp_file = Rails.root.join("tmp", "demo_last_reset.txt")
-    @original_timestamp = File.read(@timestamp_file) if File.exist?(@timestamp_file)
+
+    # Parallel test workers share the filesystem, so the real
+    # tmp/demo_last_reset.txt would race across processes. Point DemoMode at a
+    # per-process file for the duration of each test.
+    @timestamp_file = Rails.root.join("tmp", "demo_last_reset_test_#{Process.pid}.txt")
+    DemoMode.singleton_class.alias_method :original_timestamp_file_path, :timestamp_file_path
+    file = @timestamp_file
+    DemoMode.define_singleton_method(:timestamp_file_path) { file }
   end
 
   teardown do
     ENV["DEMO_MODE"] = @original_demo_mode
     ENV["DEMO_BANNER_TEXT"] = @original_banner_text
 
-    # Restore or clean up timestamp file
-    if @original_timestamp
-      File.write(@timestamp_file, @original_timestamp)
-    elsif File.exist?(@timestamp_file)
-      File.delete(@timestamp_file)
-    end
+    DemoMode.singleton_class.alias_method :timestamp_file_path, :original_timestamp_file_path
+    DemoMode.singleton_class.remove_method :original_timestamp_file_path
+    File.delete(@timestamp_file) if File.exist?(@timestamp_file)
   end
 
   test "enabled? returns false by default" do
@@ -148,6 +151,8 @@ class DemoModeTest < ActiveSupport::TestCase
   end
 
   test "timestamp_file_path returns path in tmp directory" do
-    assert_equal Rails.root.join("tmp", "demo_last_reset.txt").to_s, DemoMode.timestamp_file_path.to_s
+    # setup stubs timestamp_file_path per test process; assert the real
+    # implementation through the alias it preserved.
+    assert_equal Rails.root.join("tmp", "demo_last_reset.txt").to_s, DemoMode.original_timestamp_file_path.to_s
   end
 end

--- a/test/system/coverage_timezone_test.rb
+++ b/test/system/coverage_timezone_test.rb
@@ -38,7 +38,8 @@ class CoverageTimezoneTest < ApplicationSystemTestCase
     visit conference_schedule_path(@conference)
     assert_selector "[data-coverage-ribbon-ready]"
 
-    first(".coverage-ribbon .tick.bare").click
+    click_expecting first(".coverage-ribbon .tick.bare"),
+                    "[data-coverage-ribbon-target='lengthOptions']"
     within "[data-coverage-ribbon-target='lengthOptions']" do
       find("button", text: "1h", exact_text: true).click
     end

--- a/test/system/schedule_coverage_test.rb
+++ b/test/system/schedule_coverage_test.rb
@@ -37,23 +37,34 @@ class ScheduleCoverageSystemTest < ApplicationSystemTestCase
     assert_text "Logout"
   end
 
+  # Claim Ham Exams 9:00–10:00 from its card, landing on the conflict modal
+  # (the caller has arranged an overlapping shift elsewhere).
+  def claim_ham_exams_window
+    within "#activity-#{@cp.id}" do
+      click_expecting first(".coverage-ribbon .tick.bare"),
+                      "[data-coverage-ribbon-target='claimPanel']:not([hidden])"
+      click_expecting find("[data-coverage-ribbon-target='lengthOptions'] button", text: "1h", exact_text: true),
+                      text: "Cover 9:00 AM"
+    end
+    click_expecting within("#activity-#{@cp.id}") { find("button:not([disabled])", text: /\ACover 9:00 AM/) },
+                    ".swap-conflict-modal", wait: 10
+  end
+
   test "claiming a window from the ribbon" do
     login_as @volunteer
     visit conference_schedule_path(@conference)
     assert_selector "[data-coverage-ribbon-ready]"
 
     # Tap the first tick, pick 1 hour, claim.
-    first(".coverage-ribbon .tick.bare").click
-    assert_selector "[data-coverage-ribbon-target='claimPanel']:not([hidden])"
-    within "[data-coverage-ribbon-target='lengthOptions']" do
-      find("button", text: "1h", exact_text: true).click
-    end
-    assert_selector "button:not([disabled])", text: /\ACover 9:00 AM/
-    find("button", text: /\ACover 9:00 AM/).click
+    click_expecting first(".coverage-ribbon .tick.bare"),
+                    "[data-coverage-ribbon-target='claimPanel']:not([hidden])"
+    click_expecting find("[data-coverage-ribbon-target='lengthOptions'] button", text: "1h", exact_text: true),
+                    text: "Cover 9:00 AM"
 
-    # Back on the coverage view with the window claimed. Wait on the flash
-    # first — the form POST + redirect can outlast the default Capybara wait.
-    assert_text "Successfully signed up for 4 shifts", wait: 10
+    # The form POST + redirect can outlast the default Capybara wait, so wait
+    # on the flash with a submit-sized window.
+    click_expecting find("button:not([disabled])", text: /\ACover 9:00 AM/),
+                    text: "Successfully signed up for 4 shifts", wait: 10
     assert_current_path conference_schedule_path(@conference, day: @conference.start_date.iso8601)
     assert_selector ".tick.covered", count: 4
     assert_selector ".tick.mine", count: 4
@@ -68,7 +79,8 @@ class ScheduleCoverageSystemTest < ApplicationSystemTestCase
     visit conference_schedule_path(@conference)
     assert_selector "[data-coverage-ribbon-ready]"
 
-    first(".coverage-ribbon .tick.bare").click
+    click_expecting first(".coverage-ribbon .tick.bare"),
+                    "[data-coverage-ribbon-target='claimPanel']:not([hidden])"
     within "[data-coverage-ribbon-target='lengthOptions']" do
       assert_selector "button", count: 1
       assert_selector "button", text: "30m", exact_text: true
@@ -87,13 +99,9 @@ class ScheduleCoverageSystemTest < ApplicationSystemTestCase
     login_as @volunteer
     visit conference_schedule_path(@conference)
 
-    within ".triage-list" do
-      assert_text "1:00 PM"
-      click_link "Cover"
-    end
-
     day2 = @conference.start_date + 1.day
-    assert_selector "[data-current-day='#{day2.iso8601}']"
+    within(".triage-list") { assert_text "1:00 PM" }
+    click_expecting find(".triage-list a", text: "Cover"), "[data-current-day='#{day2.iso8601}']"
     # The gap arrived pre-selected: claim panel open, button armed at 1:00 PM.
     assert_selector "[data-coverage-ribbon-target='claimPanel']:not([hidden])"
     assert_selector "button:not([disabled])", text: /\ACover 1:00 PM/
@@ -111,12 +119,10 @@ class ScheduleCoverageSystemTest < ApplicationSystemTestCase
     visit conference_schedule_path(@conference)
     assert_selector ".coverage-card", count: 2
 
-    click_link "Hide full activities"
-    assert_selector ".coverage-card", count: 1
+    click_expecting find_link("Hide full activities"), ".coverage-card", count: 1
     assert_no_text "Front Desk"
 
-    click_link "Show full activities"
-    assert_selector ".coverage-card", count: 2
+    click_expecting find_link("Show full activities"), ".coverage-card", count: 2
   end
 
   test "I'm around chips scope the triage list" do
@@ -130,10 +136,63 @@ class ScheduleCoverageSystemTest < ApplicationSystemTestCase
     assert_selector ".triage-strip", count: 2
 
     day2 = @conference.start_date + 1.day
-    within ".card", text: "Where you're needed" do
-      click_link day2.strftime("%a")
+    chip = within(".card", text: "Where you're needed") { find_link(day2.strftime("%a")) }
+    click_expecting chip, ".triage-strip", count: 1
+  end
+
+  test "claiming over an existing shift offers swap-or-keep and swaps" do
+    # I'm on Front Desk 9:00–9:30; claiming Ham Exams 9:00–10:00 conflicts.
+    front_desk = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+    front_desk.timeslots.order(:start_time).first(2).each do |slot|
+      VolunteerSignup.create!(user: @volunteer, timeslot: slot)
     end
-    assert_selector ".triage-strip", count: 1
+
+    login_as @volunteer
+    visit conference_schedule_path(@conference)
+    assert_selector "[data-coverage-ribbon-ready]"
+
+    claim_ham_exams_window
+
+    # The conflict modal explains the clash instead of a green "0 shifts".
+    # The two conflicting slots are contiguous, so they present as one shift.
+    within ".swap-conflict-modal" do
+      assert_text "Front Desk"
+      assert_text(/9:00 AM\s*–\s*9:30 AM/)
+    end
+    click_expecting within(".swap-conflict-modal") { find_button("Cancel conflicting shift and sign up") },
+                    text: "Cancelled 2 conflicting shifts", wait: 10
+
+    assert_text "Successfully signed up for 4 shifts"
+    assert_equal 4, @volunteer.volunteer_signups.count
+    assert_equal [ @cp.id ], @volunteer.volunteer_signups.joins(:timeslot)
+                                       .distinct.pluck(:conference_program_id)
+  end
+
+  test "keeping the current shifts from the conflict modal changes nothing" do
+    front_desk = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+    front_desk.timeslots.order(:start_time).first(2).each do |slot|
+      VolunteerSignup.create!(user: @volunteer, timeslot: slot)
+    end
+
+    login_as @volunteer
+    visit conference_schedule_path(@conference)
+    assert_selector "[data-coverage-ribbon-ready]"
+
+    claim_ham_exams_window
+
+    click_expecting within(".swap-conflict-modal") { find_link("Keep my current shifts") },
+                    gone: ".swap-conflict-modal"
+    assert_equal 2, @volunteer.volunteer_signups.count
+    assert_equal front_desk.timeslots.order(:start_time).first(2).map(&:id).sort,
+                 @volunteer.volunteer_signups.pluck(:timeslot_id).sort
   end
 
   test "switching days re-renders the stack" do
@@ -147,8 +206,7 @@ class ScheduleCoverageSystemTest < ApplicationSystemTestCase
     assert_selector ".coverage-ribbon .tick", count: 8
 
     day2 = @conference.start_date + 1.day
-    click_link day2.strftime("%a %-m/%-d")
-    assert_selector "[data-current-day='#{day2.iso8601}']"
+    click_expecting find_link(day2.strftime("%a %-m/%-d")), "[data-current-day='#{day2.iso8601}']"
     assert_selector ".coverage-ribbon .tick", count: 4
   end
 end


### PR DESCRIPTION
## Summary

Fixes the confusing green **"Successfully signed up for 0 shifts"** flash a villager got when claiming a window at a day/time they were already signed up for (#267). Conflicting claims now get a modal explaining the clash, with an explicit choice: **swap** (cancel the conflicting shift(s) and take the new window) or **keep** (change nothing).

## Root causes fixed

- **Exact-duplicate window**: already-claimed slots were silently filtered to an empty list, so the controller "succeeded" at creating zero signups → green "0 shifts" notice. Now flashes *"You're already signed up for this window — nothing was changed."* (Partial same-activity overlap still extends the shift, as before.)
- **Cross-activity time overlap**: the overlap validation raised `ActiveRecord::Rollback`, which the transaction block swallows — execution fell through to the same green notice. Worse, `created_signups` kept rolled-back records, so the flash overcounted and **confirmation notifications fired for shifts that didn't exist**. Failures are now carried out of the transaction and surfaced as alerts; notifications only fire for persisted signups.

## How the modal works

- `bulk_create` detects conflicts up front via the new shared `VolunteerSignup.conflicting_for` query (any of the user's signups overlapping the requested window, excluding the window's own slots) and redirects to the schedule with `?confirm_swap=<start slot>&swap_minutes=`.
- `schedule#show` **re-derives the conflicts server-side** (URL params are never trusted; a stale link renders no modal) and shows a statically-rendered Bootstrap modal — same plain-navigation pattern as the board's manage panel (#243), no new JS.
- **Swap** reposts the claim with `replace_conflicts=1`: cancels + creates in one transaction, so a failed swap (slot filled meanwhile, missing qualification) keeps the existing shifts untouched. Success flash: *"Cancelled N conflicting shift(s). Successfully signed up for…"*
- **Keep** is a link that drops the params — nothing changes.

## Test-infrastructure fixes shaken out by the new tests

- **`click_expecting` helper** (`ApplicationSystemTestCase`): chromedriver + Chrome 150 silently drops *all* native clicks after the first Turbo body swap of a session — diagnosed with element rects + `elementFromPoint` (element perfectly clickable; JS clicks work 100%). This broadens the #241 finding and is the permanent local environment now that the stale Chrome for Testing install is gone. The helper clicks natively once, then re-dispatches via JS if the expected effect never appears. Applied across the coverage/timezone system tests, which were flaky-to-failing before (now 5/5 + three consecutive green `test:all` runs).
- **Parallel-safe DemoMode/health tests**: the suite crossed minitest's 1000-test parallelization threshold (now 12 worker processes), and these tests shared the literal `tmp/demo_last_reset.txt` across workers. They now stub `DemoMode.timestamp_file_path` to a per-process file.

## Testing

- TDD: failing controller + modal-rendering tests first, then implementation
- New coverage: duplicate-window alert, conflict → confirm redirect, atomic swap, failed-swap rollback (old shifts survive, no notification), validation-failure alert, modal render/no-render/foreign-conference guard, plus end-to-end system tests for both swap and keep
- `bin/rails test:all` — 1026 runs, 0 failures, **three consecutive green runs**
- `bin/rubocop` — no offenses

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)