### PR TITLE
Sync all profile fields from OAuth on every login (#260)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,15 @@ APP_HOST=your-app-domain.com
 # OAUTH_UID_FIELD=sub
 # OAUTH_EMAIL_FIELD=email
 # OAUTH_NAME_FIELD=name
+# Optional profile mappings: which userinfo keys hold each profile field. All
+# mapped fields are refreshed from the provider on every login (provider wins,
+# including over locally-edited values). Leave a mapping unset to not sync that
+# field; values the provider omits never blank an existing field.
+# OAUTH_PHONE_FIELD=phone
+# OAUTH_SIGNAL_FIELD=signal
+# OAUTH_DISCORD_FIELD=discord
+# OAUTH_TWITTER_FIELD=twitter
+# OAUTH_CALLSIGN_FIELD=callsign
 # Role-based access control (optional): the userinfo claim holding the user's
 # roles (a list of strings), and a regex tested against each role. When the
 # regex is unset, any authenticated user may sign in. When set, a user must have

--- a/README.md
+++ b/README.md
@@ -23,6 +23,48 @@ Village volunteer scheduling software for hacker conference villages.
 
 Sass is pinned to version `1.94.2` in `package.json` to maintain consistency. Deprecation warnings from Bootstrap's SCSS files are suppressed using the `--quiet-deps` and `--silence-deprecation` flags in the build script. This prevents noise from third-party dependency warnings while still showing warnings from our own code.
 
+### OAuth / SSO Login
+
+Villagers can sign users in through your village's existing OAuth2 provider. Setting `OAUTH_CLIENT_ID` makes a "Sign in with &lt;provider&gt;" button appear on the login page. All settings are environment variables (see `.env.example` for the full annotated list):
+
+```bash
+OAUTH_CLIENT_ID=your-oauth-client-id
+OAUTH_CLIENT_SECRET=your-oauth-client-secret
+OAUTH_PROVIDER_NAME=SSO                     # display name shown on the button
+OAUTH_SITE=https://auth.example.org
+OAUTH_AUTHORIZE_URL=/oauth/authorize
+OAUTH_TOKEN_URL=/oauth/token
+OAUTH_USERINFO_URL=/oauth/userinfo
+OAUTH_SCOPE=shifts
+```
+
+#### Userinfo field mappings
+
+Providers shape their userinfo JSON differently, so each profile field is mapped to a userinfo key via an environment variable:
+
+| Variable | Maps to | Default |
+|----------|---------|---------|
+| `OAUTH_UID_FIELD` | unique account id | `sub` (the OIDC subject) |
+| `OAUTH_EMAIL_FIELD` | email (keys the account) | `email` |
+| `OAUTH_NAME_FIELD` | Display Name (`handle`) | `name` |
+| `OAUTH_PHONE_FIELD` | phone number | *unset — not synced* |
+| `OAUTH_SIGNAL_FIELD` | Signal handle | *unset — not synced* |
+| `OAUTH_DISCORD_FIELD` | Discord handle | *unset — not synced* |
+| `OAUTH_TWITTER_FIELD` | Twitter/X handle | *unset — not synced* |
+| `OAUTH_CALLSIGN_FIELD` | ham radio callsign | *unset — not synced* |
+
+**Sync semantics — the provider is the source of truth.** Every mapped field is refreshed from the provider on **every** login, not just the first — including the Display Name, so a locally-edited name is overwritten at next sign-in when the provider sends one. Two safety rules:
+
+- A mapping that is unset is simply not synced — the field stays fully user-editable in Villagers.
+- A value the provider omits (or sends blank) never blanks an existing field.
+
+#### Role-based access control (optional)
+
+```bash
+OAUTH_ROLES_CLAIM=roles                     # userinfo claim holding the user's roles
+OAUTH_ALLOWED_ROLES_REGEX=\Avillage_admin\z # sign-in requires >=1 matching role; unset = any authenticated user
+```
+
 ## Database Seeds
 
 The application includes seed data for development and testing. Run `bin/rails db:seed` to populate the database with test data.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,25 +46,40 @@ class User < ApplicationRecord
     !profile_complete?
   end
 
+  # Profile attributes refreshed from the OAuth provider's userinfo on every
+  # login (#260): attribute => auth.info key.
+  OAUTH_PROFILE_FIELDS = {
+    handle: :name,
+    phone: :phone,
+    signal: :signal,
+    discord: :discord,
+    twitter: :twitter,
+    callsign: :callsign
+  }.freeze
+
   # Find or create a user from an OmniAuth callback.
   # Resolution order: existing identity (provider + uid) -> existing account
   # with the same email (linked) -> brand new just-in-time provisioned user.
   # OAuth users are auto-confirmed since the provider vouches for the email.
+  #
+  # Every mapped profile field is refreshed from the provider on every login —
+  # the IdP is authoritative (#260 product decision), including over a
+  # locally-edited Display Name. Absent values never blank an existing field.
   def self.from_omniauth(auth)
     # Only match an existing identity by a present uid. A blank uid identifies
     # no one, so matching on it would collapse every blank-uid login onto the
     # first such account (callers should reject blank uids before this).
-    if auth.uid.present?
-      identity = find_by(provider: auth.provider, uid: auth.uid)
-      return identity if identity
+    user = auth.uid.present? ? find_by(provider: auth.provider, uid: auth.uid) : nil
+    user ||= find_or_initialize_by(email: auth.info.email).tap do |account|
+      account.provider = auth.provider
+      account.uid = auth.uid
     end
 
-    user = find_or_initialize_by(email: auth.info.email)
-    user.provider = auth.provider
-    user.uid = auth.uid
-    # Prefill the Display Name from the provider's name on first sign-in only;
-    # never overwrite a handle the volunteer has since chosen for themselves.
-    user.handle = auth.info.name if user.handle.blank? && auth.info.name.present?
+    OAUTH_PROFILE_FIELDS.each do |attribute, info_key|
+      value = auth.info[info_key]
+      user.public_send("#{attribute}=", value) if value.present?
+    end
+
     user.password = Devise.friendly_token[0, 32] if user.encrypted_password.blank?
     user.skip_confirmation! unless user.confirmed?
     user.save

--- a/lib/omniauth/strategies/villager_oauth.rb
+++ b/lib/omniauth/strategies/villager_oauth.rb
@@ -15,6 +15,15 @@ module OmniAuth
     #   OAUTH_EMAIL_FIELD    - userinfo key holding the email     (default: "email")
     #   OAUTH_NAME_FIELD     - userinfo key holding the name      (default: "name")
     #
+    # Optional profile mappings (#260) — no defaults, so an unset mapping means
+    # the field is simply not synced from the provider:
+    #
+    #   OAUTH_PHONE_FIELD    - userinfo key holding the phone number
+    #   OAUTH_SIGNAL_FIELD   - userinfo key holding the Signal handle
+    #   OAUTH_DISCORD_FIELD  - userinfo key holding the Discord handle
+    #   OAUTH_TWITTER_FIELD  - userinfo key holding the Twitter/X handle
+    #   OAUTH_CALLSIGN_FIELD - userinfo key holding the ham radio callsign
+    #
     # NOTE: this is scaffolding. Confirm the real endpoint paths and userinfo
     # JSON shape with the provider and adjust the ENV defaults below if needed.
     class VillagerOauth < OmniAuth::Strategies::OAuth2
@@ -32,7 +41,12 @@ module OmniAuth
       info do
         {
           email: raw_info[email_field],
-          name: raw_info[name_field]
+          name: raw_info[name_field],
+          phone: field_value("OAUTH_PHONE_FIELD"),
+          signal: field_value("OAUTH_SIGNAL_FIELD"),
+          discord: field_value("OAUTH_DISCORD_FIELD"),
+          twitter: field_value("OAUTH_TWITTER_FIELD"),
+          callsign: field_value("OAUTH_CALLSIGN_FIELD")
         }
       end
 
@@ -66,6 +80,13 @@ module OmniAuth
 
       def name_field
         ENV.fetch("OAUTH_NAME_FIELD", "name")
+      end
+
+      # Only read a userinfo key when its ENV mapping is configured; nil
+      # otherwise, so unmapped fields are never synced.
+      def field_value(env_key)
+        field = ENV[env_key]
+        field.present? ? raw_info[field] : nil
       end
     end
   end

--- a/test/models/user_omniauth_test.rb
+++ b/test/models/user_omniauth_test.rb
@@ -1,11 +1,11 @@
 require "test_helper"
 
 class UserOmniauthTest < ActiveSupport::TestCase
-  def auth_hash(uid: "uid-1", email: "newcomer@example.com", name: "New Comer")
+  def auth_hash(uid: "uid-1", email: "newcomer@example.com", name: "New Comer", **profile)
     OmniAuth::AuthHash.new(
       provider: "villager_oauth",
       uid: uid,
-      info: { email: email, name: name }
+      info: { email: email, name: name, **profile }
     )
   end
 
@@ -46,17 +46,65 @@ class UserOmniauthTest < ActiveSupport::TestCase
     assert_equal "Radio Ray", user.handle
   end
 
-  test "from_omniauth never overwrites a handle the volunteer has chosen" do
+  # --- profile sync (#260): the provider is the source of truth ---
+
+  test "from_omniauth refreshes the handle from the provider on every login" do
     chosen = User.new(email: "chosen@example.com", password: "password123", password_confirmation: "password123", handle: "MyChosenName")
     chosen.skip_confirmation!
     chosen.save!
 
-    # Same person signs in via OAuth (linked by email); the provider reports a
-    # different name, but their self-chosen Display Name must survive.
+    # Same person signs in via OAuth (linked by email); the IdP is
+    # authoritative (#260 product decision), so its name replaces the
+    # locally-chosen Display Name.
     linked = User.from_omniauth(auth_hash(uid: "uid-chosen", email: "chosen@example.com", name: "Provider Name"))
 
     assert_equal chosen.id, linked.id
-    assert_equal "MyChosenName", linked.reload.handle
+    assert_equal "Provider Name", linked.reload.handle
+  end
+
+  test "from_omniauth populates all mapped profile fields for a new user" do
+    user = User.from_omniauth(auth_hash(
+      uid: "uid-full",
+      phone: "+1 555 0100",
+      signal: "@newcomer.01",
+      discord: "newcomer#1234",
+      twitter: "@newcomer",
+      callsign: "W1AW"
+    ))
+
+    assert_equal "+1 555 0100",  user.phone
+    assert_equal "@newcomer.01", user.signal
+    assert_equal "newcomer#1234", user.discord
+    assert_equal "@newcomer",    user.twitter
+    assert_equal "W1AW",         user.callsign
+  end
+
+  test "from_omniauth refreshes profile fields for a returning identity" do
+    User.from_omniauth(auth_hash(uid: "uid-refresh", email: "refresh@example.com", phone: "+1 555 0100", callsign: "W1AW"))
+
+    returning = User.from_omniauth(auth_hash(
+      uid: "uid-refresh",
+      email: "refresh@example.com",
+      name: "Updated Name",
+      phone: "+1 555 0199",
+      callsign: "KD9XYZ"
+    ))
+
+    returning.reload
+    assert_equal "Updated Name", returning.handle
+    assert_equal "+1 555 0199",  returning.phone
+    assert_equal "KD9XYZ",       returning.callsign
+  end
+
+  test "from_omniauth leaves fields untouched when the provider omits them" do
+    user = User.from_omniauth(auth_hash(uid: "uid-keep", email: "keep@example.com", phone: "+1 555 0100"))
+    user.update!(discord: "locally-set#1")
+
+    again = User.from_omniauth(auth_hash(uid: "uid-keep", email: "keep@example.com", phone: nil, discord: nil))
+
+    again.reload
+    assert_equal "+1 555 0100",   again.phone,   "an absent value must not blank an existing field"
+    assert_equal "locally-set#1", again.discord
   end
 
   test "from_omniauth falls back to the email when the provider sends no name" do

--- a/test/models/villager_oauth_strategy_test.rb
+++ b/test/models/villager_oauth_strategy_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+# The ENV-driven userinfo field mappings of the VillagerOauth strategy (#260):
+# every profile field is optional and only read when its OAUTH_*_FIELD mapping
+# is configured.
+class VillagerOauthStrategyTest < ActiveSupport::TestCase
+  def strategy_with(userinfo)
+    OmniAuth::Strategies::VillagerOauth.new(nil).tap do |strategy|
+      strategy.instance_variable_set(:@raw_info, userinfo)
+    end
+  end
+
+  test "info maps email and name by default" do
+    info = strategy_with("email" => "vol@example.com", "name" => "Vol One").info
+
+    assert_equal "vol@example.com", info[:email]
+    assert_equal "Vol One", info[:name]
+  end
+
+  test "info maps the profile fields when their ENV mappings are configured" do
+    with_env(
+      "OAUTH_PHONE_FIELD" => "phone_number",
+      "OAUTH_SIGNAL_FIELD" => "signal_handle",
+      "OAUTH_DISCORD_FIELD" => "discord_tag",
+      "OAUTH_TWITTER_FIELD" => "twitter_handle",
+      "OAUTH_CALLSIGN_FIELD" => "ham_callsign"
+    ) do
+      info = strategy_with(
+        "phone_number" => "+1 555 0100",
+        "signal_handle" => "@vol.01",
+        "discord_tag" => "vol#1234",
+        "twitter_handle" => "@vol",
+        "ham_callsign" => "W1AW"
+      ).info
+
+      assert_equal "+1 555 0100", info[:phone]
+      assert_equal "@vol.01", info[:signal]
+      assert_equal "vol#1234", info[:discord]
+      assert_equal "@vol", info[:twitter]
+      assert_equal "W1AW", info[:callsign]
+    end
+  end
+
+  test "unconfigured profile fields are nil even when userinfo has likely keys" do
+    with_env(
+      "OAUTH_PHONE_FIELD" => nil,
+      "OAUTH_SIGNAL_FIELD" => nil,
+      "OAUTH_DISCORD_FIELD" => nil,
+      "OAUTH_TWITTER_FIELD" => nil,
+      "OAUTH_CALLSIGN_FIELD" => nil
+    ) do
+      info = strategy_with("phone" => "+1 555 0100", "callsign" => "W1AW").info
+
+      assert_nil info[:phone]
+      assert_nil info[:signal]
+      assert_nil info[:discord]
+      assert_nil info[:twitter]
+      assert_nil info[:callsign]
+    end
+  end
+
+  test "a configured mapping whose key is absent from userinfo yields nil" do
+    with_env("OAUTH_PHONE_FIELD" => "phone_number") do
+      assert_nil strategy_with("email" => "vol@example.com").info[:phone]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

OAuth sign-in previously synced almost nothing from the identity provider: only `email` and `name` were mapped, only `handle` was written, and only on first sign-in. Now **every mapped profile field is populated and refreshed on every login**, with the provider as the source of truth (#260).

## Changes

- **Strategy** (`lib/omniauth/strategies/villager_oauth.rb`): `info` now maps `phone`, `signal`, `discord`, `twitter`, and `callsign` from the provider's userinfo, each behind a new optional env mapping. A mapping that is unset means the key is never read and the field is never synced.
- **Model** (`User.from_omniauth`): both resolution paths (existing identity by provider+uid, and link-by-email / just-in-time provisioning) flow through one `OAUTH_PROFILE_FIELDS` loop that assigns every *present* value on every login. Previously the existing-identity path returned early with no sync at all.
- **Behavior change (deliberate, per the issue's product decision):** the old "never overwrite a handle the volunteer has chosen" guard is reversed. The IdP is authoritative, so a locally-edited Display Name is refreshed from the provider's name at next sign-in. Values the provider omits never blank an existing field.
- **Docs**: new **OAuth / SSO Login** section in the README (button setup, full field-mapping table, sync semantics, role gate) plus annotated entries in `.env.example` and the strategy header comment.

## 📋 For the next release notes (operator-facing)

> ### OAuth profile sync (#260)
> OAuth login now populates and **refreshes the whole volunteer profile on every sign-in** — the identity provider is the source of truth.
>
> **New environment variables** (all optional; unset = that field is not synced and stays user-editable):
>
> | Variable | Maps userinfo key → field |
> |----------|---------------------------|
> | `OAUTH_PHONE_FIELD` | phone number |
> | `OAUTH_SIGNAL_FIELD` | Signal handle |
> | `OAUTH_DISCORD_FIELD` | Discord handle |
> | `OAUTH_TWITTER_FIELD` | Twitter/X handle |
> | `OAUTH_CALLSIGN_FIELD` | ham radio callsign |
>
> **⚠️ Behavior change:** the Display Name is now refreshed from the provider's name field on **every** login (previously first sign-in only, and locally-chosen names were never overwritten). If your volunteers curate their Display Names in Villagers rather than in the IdP, be aware the IdP now wins at each sign-in. Values the provider omits never blank an existing field.
>
> No migrations; configuration-only. See the README's *OAuth / SSO Login* section for the full mapping reference.

## Tests

TDD (failing tests first), covering:
- New user: all mapped fields populated from userinfo
- Returning identity: fields refreshed on later logins (provider wins, including over a locally-edited Display Name)
- Absent userinfo values / unset mappings: existing fields left untouched, never blanked
- New strategy unit test for the ENV-driven mappings (configured, unconfigured, missing-key cases)
- All pre-existing `from_omniauth` and OAuth callback/access-control tests pass

`bin/rails test` — 990 runs, 0 failures · `bin/rubocop` — no offenses. (Local `test:all` shows only the pre-existing environment flakes fixed by #268 — demo-file parallelism races and the Chrome 150 dropped-click issue — none OAuth-related; CI is green.)

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)