### PR TITLE
Optional profile columns on the shift assignments report (#261)

### DIFF
--- a/app/controllers/conference_reports_controller.rb
+++ b/app/controllers/conference_reports_controller.rb
@@ -6,11 +6,23 @@ class ConferenceReportsController < ApplicationController
   before_action :set_conference
   before_action :authorize_reports
 
+  # Optional volunteer profile columns for the shift assignments report
+  # (#261): whitelisted param key => column header. Selected via columns[]
+  # checkboxes; anything not listed here is ignored.
+  PROFILE_COLUMNS = {
+    "callsign" => "Callsign",
+    "phone" => "Phone",
+    "twitter" => "Twitter",
+    "signal" => "Signal",
+    "discord" => "Discord"
+  }.freeze
+
   def index
     @programs = @conference.programs
   end
 
   def shift_assignments
+    @profile_columns = PROFILE_COLUMNS.keys & Array(params[:columns]).map(&:to_s)
     @timeslots = filtered_timeslots
                  .includes(:volunteer_signups, :users, conference_program: :program)
                  .where("timeslots.current_volunteers_count > 0")
@@ -64,7 +76,8 @@ class ConferenceReportsController < ApplicationController
 
   def send_shift_assignments_csv
     csv_data = CSV.generate(headers: true) do |csv|
-      csv << [ "Date", "Time", "Program", "Volunteer Name", "Volunteer Email" ]
+      csv << [ "Date", "Time", "Program", "Volunteer Name", "Volunteer Email",
+               *@profile_columns.map { |column| PROFILE_COLUMNS[column] } ]
 
       @timeslots.each do |timeslot|
         timeslot.users.each do |user|
@@ -73,7 +86,8 @@ class ConferenceReportsController < ApplicationController
             "#{timeslot.start_time.strftime('%H:%M')} - #{timeslot.end_time.strftime('%H:%M')}",
             timeslot.conference_program.program.name,
             user.display_name,
-            user.email
+            user.email,
+            *@profile_columns.map { |column| user.public_send(column) }
           ]
         end
       end

--- a/app/javascript/controllers/auto_submit_controller.js
+++ b/app/javascript/controllers/auto_submit_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Submits the form it is attached to as soon as a wired control changes,
+// so toggles apply without a separate "Apply" click. Attach to a form and
+// add data-action="change->auto-submit#submit" to the controls that should
+// apply immediately.
+export default class extends Controller {
+  submit() {
+    this.element.requestSubmit()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import AutoSubmitController from "./auto_submit_controller"
+application.register("auto-submit", AutoSubmitController)
+
 import BulkCapacityUpdateController from "./bulk_capacity_update_controller"
 application.register("bulk-capacity-update", BulkCapacityUpdateController)
 

--- a/app/views/conference_reports/shift_assignments.html.erb
+++ b/app/views/conference_reports/shift_assignments.html.erb
@@ -14,7 +14,7 @@
       <h5 class="mb-0">Filters</h5>
     </div>
     <div class="card-body">
-      <%= form_with url: shift_assignments_conference_reports_path(@conference), method: :get, local: true, class: "row g-3" do %>
+      <%= form_with url: shift_assignments_conference_reports_path(@conference), method: :get, local: true, class: "row g-3", data: { controller: "auto-submit" } do %>
         <div class="col-md-4">
           <label for="program_id" class="form-label">Program</label>
           <%= select_tag :program_id,
@@ -31,13 +31,15 @@
           <%= link_to "Clear", shift_assignments_conference_reports_path(@conference), class: "btn btn-outline-secondary" %>
         </div>
         <%# Optional profile columns (#261): shown in the table and included in
-            the CSV export. Nothing checked = the classic report. %>
+            the CSV export. Toggling applies immediately (auto-submit);
+            nothing checked = the classic report. %>
         <div class="col-12">
           <label class="form-label mb-1">Extra columns</label>
           <div class="d-flex flex-wrap gap-3">
             <% ConferenceReportsController::PROFILE_COLUMNS.each do |key, label| %>
               <div class="form-check">
-                <%= check_box_tag "columns[]", key, @profile_columns.include?(key), id: "column-#{key}", class: "form-check-input" %>
+                <%= check_box_tag "columns[]", key, @profile_columns.include?(key), id: "column-#{key}",
+                    class: "form-check-input", data: { action: "change->auto-submit#submit" } %>
                 <label class="form-check-label" for="column-<%= key %>"><%= label %></label>
               </div>
             <% end %>

--- a/app/views/conference_reports/shift_assignments.html.erb
+++ b/app/views/conference_reports/shift_assignments.html.erb
@@ -6,7 +6,7 @@
       <% end %>
       <h1 class="mb-0">Shift Assignments: <%= @conference.name %></h1>
     </div>
-    <%= link_to "Export CSV", shift_assignments_conference_reports_path(@conference, format: :csv, program_id: params[:program_id], date: params[:date]), class: "btn btn-success" %>
+    <%= link_to "Export CSV", shift_assignments_conference_reports_path(@conference, format: :csv, program_id: params[:program_id], date: params[:date], columns: @profile_columns.presence), class: "btn btn-success" %>
   </div>
 
   <div class="card shadow-sm mb-4">
@@ -30,6 +30,19 @@
           <%= submit_tag "Apply Filters", class: "btn btn-primary me-2" %>
           <%= link_to "Clear", shift_assignments_conference_reports_path(@conference), class: "btn btn-outline-secondary" %>
         </div>
+        <%# Optional profile columns (#261): shown in the table and included in
+            the CSV export. Nothing checked = the classic report. %>
+        <div class="col-12">
+          <label class="form-label mb-1">Extra columns</label>
+          <div class="d-flex flex-wrap gap-3">
+            <% ConferenceReportsController::PROFILE_COLUMNS.each do |key, label| %>
+              <div class="form-check">
+                <%= check_box_tag "columns[]", key, @profile_columns.include?(key), id: "column-#{key}", class: "form-check-input" %>
+                <label class="form-check-label" for="column-<%= key %>"><%= label %></label>
+              </div>
+            <% end %>
+          </div>
+        </div>
       <% end %>
     </div>
   </div>
@@ -45,6 +58,9 @@
               <th>Program</th>
               <th>Volunteer</th>
               <th>Email</th>
+              <% @profile_columns.each do |column| %>
+                <th><%= ConferenceReportsController::PROFILE_COLUMNS[column] %></th>
+              <% end %>
             </tr>
           </thead>
           <tbody>
@@ -56,6 +72,9 @@
                   <td><%= timeslot.conference_program.program.name %></td>
                   <td><%= user.display_name %></td>
                   <td><%= user.email %></td>
+                  <% @profile_columns.each do |column| %>
+                    <td><%= user.public_send(column) %></td>
+                  <% end %>
                 </tr>
               <% end %>
             <% end %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -48,10 +48,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   private
 
+  # Effect forms: a selector (optionally narrowed by text:/count:), bare
+  # text: (page-wide), or gone: (selector must disappear).
   def click_effect?(effect_selector, text:, count:, gone:, wait:)
     if effect_selector
       options = { wait: wait }
       options[:count] = count if count
+      options[:text] = text if text
       page.has_selector?(effect_selector, **options)
     elsif gone
       page.has_no_selector?(gone, wait: wait)

--- a/test/controllers/conference_reports_controller_test.rb
+++ b/test/controllers/conference_reports_controller_test.rb
@@ -91,6 +91,65 @@ class ConferenceReportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "text/csv", response.content_type.split(";").first
   end
 
+  # Optional profile columns (#261)
+  test "shift assignments CSV includes requested profile columns" do
+    @regular_user.update!(handle: "Radio Ray", callsign: "W1AW", discord: "ray#1234", signal: "@ray.01")
+    VolunteerSignup.create!(user: @regular_user, timeslot: @conference_program.timeslots.first)
+
+    sign_in @village_admin
+    get shift_assignments_conference_reports_path(@conference, format: :csv, columns: [ "discord", "callsign", "signal" ])
+
+    # Columns render in canonical order regardless of param order.
+    header, row = response.body.lines.first(2)
+    assert_match(/Callsign,Signal,Discord/, header)
+    refute_match(/Phone/, header)
+    assert_match(/W1AW,@ray.01,ray#1234/, row)
+  end
+
+  test "shift assignments CSV keeps its default columns when none are requested" do
+    VolunteerSignup.create!(user: @regular_user, timeslot: @conference_program.timeslots.first)
+
+    sign_in @village_admin
+    get shift_assignments_conference_reports_path(@conference, format: :csv)
+
+    header = response.body.lines.first
+    assert_match(/Date,Time,Program,Volunteer Name,Volunteer Email/, header)
+    refute_match(/Callsign|Phone|Twitter|Signal|Discord/, header)
+  end
+
+  test "shift assignments ignores unknown column names" do
+    VolunteerSignup.create!(user: @regular_user, timeslot: @conference_program.timeslots.first)
+
+    sign_in @village_admin
+    get shift_assignments_conference_reports_path(@conference, format: :csv, columns: [ "encrypted_password", "callsign" ])
+
+    header = response.body.lines.first
+    assert_match(/Callsign/, header)
+    refute_match(/password/i, header)
+  end
+
+  test "shift assignments HTML table shows the selected profile columns" do
+    @regular_user.update!(phone: "+1 555 0100", twitter: "@ray")
+    VolunteerSignup.create!(user: @regular_user, timeslot: @conference_program.timeslots.first)
+
+    sign_in @village_admin
+    get shift_assignments_conference_reports_path(@conference, columns: [ "phone", "twitter" ])
+
+    assert_response :success
+    assert_select "th", text: "Phone"
+    assert_select "th", text: "Twitter"
+    assert_select "td", text: "+1 555 0100"
+    assert_select "td", text: "@ray"
+    assert_select "th", text: "Callsign", count: 0
+  end
+
+  test "shift assignments Export CSV link carries the selected columns" do
+    sign_in @village_admin
+    get shift_assignments_conference_reports_path(@conference, columns: [ "discord" ])
+
+    assert_select "a[href*='columns%5B%5D=discord']", text: "Export CSV"
+  end
+
   # Unmanned shifts report
   test "unmanned shifts report shows shifts below capacity" do
     sign_in @village_admin

--- a/test/system/shift_assignments_report_test.rb
+++ b/test/system/shift_assignments_report_test.rb
@@ -1,0 +1,58 @@
+require "application_system_test_case"
+
+# The shift assignments report's optional profile columns (#261): toggling a
+# checkbox applies immediately — no separate "Apply Filters" click needed.
+class ShiftAssignmentsReportTest < ApplicationSystemTestCase
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+    cp = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Ham Exams", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "10:00" } }
+    )
+    @volunteer = User.create!(
+      email: "ray@example.com", password: "password123", password_confirmation: "password123",
+      handle: "Radio Ray", discord: "ray#1234", callsign: "W1AW"
+    )
+    VolunteerSignup.create!(user: @volunteer, timeslot: cp.timeslots.first)
+
+    @admin = User.create!(email: "admin@example.com", password: "password123",
+                          password_confirmation: "password123", handle: "Admin")
+    UserRole.create!(user: @admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+  end
+
+  def login_as(user)
+    visit new_user_session_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    click_button "Log in"
+    assert_text "Logout"
+  end
+
+  test "checking an extra column applies it immediately" do
+    login_as @admin
+    visit shift_assignments_conference_reports_path(@conference)
+    assert_selector "td", text: "Radio Ray"
+    assert_no_selector "th", text: "Discord"
+
+    # Submit-sized waits: a toggle both submits the form AND is un-done by the
+    # helper's JS-fallback click, so a premature retry would revert it.
+    click_expecting find("#column-discord"), "th", text: "Discord", wait: 10
+    assert_selector "td", text: "ray#1234"
+
+    # The Export CSV link follows the selection.
+    assert_selector "a[href*='columns%5B%5D=discord']", text: "Export CSV"
+
+    # Unchecking applies immediately too.
+    click_expecting find("#column-discord"), "th", text: "Discord", count: 0, wait: 10
+    assert_no_selector "td", text: "ray#1234"
+  end
+end


### PR DESCRIPTION
## Summary

The volunteer (shift assignments) report can now optionally expose all volunteer profile data (#261). An **"Extra columns"** checkbox group in the report's filter card toggles **Callsign, Phone, Twitter, Signal, and Discord** into the HTML table, and the **Export CSV** link carries the selection so the download always matches the screen.

The motivating use case from the issue works out of the box: check *Discord* and *Signal* and hit Export CSV — you have the handles needed to add volunteers to the applicable chats.

## Behavior

- **Checkboxes apply immediately** — toggling one auto-submits the filter form (small reusable `auto-submit` Stimulus controller), so the table and CSV link update without pressing "Apply Filters". The button remains for the Program/Date filters, where mid-edit auto-submit would misfire.
- Nothing checked → the classic `Date / Time / Program / Volunteer / Email` report, unchanged.
- Selections live in the URL (`columns[]=`), so a configured report is shareable and bookmarkable.
- Column keys are **whitelisted server-side** (`PROFILE_COLUMNS`) — hand-edited URLs like `columns[]=encrypted_password` are silently ignored — and render in a stable canonical order regardless of param order.

## Scope notes

- The unmanned-shifts report is untouched (it has no volunteer data).
- No persistence of column preferences — the URL is the state. If the issue's broader ask (column toggles on every report) materializes later, the whitelist pattern generalizes.

## Testing

- TDD: failing tests first, covering CSV with/without selected columns, whitelist enforcement, HTML table rendering, the Export CSV link carrying the selection, and a system test proving check/uncheck applies immediately end-to-end
- `bin/rails test:all` — 1039 runs, 0 failures (system tests included)
- `bin/rubocop` — no offenses

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)