### PR TITLE
Add UI for village admins to grant/revoke the village admin role (#263)

### DIFF
--- a/app/controllers/village_admin_roles_controller.rb
+++ b/app/controllers/village_admin_roles_controller.rb
@@ -1,0 +1,44 @@
+# Grant/revoke the village admin role from the managed-user page (#263).
+# Only village admins may use either action; revoking is refused when it
+# would leave the village with no admin at all.
+class VillageAdminRolesController < ApplicationController
+  before_action :set_user
+
+  def create
+    authorize @user, :manage_village_admin_role?, policy_class: UserPolicy
+
+    role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.find_or_create_by!(user: @user, role: role)
+
+    redirect_to managed_user_path(@user), notice: "#{@user.display_name} is now a village admin."
+  end
+
+  def destroy
+    authorize @user, :manage_village_admin_role?, policy_class: UserPolicy
+
+    user_role = @user.user_roles.joins(:role).find_by(roles: { name: Role::VILLAGE_ADMIN })
+    unless user_role
+      redirect_to managed_user_path(@user), notice: "#{@user.display_name} is not a village admin."
+      return
+    end
+
+    if last_village_admin_role?(user_role)
+      redirect_to managed_user_path(@user),
+                  alert: "Cannot revoke the last village admin — grant the role to someone else first."
+      return
+    end
+
+    user_role.destroy!
+    redirect_to managed_user_path(@user), notice: "Village admin role revoked from #{@user.display_name}."
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:managed_user_id])
+  end
+
+  def last_village_admin_role?(user_role)
+    UserRole.joins(:role).where(roles: { name: Role::VILLAGE_ADMIN }).where.not(id: user_role.id).none?
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -19,6 +19,10 @@ class UserPolicy < ApplicationPolicy
     user&.village_admin?
   end
 
+  def manage_village_admin_role?
+    user&.village_admin?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       if user&.village_admin?

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -57,6 +57,28 @@
             <span class="badge bg-secondary">Volunteer</span>
           <% end %>
 
+          <%# Grant/revoke the village admin role (#263). Revoking the last
+              remaining admin is refused server-side. %>
+          <% if policy(@user).manage_village_admin_role? %>
+            <div class="mt-2">
+              <% if @user.village_admin? %>
+                <%= form_with url: managed_user_village_admin_role_path(@user), method: :delete do %>
+                  <button type="submit" class="btn btn-sm btn-outline-danger"
+                          data-turbo-confirm="Revoke the village admin role from <%= @user.display_name %>?">
+                    Revoke Village Admin
+                  </button>
+                <% end %>
+              <% else %>
+                <%= form_with url: managed_user_village_admin_role_path(@user), method: :post do %>
+                  <button type="submit" class="btn btn-sm btn-outline-primary"
+                          data-turbo-confirm="Make <%= @user.display_name %> a village admin? They will be able to manage everything in the village.">
+                    Make Village Admin
+                  </button>
+                <% end %>
+              <% end %>
+            </div>
+          <% end %>
+
           <hr>
 
           <div class="card bg-light">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,8 @@ Rails.application.routes.draw do
   resources :qualifications
   resources :managed_users, controller: "users", path: "manage/users" do
     resources :user_qualifications, only: [ :create, :destroy ]
+    # Grant/revoke the village admin role (#263)
+    resource :village_admin_role, only: [ :create, :destroy ]
   end
 
   # Leaderboard

--- a/test/controllers/village_admin_roles_controller_test.rb
+++ b/test/controllers/village_admin_roles_controller_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+
+# Granting/revoking the village admin role from the managed-user page (#263).
+class VillageAdminRolesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @admin = create_user("admin@example.com")
+    @admin_role = Role.find_or_create_by!(name: Role::VILLAGE_ADMIN)
+    UserRole.create!(user: @admin, role: @admin_role)
+    @volunteer = create_user("volunteer@example.com")
+  end
+
+  def create_user(email)
+    user = User.new(email: email, password: "password123", password_confirmation: "password123")
+    user.skip_confirmation!
+    user.save!
+    user
+  end
+
+  test "a village admin can grant the role" do
+    sign_in @admin
+
+    post managed_user_village_admin_role_path(@volunteer)
+
+    assert_redirected_to managed_user_path(@volunteer)
+    assert @volunteer.reload.village_admin?
+    assert_match(/village admin/i, flash[:notice])
+  end
+
+  test "granting is idempotent for a user who already has the role" do
+    UserRole.create!(user: @volunteer, role: @admin_role)
+    sign_in @admin
+
+    assert_no_difference "UserRole.count" do
+      post managed_user_village_admin_role_path(@volunteer)
+    end
+    assert @volunteer.reload.village_admin?
+  end
+
+  test "a village admin can revoke the role from another admin" do
+    UserRole.create!(user: @volunteer, role: @admin_role)
+    sign_in @admin
+
+    delete managed_user_village_admin_role_path(@volunteer)
+
+    assert_redirected_to managed_user_path(@volunteer)
+    assert_not @volunteer.reload.village_admin?
+    assert @admin.reload.village_admin?, "the acting admin keeps their role"
+  end
+
+  test "revoking the last remaining village admin is blocked" do
+    sign_in @admin
+
+    delete managed_user_village_admin_role_path(@admin)
+
+    assert @admin.reload.village_admin?, "the last admin must survive"
+    assert_match(/last village admin/i, flash[:alert])
+  end
+
+  test "an admin may revoke their own role when another admin exists" do
+    UserRole.create!(user: @volunteer, role: @admin_role)
+    sign_in @admin
+
+    delete managed_user_village_admin_role_path(@admin)
+
+    assert_not @admin.reload.village_admin?
+    assert @volunteer.reload.village_admin?
+  end
+
+  test "revoking from a user who is not an admin is a no-op with a notice" do
+    sign_in @admin
+
+    delete managed_user_village_admin_role_path(@volunteer)
+
+    assert_redirected_to managed_user_path(@volunteer)
+    assert_not @volunteer.reload.village_admin?
+  end
+
+  test "a non-admin cannot grant or revoke" do
+    sign_in @volunteer
+
+    post managed_user_village_admin_role_path(@volunteer)
+    assert_redirected_to root_path
+    assert_not @volunteer.reload.village_admin?
+
+    delete managed_user_village_admin_role_path(@admin)
+    assert_redirected_to root_path
+    assert @admin.reload.village_admin?
+  end
+
+  test "unauthenticated users are sent to login" do
+    post managed_user_village_admin_role_path(@volunteer)
+    assert_redirected_to new_user_session_path
+
+    delete managed_user_village_admin_role_path(@admin)
+    assert_redirected_to new_user_session_path
+  end
+
+  # --- the controls on the managed-user page ---
+
+  test "the user page offers Grant for a non-admin and Revoke for an admin" do
+    sign_in @admin
+
+    get managed_user_path(@volunteer)
+    assert_select "form[action='#{managed_user_village_admin_role_path(@volunteer)}']" do
+      assert_select "button", text: /make village admin/i
+    end
+
+    get managed_user_path(@admin)
+    assert_select "form[action='#{managed_user_village_admin_role_path(@admin)}']" do
+      assert_select "button", text: /revoke village admin/i
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The data model has always supported multiple village admins, but the only assignment path was the one-time setup wizard — adding a second admin required the Rails console. Village admins can now grant and revoke the role directly from the managed-user page (#263).

## Changes

- **UI**: `/manage/users/:id` shows a **Make Village Admin** button for non-admins and a **Revoke Village Admin** button for admins, next to the existing role badges. Both use Turbo confirm dialogs; the grant confirm spells out the scope of the role.
- **Routes/controller**: singular `village_admin_role` resource nested under `managed_users` (`POST` / `DELETE /manage/users/:id/village_admin_role`), handled by the new `VillageAdminRolesController`.
- **Authorization**: new `UserPolicy#manage_village_admin_role?` — village admins only. Non-admins are redirected to root; unauthenticated users to login.
- **Last-admin guard**: revoking is refused with a clear error whenever it would leave the village with zero admins, so the village can never lock itself out. Self-revocation works whenever another admin exists (the guard covers the self-demotion edge automatically).
- Granting is idempotent; revoking from a non-admin is a polite no-op.

## Acceptance criteria (from the issue)

- [x] Village admin can grant the village admin role to another user from the UI
- [x] Village admin can revoke the village admin role from a user
- [x] Revoking the last remaining village admin is blocked with a clear error
- [x] Non-village-admins cannot access these actions (Pundit-enforced)
- [x] Route smoke tests + controller/policy tests (TDD)

## Testing

- TDD: 9 failing controller tests first (grant, idempotent grant, revoke, last-admin block, self-revoke with backup admin, non-admin no-op revoke, authorization denials, login redirects, and button rendering per user state), then implementation
- `bin/rails test:all` — 1042 runs, 0 failures (system tests included)
- `bin/rubocop` — no offenses

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)