### PR TITLE
Add the staffing timeline: who works when, with names (#262)

### DIFF
--- a/app/assets/stylesheets/schedule.scss
+++ b/app/assets/stylesheets/schedule.scss
@@ -75,10 +75,22 @@
     z-index: 2;
   }
 
+  .timeline-lane {
+    margin-top: 0.75rem;
+
+    .lane-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.25rem;
+    }
+  }
+
   // The bar's width is its true time span. Rather than clip mid-pill or
   // overflow the timeline, content degrades as the bar narrows: the time
-  // range drops first, then the activity badge, and finally the name
-  // ellipsizes. The title tooltip always carries the full details.
+  // range drops first, then the name ellipsizes. The activity is carried by
+  // the lane and the color-matched left border; the title tooltip always
+  // has the full details.
   .timeline-bar {
     position: absolute;
     height: 2.25rem;
@@ -109,11 +121,20 @@
     }
   }
 
-  @container (max-width: 22rem) {
-    .bar-times { display: none; }
+  // Color-matched to the activity's badge (the badge_cycle in the view).
+  $lane-colors: (
+    0: var(--bs-primary),
+    1: var(--bs-success),
+    2: var(--bs-info),
+    3: var(--bs-warning),
+    4: var(--bs-dark),
+    5: var(--bs-secondary)
+  );
+  @each $index, $color in $lane-colors {
+    .timeline-bar.lane-color-#{$index} { border-left: 4px solid #{$color}; }
   }
 
   @container (max-width: 13rem) {
-    .bar-activity { display: none; }
+    .bar-times { display: none; }
   }
 }

--- a/app/assets/stylesheets/schedule.scss
+++ b/app/assets/stylesheets/schedule.scss
@@ -33,3 +33,61 @@
   &.claimable .tick.bare,
   &.claimable .tick.short { cursor: pointer; }
 }
+
+// --- Staffing timeline (#262) -------------------------------------------
+// Horizontal who-works-when view: absolute-positioned shift bars over an
+// hour-ruled canvas, themed off Bootstrap CSS variables like the ribbon.
+.timeline-scroll { overflow-x: auto; }
+
+.staffing-timeline {
+  .timeline-ruler {
+    position: relative;
+    height: 1.5rem;
+    color: var(--bs-secondary-color);
+    font-size: 0.75rem;
+
+    .hour-label { position: absolute; transform: translateX(-50%); white-space: nowrap; }
+    .hour-label.edge-start { transform: none; }
+  }
+
+  .timeline-body {
+    position: relative;
+    background: var(--bs-tertiary-bg);
+    border-radius: 0.375rem;
+    overflow: hidden;
+  }
+
+  .hour-line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--bs-border-color);
+  }
+
+  .timeline-now {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--bs-danger);
+    z-index: 2;
+  }
+
+  .timeline-bar {
+    position: absolute;
+    height: 2.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 0.5rem;
+    white-space: nowrap;
+    overflow: hidden;
+    min-width: 2rem;
+    background: var(--bs-body-bg);
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    z-index: 1;
+  }
+}

--- a/app/assets/stylesheets/schedule.scss
+++ b/app/assets/stylesheets/schedule.scss
@@ -50,11 +50,12 @@
     .hour-label.edge-start { transform: none; }
   }
 
+  // overflow stays visible so a short shift's full-width label (see
+  // .timeline-bar min-width) isn't clipped at the canvas edge.
   .timeline-body {
     position: relative;
     background: var(--bs-tertiary-bg);
     border-radius: 0.375rem;
-    overflow: hidden;
   }
 
   .hour-line {
@@ -82,12 +83,20 @@
     gap: 0.5rem;
     padding: 0 0.5rem;
     white-space: nowrap;
-    overflow: hidden;
-    min-width: 2rem;
+    // A shift shorter than its label grows to fit — the left edge stays the
+    // truthful time anchor, and each bar has its own lane so nothing collides.
+    min-width: fit-content;
     background: var(--bs-body-bg);
     border: 1px solid var(--bs-border-color);
     border-radius: 0.375rem;
     font-size: 0.875rem;
     z-index: 1;
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      border-color: var(--bs-primary);
+      z-index: 2;
+    }
   }
 }

--- a/app/assets/stylesheets/schedule.scss
+++ b/app/assets/stylesheets/schedule.scss
@@ -75,6 +75,10 @@
     z-index: 2;
   }
 
+  // The bar's width is its true time span. Rather than clip mid-pill or
+  // overflow the timeline, content degrades as the bar narrows: the time
+  // range drops first, then the activity badge, and finally the name
+  // ellipsizes. The title tooltip always carries the full details.
   .timeline-bar {
     position: absolute;
     height: 2.25rem;
@@ -83,9 +87,8 @@
     gap: 0.5rem;
     padding: 0 0.5rem;
     white-space: nowrap;
-    // A shift shorter than its label grows to fit — the left edge stays the
-    // truthful time anchor, and each bar has its own lane so nothing collides.
-    min-width: fit-content;
+    overflow: hidden;
+    min-width: 1.25rem;
     background: var(--bs-body-bg);
     border: 1px solid var(--bs-border-color);
     border-radius: 0.375rem;
@@ -93,10 +96,24 @@
     z-index: 1;
     color: inherit;
     text-decoration: none;
+    container-type: inline-size;
+
+    .bar-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
 
     &:hover {
       border-color: var(--bs-primary);
       z-index: 2;
     }
+  }
+
+  @container (max-width: 22rem) {
+    .bar-times { display: none; }
+  }
+
+  @container (max-width: 13rem) {
+    .bar-activity { display: none; }
   }
 }

--- a/app/assets/stylesheets/schedule.scss
+++ b/app/assets/stylesheets/schedule.scss
@@ -89,8 +89,7 @@
   // The bar's width is its true time span. Rather than clip mid-pill or
   // overflow the timeline, content degrades as the bar narrows: the time
   // range drops first, then the name ellipsizes. The activity is carried by
-  // the lane and the color-matched left border; the title tooltip always
-  // has the full details.
+  // the lane; the title tooltip always has the full details.
   .timeline-bar {
     position: absolute;
     height: 2.25rem;
@@ -119,19 +118,6 @@
       border-color: var(--bs-primary);
       z-index: 2;
     }
-  }
-
-  // Color-matched to the activity's badge (the badge_cycle in the view).
-  $lane-colors: (
-    0: var(--bs-primary),
-    1: var(--bs-success),
-    2: var(--bs-info),
-    3: var(--bs-warning),
-    4: var(--bs-dark),
-    5: var(--bs-secondary)
-  );
-  @each $index, $color in $lane-colors {
-    .timeline-bar.lane-color-#{$index} { border-left: 4px solid #{$color}; }
   }
 
   @container (max-width: 13rem) {

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -91,10 +91,84 @@ class ScheduleController < ApplicationController
     load_manage_panel if params[:manage].present?
   end
 
+  # Staffing timeline (#262): who works when, at a glance — one horizontal bar
+  # per contiguous volunteer shift across the day's manageable activities.
+  # Conference managers see every activity; activity leads only their own.
+  # Filters: day, activity (program_id), and a from/to time window.
+  def timeline
+    authorize @conference, :show?, policy_class: ConferencePolicy
+
+    @manageable_program_ids = manageable_program_ids
+    if @manageable_program_ids.empty?
+      redirect_to conference_schedule_coverage_path(@conference),
+                  alert: "You don't manage any activities at this conference."
+      return
+    end
+
+    @days = (@conference.start_date..@conference.end_date).to_a
+    @day = resolve_day
+
+    @programs = Program.where(id: @manageable_program_ids).order(:name)
+    @program_filter = @programs.find_by(id: params[:program_id])
+    program_ids = @program_filter ? [ @program_filter.id ] : @manageable_program_ids.to_a
+
+    day_slots = Timeslot.joins(:conference_program)
+                        .where(conference_programs: { conference_id: @conference.id, program_id: program_ids })
+                        .where(start_time: @day.in_time_zone.all_day)
+    scheduled_start = day_slots.minimum(:start_time)
+    scheduled_end = day_slots.maximum(:end_time)
+    if scheduled_start.nil?
+      @bars = []
+      return
+    end
+
+    # The visible window: the day's scheduled span, narrowed by from/to.
+    @window_start = parse_window_time(params[:from]) || scheduled_start
+    @window_end = parse_window_time(params[:to]) || scheduled_end
+    @window_end = @window_start + 1.hour if @window_end <= @window_start
+
+    @bars = timeline_bars(program_ids)
+            .select { |bar| bar[:starts_at] < @window_end && bar[:ends_at] > @window_start }
+            .sort_by { |bar| [ bar[:starts_at], bar[:user].display_name ] }
+  end
+
   private
 
   def set_conference
     @conference = Conference.find(params[:conference_id])
+  end
+
+  # The day's signups for the given programs, collapsed into contiguous
+  # ranges per volunteer+activity: [{ user:, program_name:, starts_at:, ends_at: }]
+  def timeline_bars(program_ids)
+    signups = VolunteerSignup.joins(timeslot: :conference_program)
+                             .where(conference_programs: { conference_id: @conference.id, program_id: program_ids })
+                             .where(timeslots: { start_time: @day.in_time_zone.all_day })
+                             .includes(:user, timeslot: { conference_program: :program })
+                             .sort_by { |signup| signup.timeslot.start_time }
+
+    signups.group_by { |signup| [ signup.user_id, signup.timeslot.conference_program_id ] }
+           .values
+           .flat_map do |group|
+      group.chunk_while { |a, b| a.timeslot.end_time == b.timeslot.start_time }.map do |run|
+        {
+          user: run.first.user,
+          program_name: run.first.timeslot.conference_program.program.name,
+          starts_at: run.first.timeslot.start_time,
+          ends_at: run.last.timeslot.end_time
+        }
+      end
+    end
+  end
+
+  # "HH:MM" on the selected day, in the conference's zone; nil when absent
+  # or unparseable.
+  def parse_window_time(value)
+    return nil if value.blank?
+
+    Time.zone.parse("#{@day.iso8601} #{value}")
+  rescue ArgumentError
+    nil
   end
 
   # Swap-or-keep confirmation (#267): a conflicting claim redirects here with

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -91,10 +91,11 @@ class ScheduleController < ApplicationController
     load_manage_panel if params[:manage].present?
   end
 
-  # Staffing timeline (#262): who works when, at a glance — one horizontal bar
-  # per contiguous volunteer shift across the day's manageable activities.
-  # Conference managers see every activity; activity leads only their own.
-  # Filters: day, activity (program_id), and a from/to time window.
+  # Staffing timeline (#262): who works when, at a glance — one lane per
+  # activity, one horizontal bar per contiguous volunteer shift. Conference
+  # managers see every activity; activity leads only their own, and the
+  # activity checkboxes let multi-activity leads pick which lanes show.
+  # Filters: day, activities (program_ids[]), and a from/to time window.
   def timeline
     authorize @conference, :show?, policy_class: ConferencePolicy
 
@@ -109,27 +110,40 @@ class ScheduleController < ApplicationController
     @day = resolve_day
 
     @programs = Program.where(id: @manageable_program_ids).order(:name)
-    @program_filter = @programs.find_by(id: params[:program_id])
-    program_ids = @program_filter ? [ @program_filter.id ] : @manageable_program_ids.to_a
+    # Absent param = everything; a present-but-empty selection (all boxes
+    # unchecked) honestly shows nothing. Foreign ids are dropped.
+    @selected_program_ids =
+      if params.key?(:program_ids)
+        Array(params[:program_ids]).map(&:to_i) & @manageable_program_ids.to_a
+      else
+        @manageable_program_ids.to_a
+      end
+
+    @lanes = []
+    return if @selected_program_ids.empty?
 
     day_slots = Timeslot.joins(:conference_program)
-                        .where(conference_programs: { conference_id: @conference.id, program_id: program_ids })
+                        .where(conference_programs: { conference_id: @conference.id, program_id: @selected_program_ids })
                         .where(start_time: @day.in_time_zone.all_day)
     scheduled_start = day_slots.minimum(:start_time)
     scheduled_end = day_slots.maximum(:end_time)
-    if scheduled_start.nil?
-      @bars = []
-      return
-    end
+    return if scheduled_start.nil?
 
     # The visible window: the day's scheduled span, narrowed by from/to.
     @window_start = parse_window_time(params[:from]) || scheduled_start
     @window_end = parse_window_time(params[:to]) || scheduled_end
     @window_end = @window_start + 1.hour if @window_end <= @window_start
 
-    @bars = timeline_bars(program_ids)
-            .select { |bar| bar[:starts_at] < @window_end && bar[:ends_at] > @window_start }
-            .sort_by { |bar| [ bar[:starts_at], bar[:user].display_name ] }
+    bars = timeline_bars(@selected_program_ids)
+           .select { |bar| bar[:starts_at] < @window_end && bar[:ends_at] > @window_start }
+    @lanes = @programs.select { |program| @selected_program_ids.include?(program.id) }
+                      .map do |program|
+      {
+        program: program,
+        bars: bars.select { |bar| bar[:program_id] == program.id }
+                  .sort_by { |bar| [ bar[:starts_at], bar[:user].display_name ] }
+      }
+    end
   end
 
   private
@@ -153,6 +167,7 @@ class ScheduleController < ApplicationController
       group.chunk_while { |a, b| a.timeslot.end_time == b.timeslot.start_time }.map do |run|
         {
           user: run.first.user,
+          program_id: run.first.timeslot.conference_program.program_id,
           program_name: run.first.timeslot.conference_program.program.name,
           starts_at: run.first.timeslot.start_time,
           ends_at: run.last.timeslot.end_time

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,8 +3,15 @@ class UserPolicy < ApplicationPolicy
     user&.village_admin?
   end
 
+  # Conference managers and activity leads may read volunteer profiles (#262):
+  # the staffing timeline links to them, and these roles already receive the
+  # same contact data through the reports. Editing stays village-admin-only.
   def show?
-    user&.village_admin?
+    return true if user&.village_admin?
+    return false if user.nil?
+
+    ConferenceRole.exists?(user: user) ||
+      ConferenceProgramRole.exists?(user: user, role_name: ConferenceProgramRole::ACTIVITY_LEAD)
   end
 
   def edit?

--- a/app/views/schedule/board.html.erb
+++ b/app/views/schedule/board.html.erb
@@ -1,7 +1,10 @@
 <div class="container-fluid mt-4" style="max-width: 1440px;">
   <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
     <h1 class="mb-0"><%= @conference.name %> - Coverage Board</h1>
-    <%= link_to "Schedule", conference_schedule_path(@conference), class: "btn btn-outline-secondary btn-sm" %>
+    <div class="d-flex gap-2">
+      <%= link_to "Staffing timeline", conference_schedule_timeline_path(@conference), class: "btn btn-outline-primary btn-sm" %>
+      <%= link_to "Schedule", conference_schedule_path(@conference), class: "btn btn-outline-secondary btn-sm" %>
+    </div>
   </div>
   <p class="text-muted">Is every activity covered every day? Click a day to manage it.</p>
 

--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -7,7 +7,10 @@
       <h1 class="mb-0"><%= @conference.name %> - Schedule</h1>
     </div>
     <% if @can_manage_any %>
-      <%= link_to "Coverage board", conference_schedule_board_path(@conference), class: "btn btn-outline-primary btn-sm" %>
+      <div class="d-flex gap-2">
+        <%= link_to "Staffing timeline", conference_schedule_timeline_path(@conference), class: "btn btn-outline-primary btn-sm" %>
+        <%= link_to "Coverage board", conference_schedule_board_path(@conference), class: "btn btn-outline-primary btn-sm" %>
+      </div>
     <% end %>
   </div>
 

--- a/app/views/schedule/timeline.html.erb
+++ b/app/views/schedule/timeline.html.erb
@@ -1,6 +1,6 @@
 <%# Staffing timeline (#262): horizontally-scrolling who-works-when view.
-    One bar per contiguous volunteer shift, positioned by time within the
-    day's scheduled window; the badge names the activity. %>
+    One lane per activity, one bar per contiguous volunteer shift, positioned
+    by time within the day's scheduled window on a shared hour ruler. %>
 <div class="container-fluid mt-4" style="max-width: 1440px;">
   <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
     <h1 class="mb-0"><%= @conference.name %> - Staffing Timeline</h1>
@@ -11,12 +11,19 @@
   </div>
   <p class="text-muted">Who is scheduled when — spot thin handoffs and high-turnover stretches at a glance.</p>
 
-  <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+  <%
+    # A stable Bootstrap color per activity, keyed across ALL manageable
+    # programs so an activity keeps its color as lanes are toggled.
+    badge_cycle = %w[text-bg-primary text-bg-success text-bg-info text-bg-warning text-bg-dark text-bg-secondary]
+    color_index = @programs.each_with_index.to_h { |program, index| [ program.id, index % badge_cycle.size ] }
+  %>
+
+  <div class="d-flex align-items-start flex-wrap gap-3 mb-3">
     <div class="btn-group" role="group" aria-label="Day" data-current-day="<%= @day.iso8601 %>">
       <% @days.each do |day| %>
         <%= link_to day.strftime("%a %-m/%-d"),
             conference_schedule_timeline_path(@conference, day: day.iso8601,
-              program_id: params[:program_id].presence, from: params[:from].presence, to: params[:to].presence),
+              program_ids: params[:program_ids].presence, from: params[:from].presence, to: params[:to].presence),
             class: "btn btn-sm #{day == @day ? 'btn-primary' : 'btn-outline-primary'}" %>
       <% end %>
     </div>
@@ -24,13 +31,26 @@
     <%= form_with url: conference_schedule_timeline_path(@conference), method: :get, local: true,
                   class: "d-flex align-items-end flex-wrap gap-2", data: { controller: "auto-submit" } do %>
       <input type="hidden" name="day" value="<%= @day.iso8601 %>">
-      <div>
-        <label class="form-label small mb-0" for="timeline-program">Activity</label>
-        <%= select_tag :program_id,
-            options_from_collection_for_select(@programs, :id, :name, params[:program_id]),
-            include_blank: "All activities", id: "timeline-program",
-            class: "form-select form-select-sm", data: { action: "change->auto-submit#submit" } %>
-      </div>
+      <% if @programs.size > 1 %>
+        <fieldset class="me-2">
+          <legend class="form-label small mb-0 float-none w-auto">Activities</legend>
+          <%# The blank entry keeps program_ids[] present when every box is
+              unchecked, so "none selected" doesn't snap back to "all". %>
+          <input type="hidden" name="program_ids[]" value="">
+          <div class="d-flex flex-wrap gap-3 pt-1">
+            <% @programs.each do |program| %>
+              <div class="form-check">
+                <%= check_box_tag "program_ids[]", program.id, @selected_program_ids.include?(program.id),
+                    id: "timeline-program-#{program.id}", class: "form-check-input",
+                    data: { action: "change->auto-submit#submit" } %>
+                <label class="form-check-label" for="timeline-program-<%= program.id %>">
+                  <span class="badge <%= badge_cycle[color_index[program.id]] %>"><%= program.name %></span>
+                </label>
+              </div>
+            <% end %>
+          </div>
+        </fieldset>
+      <% end %>
       <div>
         <label class="form-label small mb-0" for="timeline-from">From</label>
         <%= time_field_tag :from, params[:from], id: "timeline-from", class: "form-control form-control-sm" %>
@@ -45,10 +65,13 @@
     <% end %>
   </div>
 
-  <% if @bars.empty? %>
+  <% if @lanes.empty? %>
     <div class="alert alert-secondary">
-      No one is scheduled<%= " for the selected filters" if params[:program_id].present? || params[:from].present? || params[:to].present? %>
-      on <%= @day.strftime("%A, %B %-d") %>.
+      <% if @selected_program_ids.empty? %>
+        No activities selected — check at least one activity above.
+      <% else %>
+        Nothing scheduled on <%= @day.strftime("%A, %B %-d") %>.
+      <% end %>
     </div>
   <% else %>
     <%
@@ -59,9 +82,7 @@
       row_height = 2.5
       now = Time.current
       show_now = now.between?(@window_start, @window_end)
-      # A stable Bootstrap color per activity so bars group visually.
-      badge_cycle = %w[text-bg-primary text-bg-success text-bg-info text-bg-warning text-bg-dark text-bg-secondary]
-      badge_class = @programs.each_with_index.to_h { |program, index| [ program.name, badge_cycle[index % badge_cycle.size] ] }
+      total_bars = @lanes.sum { |lane| lane[:bars].size }
     %>
     <div class="timeline-scroll pb-2">
       <div class="staffing-timeline" style="min-width: <%= [ hours * 8, 24 ].max %>rem;">
@@ -70,31 +91,40 @@
             <span class="hour-label <%= "edge-start" if index.zero? %>" style="left: <%= position.call(mark) %>%;"><%= mark.strftime("%-l %p") %></span>
           <% end %>
         </div>
-        <div class="timeline-body" style="height: <%= @bars.size * row_height + 0.5 %>rem;">
-          <% ruler_marks.each do |mark| %>
-            <div class="hour-line" style="left: <%= position.call(mark) %>%;"></div>
-          <% end %>
-          <% if show_now %>
-            <div class="timeline-now" style="left: <%= position.call(now) %>%;" title="Now"></div>
-          <% end %>
-          <% @bars.each_with_index do |bar, row| %>
-            <%# The bar's width is the truthful time span. As it narrows, the
-                time range and then the activity badge drop out (container
-                queries) and the name ellipsizes; the tooltip always carries
-                the full details. %>
-            <%= link_to managed_user_path(bar[:user]), class: "timeline-bar",
-                style: "left: #{position.call(bar[:starts_at])}%; width: #{(position.call(bar[:ends_at]) - position.call(bar[:starts_at])).round(3)}%; top: #{(row * row_height + 0.25).round(2)}rem;",
-                title: "#{display_name_with_callsign(bar[:user])} — #{bar[:program_name]}, #{bar[:starts_at].strftime("%-l:%M %p")} – #{bar[:ends_at].strftime("%-l:%M %p")}" do %>
-              <strong class="bar-name"><%= display_name_with_callsign(bar[:user]) %></strong>
-              <span class="badge bar-activity <%= badge_class.fetch(bar[:program_name], "text-bg-primary") %>"><%= bar[:program_name] %></span>
-              <span class="text-muted small bar-times"><%= bar[:starts_at].strftime("%-l:%M") %>–<%= bar[:ends_at].strftime("%-l:%M %p") %></span>
-            <% end %>
-          <% end %>
-        </div>
+        <% @lanes.each do |lane| %>
+          <div class="timeline-lane" data-program-name="<%= lane[:program].name %>">
+            <div class="lane-header">
+              <span class="badge <%= badge_cycle[color_index[lane[:program].id]] %>"><%= lane[:program].name %></span>
+              <span class="text-muted small"><%= lane[:bars].size %> shift<%= "s" unless lane[:bars].size == 1 %></span>
+            </div>
+            <div class="timeline-body" style="height: <%= [ lane[:bars].size, 1 ].max * row_height + 0.5 %>rem;">
+              <% ruler_marks.each do |mark| %>
+                <div class="hour-line" style="left: <%= position.call(mark) %>%;"></div>
+              <% end %>
+              <% if show_now %>
+                <div class="timeline-now" style="left: <%= position.call(now) %>%;" title="Now"></div>
+              <% end %>
+              <% if lane[:bars].empty? %>
+                <p class="text-muted small m-2 mb-0">No one scheduled in this window.</p>
+              <% end %>
+              <% lane[:bars].each_with_index do |bar, row| %>
+                <%# The bar's width is the truthful time span. As it narrows,
+                    the time range drops out (container query) and the name
+                    ellipsizes; the tooltip always carries the full details. %>
+                <%= link_to managed_user_path(bar[:user]), class: "timeline-bar lane-color-#{color_index[lane[:program].id]}",
+                    style: "left: #{position.call(bar[:starts_at])}%; width: #{(position.call(bar[:ends_at]) - position.call(bar[:starts_at])).round(3)}%; top: #{(row * row_height + 0.25).round(2)}rem;",
+                    title: "#{display_name_with_callsign(bar[:user])} — #{bar[:program_name]}, #{bar[:starts_at].strftime("%-l:%M %p")} – #{bar[:ends_at].strftime("%-l:%M %p")}" do %>
+                  <strong class="bar-name"><%= display_name_with_callsign(bar[:user]) %></strong>
+                  <span class="text-muted small bar-times"><%= bar[:starts_at].strftime("%-l:%M") %>–<%= bar[:ends_at].strftime("%-l:%M %p") %></span>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
     <p class="text-muted small">
-      <%= @bars.size %> shift<%= "s" unless @bars.size == 1 %> ·
+      <%= total_bars %> shift<%= "s" unless total_bars == 1 %> ·
       <%= @window_start.strftime("%-l:%M %p") %> – <%= @window_end.strftime("%-l:%M %p") %>
     </p>
   <% end %>

--- a/app/views/schedule/timeline.html.erb
+++ b/app/views/schedule/timeline.html.erb
@@ -11,13 +11,6 @@
   </div>
   <p class="text-muted">Who is scheduled when — spot thin handoffs and high-turnover stretches at a glance.</p>
 
-  <%
-    # A stable Bootstrap color per activity, keyed across ALL manageable
-    # programs so an activity keeps its color as lanes are toggled.
-    badge_cycle = %w[text-bg-primary text-bg-success text-bg-info text-bg-warning text-bg-dark text-bg-secondary]
-    color_index = @programs.each_with_index.to_h { |program, index| [ program.id, index % badge_cycle.size ] }
-  %>
-
   <div class="d-flex align-items-start flex-wrap gap-3 mb-3">
     <div class="btn-group" role="group" aria-label="Day" data-current-day="<%= @day.iso8601 %>">
       <% @days.each do |day| %>
@@ -44,7 +37,7 @@
                     id: "timeline-program-#{program.id}", class: "form-check-input",
                     data: { action: "change->auto-submit#submit" } %>
                 <label class="form-check-label" for="timeline-program-<%= program.id %>">
-                  <span class="badge <%= badge_cycle[color_index[program.id]] %>"><%= program.name %></span>
+                  <span class="badge text-bg-secondary"><%= program.name %></span>
                 </label>
               </div>
             <% end %>
@@ -94,7 +87,7 @@
         <% @lanes.each do |lane| %>
           <div class="timeline-lane" data-program-name="<%= lane[:program].name %>">
             <div class="lane-header">
-              <span class="badge <%= badge_cycle[color_index[lane[:program].id]] %>"><%= lane[:program].name %></span>
+              <span class="badge text-bg-secondary"><%= lane[:program].name %></span>
               <span class="text-muted small"><%= lane[:bars].size %> shift<%= "s" unless lane[:bars].size == 1 %></span>
             </div>
             <div class="timeline-body" style="height: <%= [ lane[:bars].size, 1 ].max * row_height + 0.5 %>rem;">
@@ -111,7 +104,7 @@
                 <%# The bar's width is the truthful time span. As it narrows,
                     the time range drops out (container query) and the name
                     ellipsizes; the tooltip always carries the full details. %>
-                <%= link_to managed_user_path(bar[:user]), class: "timeline-bar lane-color-#{color_index[lane[:program].id]}",
+                <%= link_to managed_user_path(bar[:user]), class: "timeline-bar",
                     style: "left: #{position.call(bar[:starts_at])}%; width: #{(position.call(bar[:ends_at]) - position.call(bar[:starts_at])).round(3)}%; top: #{(row * row_height + 0.25).round(2)}rem;",
                     title: "#{display_name_with_callsign(bar[:user])} — #{bar[:program_name]}, #{bar[:starts_at].strftime("%-l:%M %p")} – #{bar[:ends_at].strftime("%-l:%M %p")}" do %>
                   <strong class="bar-name"><%= display_name_with_callsign(bar[:user]) %></strong>

--- a/app/views/schedule/timeline.html.erb
+++ b/app/views/schedule/timeline.html.erb
@@ -78,13 +78,15 @@
             <div class="timeline-now" style="left: <%= position.call(now) %>%;" title="Now"></div>
           <% end %>
           <% @bars.each_with_index do |bar, row| %>
-            <div class="timeline-bar"
-                 style="left: <%= position.call(bar[:starts_at]) %>%; width: <%= (position.call(bar[:ends_at]) - position.call(bar[:starts_at])).round(3) %>%; top: <%= (row * row_height + 0.25).round(2) %>rem;"
-                 title="<%= display_name_with_callsign(bar[:user]) %> — <%= bar[:program_name] %>, <%= bar[:starts_at].strftime("%-l:%M %p") %> – <%= bar[:ends_at].strftime("%-l:%M %p") %>">
+            <%# min-width: fit-content lets short shifts show their full label;
+                the bar's left edge is the truthful time anchor. %>
+            <%= link_to managed_user_path(bar[:user]), class: "timeline-bar",
+                style: "left: #{position.call(bar[:starts_at])}%; width: #{(position.call(bar[:ends_at]) - position.call(bar[:starts_at])).round(3)}%; top: #{(row * row_height + 0.25).round(2)}rem;",
+                title: "#{display_name_with_callsign(bar[:user])} — #{bar[:program_name]}, #{bar[:starts_at].strftime("%-l:%M %p")} – #{bar[:ends_at].strftime("%-l:%M %p")}" do %>
               <strong><%= display_name_with_callsign(bar[:user]) %></strong>
               <span class="badge <%= badge_class.fetch(bar[:program_name], "text-bg-primary") %>"><%= bar[:program_name] %></span>
               <span class="text-muted small"><%= bar[:starts_at].strftime("%-l:%M") %>–<%= bar[:ends_at].strftime("%-l:%M %p") %></span>
-            </div>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/app/views/schedule/timeline.html.erb
+++ b/app/views/schedule/timeline.html.erb
@@ -64,7 +64,7 @@
       badge_class = @programs.each_with_index.to_h { |program, index| [ program.name, badge_cycle[index % badge_cycle.size] ] }
     %>
     <div class="timeline-scroll pb-2">
-      <div class="staffing-timeline" style="min-width: <%= [ hours * 6, 24 ].max %>rem;">
+      <div class="staffing-timeline" style="min-width: <%= [ hours * 8, 24 ].max %>rem;">
         <div class="timeline-ruler">
           <% ruler_marks.each_with_index do |mark, index| %>
             <span class="hour-label <%= "edge-start" if index.zero? %>" style="left: <%= position.call(mark) %>%;"><%= mark.strftime("%-l %p") %></span>
@@ -78,14 +78,16 @@
             <div class="timeline-now" style="left: <%= position.call(now) %>%;" title="Now"></div>
           <% end %>
           <% @bars.each_with_index do |bar, row| %>
-            <%# min-width: fit-content lets short shifts show their full label;
-                the bar's left edge is the truthful time anchor. %>
+            <%# The bar's width is the truthful time span. As it narrows, the
+                time range and then the activity badge drop out (container
+                queries) and the name ellipsizes; the tooltip always carries
+                the full details. %>
             <%= link_to managed_user_path(bar[:user]), class: "timeline-bar",
                 style: "left: #{position.call(bar[:starts_at])}%; width: #{(position.call(bar[:ends_at]) - position.call(bar[:starts_at])).round(3)}%; top: #{(row * row_height + 0.25).round(2)}rem;",
                 title: "#{display_name_with_callsign(bar[:user])} — #{bar[:program_name]}, #{bar[:starts_at].strftime("%-l:%M %p")} – #{bar[:ends_at].strftime("%-l:%M %p")}" do %>
-              <strong><%= display_name_with_callsign(bar[:user]) %></strong>
-              <span class="badge <%= badge_class.fetch(bar[:program_name], "text-bg-primary") %>"><%= bar[:program_name] %></span>
-              <span class="text-muted small"><%= bar[:starts_at].strftime("%-l:%M") %>–<%= bar[:ends_at].strftime("%-l:%M %p") %></span>
+              <strong class="bar-name"><%= display_name_with_callsign(bar[:user]) %></strong>
+              <span class="badge bar-activity <%= badge_class.fetch(bar[:program_name], "text-bg-primary") %>"><%= bar[:program_name] %></span>
+              <span class="text-muted small bar-times"><%= bar[:starts_at].strftime("%-l:%M") %>–<%= bar[:ends_at].strftime("%-l:%M %p") %></span>
             <% end %>
           <% end %>
         </div>

--- a/app/views/schedule/timeline.html.erb
+++ b/app/views/schedule/timeline.html.erb
@@ -1,0 +1,97 @@
+<%# Staffing timeline (#262): horizontally-scrolling who-works-when view.
+    One bar per contiguous volunteer shift, positioned by time within the
+    day's scheduled window; the badge names the activity. %>
+<div class="container-fluid mt-4" style="max-width: 1440px;">
+  <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+    <h1 class="mb-0"><%= @conference.name %> - Staffing Timeline</h1>
+    <div class="d-flex gap-2">
+      <%= link_to "Schedule", conference_schedule_path(@conference), class: "btn btn-outline-secondary btn-sm" %>
+      <%= link_to "Coverage board", conference_schedule_board_path(@conference), class: "btn btn-outline-primary btn-sm" %>
+    </div>
+  </div>
+  <p class="text-muted">Who is scheduled when — spot thin handoffs and high-turnover stretches at a glance.</p>
+
+  <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+    <div class="btn-group" role="group" aria-label="Day" data-current-day="<%= @day.iso8601 %>">
+      <% @days.each do |day| %>
+        <%= link_to day.strftime("%a %-m/%-d"),
+            conference_schedule_timeline_path(@conference, day: day.iso8601,
+              program_id: params[:program_id].presence, from: params[:from].presence, to: params[:to].presence),
+            class: "btn btn-sm #{day == @day ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <% end %>
+    </div>
+
+    <%= form_with url: conference_schedule_timeline_path(@conference), method: :get, local: true,
+                  class: "d-flex align-items-end flex-wrap gap-2", data: { controller: "auto-submit" } do %>
+      <input type="hidden" name="day" value="<%= @day.iso8601 %>">
+      <div>
+        <label class="form-label small mb-0" for="timeline-program">Activity</label>
+        <%= select_tag :program_id,
+            options_from_collection_for_select(@programs, :id, :name, params[:program_id]),
+            include_blank: "All activities", id: "timeline-program",
+            class: "form-select form-select-sm", data: { action: "change->auto-submit#submit" } %>
+      </div>
+      <div>
+        <label class="form-label small mb-0" for="timeline-from">From</label>
+        <%= time_field_tag :from, params[:from], id: "timeline-from", class: "form-control form-control-sm" %>
+      </div>
+      <div>
+        <label class="form-label small mb-0" for="timeline-to">To</label>
+        <%= time_field_tag :to, params[:to], id: "timeline-to", class: "form-control form-control-sm" %>
+      </div>
+      <button type="submit" class="btn btn-primary btn-sm">Apply</button>
+      <%= link_to "Clear", conference_schedule_timeline_path(@conference, day: @day.iso8601),
+          class: "btn btn-outline-secondary btn-sm" %>
+    <% end %>
+  </div>
+
+  <% if @bars.empty? %>
+    <div class="alert alert-secondary">
+      No one is scheduled<%= " for the selected filters" if params[:program_id].present? || params[:from].present? || params[:to].present? %>
+      on <%= @day.strftime("%A, %B %-d") %>.
+    </div>
+  <% else %>
+    <%
+      window_seconds = (@window_end - @window_start).to_f
+      position = ->(time) { ((time.clamp(@window_start, @window_end) - @window_start) / window_seconds * 100).round(3) }
+      hours = (window_seconds / 1.hour).ceil
+      ruler_marks = (0..hours).map { |offset| @window_start + offset.hours }.select { |mark| mark <= @window_end }
+      row_height = 2.5
+      now = Time.current
+      show_now = now.between?(@window_start, @window_end)
+      # A stable Bootstrap color per activity so bars group visually.
+      badge_cycle = %w[text-bg-primary text-bg-success text-bg-info text-bg-warning text-bg-dark text-bg-secondary]
+      badge_class = @programs.each_with_index.to_h { |program, index| [ program.name, badge_cycle[index % badge_cycle.size] ] }
+    %>
+    <div class="timeline-scroll pb-2">
+      <div class="staffing-timeline" style="min-width: <%= [ hours * 6, 24 ].max %>rem;">
+        <div class="timeline-ruler">
+          <% ruler_marks.each_with_index do |mark, index| %>
+            <span class="hour-label <%= "edge-start" if index.zero? %>" style="left: <%= position.call(mark) %>%;"><%= mark.strftime("%-l %p") %></span>
+          <% end %>
+        </div>
+        <div class="timeline-body" style="height: <%= @bars.size * row_height + 0.5 %>rem;">
+          <% ruler_marks.each do |mark| %>
+            <div class="hour-line" style="left: <%= position.call(mark) %>%;"></div>
+          <% end %>
+          <% if show_now %>
+            <div class="timeline-now" style="left: <%= position.call(now) %>%;" title="Now"></div>
+          <% end %>
+          <% @bars.each_with_index do |bar, row| %>
+            <div class="timeline-bar"
+                 style="left: <%= position.call(bar[:starts_at]) %>%; width: <%= (position.call(bar[:ends_at]) - position.call(bar[:starts_at])).round(3) %>%; top: <%= (row * row_height + 0.25).round(2) %>rem;"
+                 title="<%= display_name_with_callsign(bar[:user]) %> — <%= bar[:program_name] %>, <%= bar[:starts_at].strftime("%-l:%M %p") %> – <%= bar[:ends_at].strftime("%-l:%M %p") %>">
+              <strong><%= display_name_with_callsign(bar[:user]) %></strong>
+              <span class="badge <%= badge_class.fetch(bar[:program_name], "text-bg-primary") %>"><%= bar[:program_name] %></span>
+              <span class="text-muted small"><%= bar[:starts_at].strftime("%-l:%M") %>–<%= bar[:ends_at].strftime("%-l:%M %p") %></span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <p class="text-muted small">
+      <%= @bars.size %> shift<%= "s" unless @bars.size == 1 %> ·
+      <%= @window_start.strftime("%-l:%M %p") %> – <%= @window_end.strftime("%-l:%M %p") %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -89,9 +89,11 @@
                   <% @user.qualifications.each do |qualification| %>
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                       <%= qualification.name %>
-                      <%= link_to "Remove", managed_user_user_qualification_path(@user, @user.user_qualifications.find_by(qualification: qualification)),
-                          data: { turbo_method: :delete, turbo_confirm: "Remove this qualification from #{@user.email}?" },
-                          class: "btn btn-sm btn-outline-danger" %>
+                      <% if policy(@user).grant_qualification? %>
+                        <%= link_to "Remove", managed_user_user_qualification_path(@user, @user.user_qualifications.find_by(qualification: qualification)),
+                            data: { turbo_method: :delete, turbo_confirm: "Remove this qualification from #{@user.email}?" },
+                            class: "btn btn-sm btn-outline-danger" %>
+                      <% end %>
                     </li>
                   <% end %>
                 </ul>
@@ -100,7 +102,7 @@
               <% end %>
 
               <% available_qualifications = @qualifications - @user.qualifications %>
-              <% if available_qualifications.any? %>
+              <% if available_qualifications.any? && policy(@user).grant_qualification? %>
                 <%= form_with url: managed_user_user_qualifications_path(@user), method: :post, local: true, class: "d-flex gap-2" do |f| %>
                   <select name="qualification_id" class="form-select form-select-sm" required>
                     <option value="">Select qualification...</option>
@@ -114,10 +116,16 @@
             </div>
           </div>
         </div>
-        <div class="card-footer d-flex justify-content-between">
-          <%= link_to "← Back to Users", managed_users_path, class: "btn btn-link" %>
-          <%= link_to "Edit", edit_managed_user_path(@user), class: "btn btn-outline-primary" %>
-        </div>
+        <% if policy(User).index? || policy(@user).edit? %>
+          <div class="card-footer d-flex justify-content-between">
+            <% if policy(User).index? %>
+              <%= link_to "← Back to Users", managed_users_path, class: "btn btn-link" %>
+            <% end %>
+            <% if policy(@user).edit? %>
+              <%= link_to "Edit", edit_managed_user_path(@user), class: "btn btn-outline-primary" %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,41 +3,33 @@
     <div class="col-lg-10 col-xl-8">
       <div class="card">
         <div class="card-header d-flex align-items-center">
-          <%= link_to managed_users_path, class: "btn btn-secondary btn-sm me-3" do %>
-            <span aria-hidden="true">&larr;</span> Users
+          <% if policy(User).index? %>
+            <%= link_to managed_users_path, class: "btn btn-secondary btn-sm me-3" do %>
+              <span aria-hidden="true">&larr;</span> Users
+            <% end %>
           <% end %>
           <h2 class="h4 mb-0"><%= @user.email %></h2>
         </div>
         <div class="card-body">
+          <%# Every profile attribute, blank or not (#262) — a viewer must be
+              able to tell "not set" from "hidden". %>
           <dl class="row">
-            <% if @user.handle.present? %>
-              <dt class="col-sm-3">Display Name:</dt>
-              <dd class="col-sm-9"><%= @user.handle %></dd>
-            <% end %>
-
-            <% if @user.callsign.present? %>
-              <dt class="col-sm-3">Callsign:</dt>
-              <dd class="col-sm-9"><%= @user.callsign %></dd>
-            <% end %>
-
-            <% if @user.phone.present? %>
-              <dt class="col-sm-3">Phone:</dt>
-              <dd class="col-sm-9"><%= @user.phone %></dd>
-            <% end %>
-
-            <% if @user.twitter.present? %>
-              <dt class="col-sm-3">Twitter:</dt>
-              <dd class="col-sm-9"><%= @user.twitter %></dd>
-            <% end %>
-
-            <% if @user.signal.present? %>
-              <dt class="col-sm-3">Signal:</dt>
-              <dd class="col-sm-9"><%= @user.signal %></dd>
-            <% end %>
-
-            <% if @user.discord.present? %>
-              <dt class="col-sm-3">Discord:</dt>
-              <dd class="col-sm-9"><%= @user.discord %></dd>
+            <% {
+                 "Display Name" => @user.handle,
+                 "Callsign" => @user.callsign,
+                 "Phone" => @user.phone,
+                 "Twitter" => @user.twitter,
+                 "Signal" => @user.signal,
+                 "Discord" => @user.discord
+               }.each do |label, value| %>
+              <dt class="col-sm-3"><%= label %>:</dt>
+              <dd class="col-sm-9">
+                <% if value.present? %>
+                  <%= value %>
+                <% else %>
+                  <span class="text-muted">&mdash;</span>
+                <% end %>
+              </dd>
             <% end %>
           </dl>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
     get "schedule", to: "schedule#show", as: :schedule
     get "schedule/coverage", to: "schedule#coverage", as: :schedule_coverage
     get "schedule/board", to: "schedule#board", as: :schedule_board
+    get "schedule/timeline", to: "schedule#timeline", as: :schedule_timeline
     get "leaderboard", to: "leaderboard#conference", as: :leaderboard
     resources :volunteer_signups, only: [ :index, :create, :destroy ] do
       collection do

--- a/test/controllers/schedule_timeline_test.rb
+++ b/test/controllers/schedule_timeline_test.rb
@@ -1,0 +1,140 @@
+require "test_helper"
+
+# Staffing timeline (#262): a horizontally-scrolling who-works-when view for
+# conference managers and activity leads — one bar per contiguous volunteer
+# shift, labeled with the volunteer's name and the activity.
+class ScheduleTimelineTest < ActionDispatch::IntegrationTest
+  setup do
+    @village = Village.create!(name: "Test Village", setup_complete: true)
+    @conference = Conference.create!(
+      village: @village,
+      name: "Test Conference",
+      start_date: Date.tomorrow,
+      end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00",
+      conference_hours_end: "17:00"
+    )
+    @exams = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Ham Exams", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" } }
+    )
+    @desk = ConferenceProgram.create!(
+      conference: @conference,
+      program: Program.create!(name: "Front Desk", village: @village),
+      day_schedules: { "0" => { "enabled" => true, "start" => "09:00", "end" => "11:00" } }
+    )
+
+    @admin = create_user("admin@example.com", handle: "Admin")
+    UserRole.create!(user: @admin, role: Role.find_or_create_by!(name: Role::VILLAGE_ADMIN))
+    @volunteer = create_user("ray@example.com", handle: "Radio Ray", callsign: "W1AW")
+    @other_volunteer = create_user("sam@example.com", handle: "Sam")
+
+    # Ray: Ham Exams 9:00-10:00 (4 slots -> one bar). Sam: Front Desk 9:30-10:00.
+    @exams.timeslots.order(:start_time).first(4).each { |slot| VolunteerSignup.create!(user: @volunteer, timeslot: slot) }
+    @desk.timeslots.order(:start_time).offset(2).first(2).each { |slot| VolunteerSignup.create!(user: @other_volunteer, timeslot: slot) }
+  end
+
+  def create_user(email, handle:, callsign: nil)
+    user = User.new(email: email, password: "password123", password_confirmation: "password123",
+                    handle: handle, callsign: callsign)
+    user.skip_confirmation!
+    user.save!
+    user
+  end
+
+  test "a village admin sees one bar per contiguous shift with name and activity" do
+    sign_in @admin
+    get conference_schedule_timeline_path(@conference)
+
+    assert_response :success
+    assert_select ".timeline-bar", 2
+    assert_select ".timeline-bar", text: /Radio Ray/ do
+      assert_select ".badge", text: "Ham Exams"
+    end
+    assert_select ".timeline-bar", text: /Sam/ do
+      assert_select ".badge", text: "Front Desk"
+    end
+  end
+
+  test "a conference lead sees all activities" do
+    lead = create_user("lead@example.com", handle: "Lead")
+    ConferenceRole.create!(user: lead, conference: @conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+    sign_in lead
+
+    get conference_schedule_timeline_path(@conference)
+
+    assert_response :success
+    assert_select ".timeline-bar", 2
+  end
+
+  test "an activity lead sees only their own activity's bars" do
+    lead = create_user("activity-lead@example.com", handle: "Exams Lead")
+    ConferenceProgramRole.create!(user: lead, conference_program: @exams,
+                                  role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in lead
+
+    get conference_schedule_timeline_path(@conference)
+
+    assert_response :success
+    assert_select ".timeline-bar", 1
+    assert_select ".timeline-bar", text: /Radio Ray/
+    assert_select ".timeline-bar", text: /Sam/, count: 0
+  end
+
+  test "a plain volunteer is redirected away" do
+    sign_in @volunteer
+    get conference_schedule_timeline_path(@conference)
+
+    assert_redirected_to conference_schedule_coverage_path(@conference)
+  end
+
+  test "unauthenticated users are sent to login" do
+    get conference_schedule_timeline_path(@conference)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "the activity filter narrows to one activity" do
+    sign_in @admin
+    get conference_schedule_timeline_path(@conference, program_id: @desk.program_id)
+
+    assert_select ".timeline-bar", 1
+    assert_select ".timeline-bar", text: /Sam/
+  end
+
+  test "the time window filter keeps only overlapping bars" do
+    sign_in @admin
+    # 10:15-11:00 window: Ray (ends 10:00) and Sam (ends 10:00) both fall out.
+    get conference_schedule_timeline_path(@conference, from: "10:15", to: "11:00")
+    assert_select ".timeline-bar", 0
+
+    # 9:45-10:30 overlaps both.
+    get conference_schedule_timeline_path(@conference, from: "09:45", to: "10:30")
+    assert_select ".timeline-bar", 2
+  end
+
+  test "the day param scopes the timeline" do
+    sign_in @admin
+    get conference_schedule_timeline_path(@conference, day: (@conference.start_date + 1.day).iso8601)
+
+    assert_response :success
+    assert_select ".timeline-bar", 0
+  end
+
+  test "managers get a link to the timeline from the schedule and the board" do
+    sign_in @admin
+
+    get conference_schedule_path(@conference)
+    assert_select "a[href='#{conference_schedule_timeline_path(@conference)}']", text: /staffing timeline/i
+
+    get conference_schedule_board_path(@conference)
+    assert_select "a[href='#{conference_schedule_timeline_path(@conference)}']", text: /staffing timeline/i
+  end
+
+  test "plain volunteers get no timeline link on the schedule" do
+    sign_in @volunteer
+    get conference_schedule_path(@conference)
+
+    assert_select "a[href='#{conference_schedule_timeline_path(@conference)}']", count: 0
+  end
+end

--- a/test/controllers/schedule_timeline_test.rb
+++ b/test/controllers/schedule_timeline_test.rb
@@ -43,17 +43,20 @@ class ScheduleTimelineTest < ActionDispatch::IntegrationTest
     user
   end
 
-  test "a village admin sees one bar per contiguous shift with name and activity" do
+  test "a village admin sees a lane per activity with one bar per contiguous shift" do
     sign_in @admin
     get conference_schedule_timeline_path(@conference)
 
     assert_response :success
-    assert_select ".timeline-bar", 2
-    assert_select ".timeline-bar", text: /Radio Ray/ do
-      assert_select ".badge", text: "Ham Exams"
+    assert_select ".timeline-lane", 2
+    assert_select ".timeline-lane[data-program-name='Ham Exams']" do
+      assert_select ".lane-header .badge", text: "Ham Exams"
+      assert_select ".timeline-bar", 1
+      assert_select ".timeline-bar", text: /Radio Ray/
     end
-    assert_select ".timeline-bar", text: /Sam/ do
-      assert_select ".badge", text: "Front Desk"
+    assert_select ".timeline-lane[data-program-name='Front Desk']" do
+      assert_select ".timeline-bar", 1
+      assert_select ".timeline-bar", text: /Sam/
     end
   end
 
@@ -68,7 +71,7 @@ class ScheduleTimelineTest < ActionDispatch::IntegrationTest
     assert_select ".timeline-bar", 2
   end
 
-  test "an activity lead sees only their own activity's bars" do
+  test "an activity lead sees only their own activity's lane and no foreign filter options" do
     lead = create_user("activity-lead@example.com", handle: "Exams Lead")
     ConferenceProgramRole.create!(user: lead, conference_program: @exams,
                                   role_name: ConferenceProgramRole::ACTIVITY_LEAD)
@@ -77,8 +80,21 @@ class ScheduleTimelineTest < ActionDispatch::IntegrationTest
     get conference_schedule_timeline_path(@conference)
 
     assert_response :success
-    assert_select ".timeline-bar", 1
+    assert_select ".timeline-lane", 1
     assert_select ".timeline-bar", text: /Radio Ray/
+    assert_select ".timeline-bar", text: /Sam/, count: 0
+    assert_select "input[name='program_ids[]'][value='#{@desk.program_id}']", count: 0
+  end
+
+  test "an activity lead cannot opt into a foreign activity via program_ids" do
+    lead = create_user("activity-lead@example.com", handle: "Exams Lead")
+    ConferenceProgramRole.create!(user: lead, conference_program: @exams,
+                                  role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in lead
+
+    get conference_schedule_timeline_path(@conference, program_ids: [ @desk.program_id ])
+
+    assert_response :success
     assert_select ".timeline-bar", text: /Sam/, count: 0
   end
 
@@ -94,12 +110,28 @@ class ScheduleTimelineTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_user_session_path
   end
 
-  test "the activity filter narrows to one activity" do
+  test "activity checkboxes select which lanes show" do
     sign_in @admin
-    get conference_schedule_timeline_path(@conference, program_id: @desk.program_id)
 
-    assert_select ".timeline-bar", 1
+    # Both offered as checkboxes, both checked by default.
+    get conference_schedule_timeline_path(@conference)
+    assert_select "input[type=checkbox][name='program_ids[]']", 2
+    assert_select "input[type=checkbox][name='program_ids[]'][checked]", 2
+
+    # Deselecting down to one narrows the lanes.
+    get conference_schedule_timeline_path(@conference, program_ids: [ @desk.program_id ])
+    assert_select ".timeline-lane", 1
     assert_select ".timeline-bar", text: /Sam/
+    assert_select "input[type=checkbox][name='program_ids[]'][checked]", 1
+  end
+
+  test "deselecting every activity shows an empty state, not everything" do
+    sign_in @admin
+    get conference_schedule_timeline_path(@conference, program_ids: [ "" ])
+
+    assert_response :success
+    assert_select ".timeline-lane", 0
+    assert_select ".timeline-bar", 0
   end
 
   test "the time window filter keeps only overlapping bars" do

--- a/test/controllers/schedule_timeline_test.rb
+++ b/test/controllers/schedule_timeline_test.rb
@@ -121,6 +121,25 @@ class ScheduleTimelineTest < ActionDispatch::IntegrationTest
     assert_select ".timeline-bar", 0
   end
 
+  test "bars link to the volunteer's profile" do
+    sign_in @admin
+    get conference_schedule_timeline_path(@conference)
+
+    assert_select "a.timeline-bar[href='#{managed_user_path(@volunteer)}']", text: /Radio Ray/
+    assert_select "a.timeline-bar[href='#{managed_user_path(@other_volunteer)}']", text: /Sam/
+  end
+
+  test "bars link to the volunteer's profile for activity leads too" do
+    lead = create_user("activity-lead@example.com", handle: "Exams Lead")
+    ConferenceProgramRole.create!(user: lead, conference_program: @exams,
+                                  role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in lead
+
+    get conference_schedule_timeline_path(@conference)
+
+    assert_select "a.timeline-bar[href='#{managed_user_path(@volunteer)}']"
+  end
+
   test "managers get a link to the timeline from the schedule and the board" do
     sign_in @admin
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -77,6 +77,50 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   # Edit action tests
+  # Manager-level read access (#262): the staffing timeline links volunteers'
+  # profiles, and its audience includes conference managers and activity leads.
+  test "a conference lead can view a volunteer's profile read-only" do
+    conference = Conference.create!(
+      village: @village, name: "Test Conference",
+      start_date: Date.tomorrow, end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00", conference_hours_end: "17:00"
+    )
+    lead = User.create!(email: "lead@example.com", password: "password123",
+                        password_confirmation: "password123", handle: "lead")
+    ConferenceRole.create!(user: lead, conference: conference, role_name: ConferenceRole::CONFERENCE_LEAD)
+    sign_in_user(lead)
+
+    get managed_user_path(@volunteer)
+
+    assert_response :success
+    # Admin-only controls stay hidden.
+    assert_select "a", text: "Edit", count: 0
+    assert_select "a", text: "← Back to Users", count: 0
+    assert_select "input[type=submit][value=Grant]", count: 0
+    assert_select "form[action=?]", managed_user_village_admin_role_path(@volunteer), count: 0
+  end
+
+  test "an activity lead can view a volunteer's profile" do
+    conference = Conference.create!(
+      village: @village, name: "Test Conference",
+      start_date: Date.tomorrow, end_date: Date.tomorrow + 1.day,
+      conference_hours_start: "09:00", conference_hours_end: "17:00"
+    )
+    conference_program = ConferenceProgram.create!(
+      conference: conference,
+      program: Program.create!(name: "Ham Exams", village: @village)
+    )
+    activity_lead = User.create!(email: "activity-lead@example.com", password: "password123",
+                                 password_confirmation: "password123", handle: "activitylead")
+    ConferenceProgramRole.create!(user: activity_lead, conference_program: conference_program,
+                                  role_name: ConferenceProgramRole::ACTIVITY_LEAD)
+    sign_in_user(activity_lead)
+
+    get managed_user_path(@volunteer)
+
+    assert_response :success
+  end
+
   test "should get edit as village admin" do
     sign_in_user(@village_admin)
     get edit_managed_user_url(@volunteer)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -93,11 +93,25 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get managed_user_path(@volunteer)
 
     assert_response :success
-    # Admin-only controls stay hidden.
+    # Admin-only controls stay hidden — including both links to the
+    # admin-only user index (header and footer).
     assert_select "a", text: "Edit", count: 0
-    assert_select "a", text: "← Back to Users", count: 0
+    assert_select "a[href=?]", managed_users_path, count: 0
     assert_select "input[type=submit][value=Grant]", count: 0
     assert_select "form[action=?]", managed_user_village_admin_role_path(@volunteer), count: 0
+  end
+
+  test "the profile lists every contact attribute, with placeholders for blanks" do
+    @volunteer.update!(discord: "vol#1234")   # everything else stays blank
+    sign_in_user(@village_admin)
+
+    get managed_user_path(@volunteer)
+
+    [ "Display Name:", "Callsign:", "Phone:", "Twitter:", "Signal:", "Discord:" ].each do |label|
+      assert_select "dt", text: label
+    end
+    assert_select "dd", text: "vol#1234"
+    assert_select "dd .text-muted", minimum: 1   # blank fields show a placeholder
   end
 
   test "an activity lead can view a volunteer's profile" do


### PR DESCRIPTION
## Summary

A new manager-facing **Staffing Timeline** page (`/conferences/:id/schedule/timeline`) answering #262's ask: a left-to-right, horizontally-scrolling timeline showing **who is scheduled at any given time**, built for spotting thin handoffs and high-turnover stretches. Follows the layout suggested in the issue's mockup, restyled to the site's Bootstrap look.

## What it looks like

- **One swimlane per activity**: a neutral activity badge heads each lane with its shift count; the lane's bars sit beneath it on a shared hour ruler with gridlines and a red now-line on the current day.
- **One bar per contiguous shift** (consecutive 15-min slots merge), positioned and sized by its true time span, labeled with the volunteer's Display Name (+ callsign) and time range.
- **Truthful widths, degrading labels**: as a bar narrows, the time range drops out (CSS container query) and the name ellipsizes — no mid-pill clipping, no bars outgrowing the timeline. The hover tooltip always carries full details.
- **Bars are links** to the volunteer's profile page.

## Filters (per the issue)

- **Day** chips, like the schedule
- **Activities**: auto-applying checkboxes (shown when there's more than one) so a multi-activity lead can select/deselect which lanes they see; unchecking everything shows an honest empty state
- **Time window**: From/To fields with Apply/Clear

## Access control

- Same gate as the coverage board: village admins and conference leads/admins see every activity; **activity leads see exactly the activities they lead** — in the lanes *and* the filter options. Foreign `program_ids` in the URL are silently dropped. Plain volunteers are redirected away, so names stay manager-only.
- **"Staffing timeline" buttons** in the schedule header and on the coverage board for anyone with manage rights.

## Supporting changes

- **`UserPolicy#show?` widened to manager read access**: conference leads/admins and activity leads can now view volunteer profiles (the timeline links there, and these roles already receive the same contact data via the shift reports). All write controls on that page — Edit, qualification grant/remove, both links to the admin-only user index, the village-admin role buttons — sit behind their own policy checks and stay village-admin-only.
- **The profile lists every attribute** — Display Name, Callsign, Phone, Twitter, Signal, Discord — with an em-dash placeholder for blanks, so "not set" is distinguishable from "hidden".

## Testing

- TDD throughout: 14 timeline controller tests (lane grouping, contiguous-shift merging, all three role scopes, foreign-id rejection, checkbox/multi-select behavior, empty-state, time-window and day filters, link placement and profile links) plus profile-access and full-attribute tests
- Visually verified against the issue's mockup across mixed shift lengths (15 min / 1 h / 3 h)
- `bin/rails test:all` — 1065 runs, 0 failures (system tests included)
- `bin/rubocop` — no offenses

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)